### PR TITLE
Use nodemon to restart app server on file change/save

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To build sites using Hugo, install [Hugo](http://gohugo.io/overview/installing/)
     secret: 'testSecret'
   }
   ```
-* Run the server with `npm start` or `node app.js`
+* Run the server with `npm start` or `node app.js` (You can use `npm run watch` for the server to restart when you save file changes)
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "grunt-sails-linker": "~0.9.5",
     "grunt-sync": "~0.0.4",
     "include-all": "~0.1.3",
-    "nodemon": "^1.3.7",
     "passport": "^0.2.1",
     "passport-github": "^0.1.5",
     "passport-local": "^1.0.0",
@@ -32,8 +31,9 @@
   },
   "scripts": {
     "preinstall": "gem install github-pages",
-    "start": "nodemon app.js",
+    "start": "node app.js",
     "debug": "node debug app.js",
+    "watch": "nodemon app.js",
     "test": "mocha test/bootstrap.test.js test/unit/**/*.test.js"
   },
   "main": "app.js",
@@ -44,6 +44,7 @@
   "author": "dhcole",
   "license": "Public Domain",
   "devDependencies": {
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "nodemon": "^1.3.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-sails-linker": "~0.9.5",
     "grunt-sync": "~0.0.4",
     "include-all": "~0.1.3",
+    "nodemon": "^1.3.7",
     "passport": "^0.2.1",
     "passport-github": "^0.1.5",
     "passport-local": "^1.0.0",
@@ -31,7 +32,7 @@
   },
   "scripts": {
     "preinstall": "gem install github-pages",
-    "start": "node app.js",
+    "start": "nodemon app.js",
     "debug": "node debug app.js",
     "test": "mocha test/bootstrap.test.js test/unit/**/*.test.js"
   },


### PR DESCRIPTION
This PR isn't related to a documented issue, but Sails does not automatically reload the app server once you make a file change, which can get kind of annoying when you start debugging an issue only to remember that you didn't restart the server. :disappointed: 

I added [`nodemon`](http://npm.im/nodemon) as a dependency and have `npm start` use nodemon to watch for file changes and restart the Sails server.