### PR TITLE
Copy materialize assets on npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ assets/site
 # Browserify bundle
 assets/js/bundle.js
 
+# Materialize assets
+assets/font/
+assets/js/dependencies/materialize.js
+assets/styles/materialize.css
+
 
 ################################################
 # Dependencies

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.96.1/css/materialize.min.css">
+    <link rel="stylesheet" href="/styles/materialize.css">
     <link rel="stylesheet" href="/styles/importer.css">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -18,6 +18,6 @@
     <main class="container"></main>
     <footer class="page-footer orange"></footer>
     <script src="/js/bundle.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.96.1/js/materialize.min.js"></script>
+    <script src="/js/dependencies/materialize.js"></script>
   </body>
 </html>

--- a/config/routes.js
+++ b/config/routes.js
@@ -24,20 +24,6 @@ module.exports.routes = {
 
   /***************************************************************************
   *                                                                          *
-  * Make the view located at `views/homepage.ejs` (or `views/homepage.jade`, *
-  * etc. depending on your default view engine) your home page.              *
-  *                                                                          *
-  * (Alternatively, remove this and add an `index.html` file in your         *
-  * `assets` directory)                                                      *
-  *                                                                          *
-  ***************************************************************************/
-
-  '/': {
-    view: 'homepage'
-  },
-
-  /***************************************************************************
-  *                                                                          *
   * Custom routes here...                                                    *
   *                                                                          *
   *  If a request to a URL doesn't match any of the custom routes above, it  *

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt-sync": "~0.0.4",
     "include-all": "~0.1.3",
     "jquery": "^2.1.4",
+    "materialize-css": "^0.96.1",
     "passport": "^0.2.1",
     "passport-github": "^0.1.5",
     "passport-local": "^1.0.0",
@@ -33,14 +34,15 @@
     "validator": "^3.39.0"
   },
   "scripts": {
-    "preinstall": "gem install github-pages",
+    "install": "gem install github-pages && npm run materialize",
     "start": "npm run browserify && node app.js",
     "debug": "node debug app.js",
     "browserify": "browserify -t brfs assets/app/app.js -o assets/js/bundle.js",
     "dev": "npm run watch & npm run watchify",
     "watch": "nodemon app.js",
     "watchify": "watchify --debug -t brfs assets/app/app.js -o assets/js/bundle.js",
-    "test": "mocha test/bootstrap.test.js test/unit/**/*.test.js"
+    "test": "mocha test/bootstrap.test.js test/unit/**/*.test.js",
+    "materialize": "cp node_modules/materialize-css/bin/materialize.css assets/styles/ && cp -R node_modules/materialize-css/font assets/ && cp node_modules/materialize-css/bin/materialize.js assets/js/dependencies/"
   },
   "main": "app.js",
   "repository": {


### PR DESCRIPTION
Resolves #43

@jeremiak went with your suggested approach. We could call in the repo from github, but then we're just pulling from the repo `head` and we'll be getting constantly whatever the latest code is... or we pin to a commit but then we're off release cycle. I was also getting issues using browserify with materialize, as if there are missing upstream dependencies... so this works for now! /shrug