### PR TITLE
Escape HTML in templates

### DIFF
--- a/assets/app/templates/AddSiteTemplate.html
+++ b/assets/app/templates/AddSiteTemplate.html
@@ -33,10 +33,10 @@
   <section>
     <h5>Or add your own Github repository</h5>
     <form>
-      <input type="hidden" name="owner" value="<%= user.username %>"></input>
+      <input type="hidden" name="owner" value="<%- user.username %>"></input>
       </br >
 
-      <input type="hidden" name="user" value="<%= user.id %>"></input>
+      <input type="hidden" name="user" value="<%- user.id %>"></input>
       </br >
 
       <label for="repository">repository name</label>

--- a/assets/app/templates/SiteListItemTemplate.html
+++ b/assets/app/templates/SiteListItemTemplate.html
@@ -1,13 +1,13 @@
-<div class="collapsible-header active"><%= repository %>
+<div class="collapsible-header active"><%- repository %>
   <span class="right">
-    <a href="http://prose.io/#<%= owner %>/<%= repository %>" target="_blank" class="edit" alt="edit the site <%= repository %> using prose.io"><i class="mdi-editor-mode-edit"></i></a>
-    <a href="#" class="delete" alt="delete the site <%= repository %>"><i class="mdi-action-delete"></i></a>
+    <a href="http://prose.io/#<%- owner %>/<%- repository %>" target="_blank" class="edit" alt="edit the site <%- repository %> using prose.io"><i class="mdi-editor-mode-edit"></i></a>
+    <a href="#" class="delete" alt="delete the site <%- repository %>"><i class="mdi-action-delete"></i></a>
     <% if (builds.length != 0) { %>
-      <a href="/site/<%= owner %>/<%= repository %>/<%= defaultBranch %>" class="view" alt="go to the site <%= repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
+      <a href="/site/<%- owner %>/<%- repository %>/<%- defaultBranch %>" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
     <% } %>
   </span>
 </div>
 <div class="collapsible-body">
-  <p>This is uses <%= engine %> as a build engine and has been built <%= builds.length %> times</p>
+  <p>This is uses <%- engine %> as a build engine and has been built <%= builds.length %> times</p>
 
 </div>

--- a/assets/app/templates/UserTemplate.html
+++ b/assets/app/templates/UserTemplate.html
@@ -1,6 +1,6 @@
 <ul id="nav-mobile">
 <% if(username) {%>
-  <li>hey <%= username %>!</li>
+  <li>hey <%- username %>!</li>
   <li><a href="/logout">logout</a></li>
 <% } else { %>
   <li><a href="/auth/github">login</a></li>


### PR DESCRIPTION
This uses Underscores `<%-` operator to escape the HTML used in templates. This touched the add new site template, the login button/view template, and the individual list item view template.

To close #42