### PR TITLE
Only show one add new site form

### DIFF
--- a/assets/app/templates/SiteListTemplate.html
+++ b/assets/app/templates/SiteListTemplate.html
@@ -1,6 +1,6 @@
 <% if(authenticated) { %>
   <h1>Your current sites</h1>
-  <a href="#" class="add-site">Add a site</a>
+  <a href="#" class="add-site-action">Add a site</a>
   <ul></ul>
 <% } else { %>
   <h1>Please <a href="/auth/github">authenticate with GitHub</a> to continue</h1>

--- a/assets/app/views/AddSiteView.js
+++ b/assets/app/views/AddSiteView.js
@@ -8,7 +8,7 @@ var templateHtml = fs.readFileSync(__dirname + '/../templates/AddSiteTemplate.ht
 
 var AddSiteView = Backbone.View.extend({
   tagName: 'div',
-  className: 'add-site',
+  className: 'add-site-form',
   events: {
     'click .submit': 'onSubmit',
   },

--- a/assets/app/views/SiteListView.js
+++ b/assets/app/views/SiteListView.js
@@ -11,15 +11,26 @@ var SiteListView = Backbone.View.extend({
   el: 'main',
   template: _.template(templateHtml),
   events: {
-    'click .add-site': 'onAddSite'
+    'click .add-site-action': 'toggleAddSiteView'
   },
   initialize: function initializeSiteListView(opts) {
     this.user = opts.user;
+
     this.listenTo(this.collection, 'sync', this.render);
     this.listenTo(this.user, 'change', this.render);
+
+    this.views = {
+      addView: new AddSiteView()
+    };
+
+    this.views.addView.on('success', function() {
+      this.collection.fetch();
+    }, this);
   },
   render: function renderSiteListView() {
     this.$el.html(this.template({authenticated: this.user.isAuthenticated()}));
+    this.$el.prepend(this.views.addView.$el);
+
     var $list = this.$('ul');
     $list.empty();
 
@@ -30,15 +41,9 @@ var SiteListView = Backbone.View.extend({
 
     return this;
   },
-  onAddSite: function onAddSite() {
-    var addView = new AddSiteView();
-
-    addView.on('success', function() {
-      this.collection.fetch();
-      setTimeout(function() { addView.remove(); }, 2000);
-    }, this);
-
-    this.$el.prepend(addView.$el);
+  toggleAddSiteView: function toggleAddSiteView() {
+    this.views.addView.$el.toggleClass('show');
+    return this;
   }
 });
 

--- a/assets/styles/importer.less
+++ b/assets/styles/importer.less
@@ -45,3 +45,10 @@ nav h1 {
 nav .user {
   right: 0;
 }
+
+.add-site-form {
+  display: none;
+}
+.add-site-form.show {
+  display: block;
+}


### PR DESCRIPTION
This PR should close #31 by only having one add site form on the site. I've gone ahead and made sure that there is only one add new site view instantiated at a time in the application and I store a reference to it. Then instead of the action triggering a view creation and insertion it just toggles a display class.