### PR TITLE
Run browserify before starting node app

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
   },
   "scripts": {
     "preinstall": "gem install github-pages",
-    "start": "node app.js",
+    "start": "npm run browserify && node app.js",
     "debug": "node debug app.js",
+    "browserify": "browserify -t brfs assets/app/app.js -o assets/js/bundle.js",
     "dev": "npm run watch & npm run watchify",
     "watch": "nodemon app.js",
     "watchify": "watchify --debug -t brfs assets/app/app.js -o assets/js/bundle.js",


### PR DESCRIPTION
In the case where somebody is running `npm start` such as on a deploy, they're going to need a bundle that is freshly compiled. So I've altered `npm start` to run `browserify` so that there is a `bundle.js` and puts it where expected.