### PR TITLE
Remove passports from user model API response

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -20,6 +20,13 @@ var User = {
     builds: {
       collection: 'build',
       via: 'user'
+    },
+
+    // Method to return JSON to the API
+    toJSON: function() {
+      var obj = this.toObject();
+      delete obj.passports;
+      return obj;
     }
   }
 };


### PR DESCRIPTION
Blocks passport models from being returned as part of user responses.

Resolves #19 