### PR TITLE
Dry up url for Site model and collection

### DIFF
--- a/assets/app/models/Site.js
+++ b/assets/app/models/Site.js
@@ -1,5 +1,7 @@
 var Backbone = require('backbone');
 
+var siteUrl = '/v0/site';
+
 var SiteModel = Backbone.Model.extend({
   defaults: {
     'builds': [],
@@ -7,12 +9,12 @@ var SiteModel = Backbone.Model.extend({
     'engine': 'jekyll',
     'branch': 'master'
   },
-  urlRoot: '/v0/site'
+  urlRoot: siteUrl
 });
 
 var SiteCollection = Backbone.Collection.extend({
   model: SiteModel,
-  url: '/v0/site',
+  url: siteUrl,
 
   initialize: function() {
     this.fetch();


### PR DESCRIPTION
The Site model and collection share the same URL but it was listed in both models. We still have an open question of how we will version the API, but until we decide one way or the other here is a small dry commit.

This will close #33 