### PR TITLE
Blueprint options hook

### DIFF
--- a/api/hooks/blueprint-options/index.js
+++ b/api/hooks/blueprint-options/index.js
@@ -1,0 +1,31 @@
+/* Blueprint Options hook
+ * Returns the definition of model attributions based
+ * on OPTION requests to Blueprint model routes
+ */
+module.exports = function(sails) {
+
+  // Set up route using blueprint prefix
+  var urlBase = sails.config.blueprints.prefix || '',
+      key = 'OPTIONS ' + urlBase + '/:model',
+      routes = {};
+
+  // Handle matching routes
+  routes[key] = function(req, res, next) {
+
+    // Get model and corresponding controller
+    var model = req.param('model').toLowerCase(),
+        Model = sails.models[model],
+        Controller = sails.controllers[model];
+
+    // Exit if model and controller don't exist
+    if (!Model || !Controller) return next();
+
+    // Send model definition
+    res.json(Model.definition);
+
+  };
+
+  // Execute matching route first
+  return { routes: { before: routes } };
+
+};


### PR DESCRIPTION
Adds a hook that returns the definition of model attributions based on OPTION requests to Blueprint model routes. 

This will be used to build and validate client-side forms.

Example:

`OPTIONS http://localhost:1337/v0/build`

```json
{
  "completedAt": {
    "type": "datetime"
  },
  "error": {
    "type": "string"
  },
  "branch": {
    "type": "string"
  },
  "state": {
    "type": "string",
    "defaultsTo": "processing",
    "enum": [
      "error",
      "processing",
      "skipped",
      "success"
    ]
  },
  "site": {
    "type": "integer",
    "model": "site",
    "foreignKey": true,
    "alias": "site"
  },
  "user": {
    "type": "integer",
    "model": "user",
    "foreignKey": true,
    "alias": "user"
  },
  "id": {
    "type": "integer",
    "autoIncrement": true,
    "primaryKey": true,
    "unique": true
  },
  "createdAt": {
    "type": "datetime"
  },
  "updatedAt": {
    "type": "datetime"
  }
}
```