### PR TITLE
Return not found error from GitHub to user

### DIFF
--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -48,7 +48,9 @@ module.exports = {
       if (err) {
         var ghErr, hookMessage = 'Hook already exists on this repository';
         try { ghErr = JSON.parse(err.message).errors[0].message; } catch(e) {}
-        if (ghErr !== hookMessage) return done(err);
+        if (ghErr === hookMessage) return done();
+        if (JSON.parse(err.message)) return done(JSON.parse(err.message));
+        return done(err);
       }
       done();
     });


### PR DESCRIPTION
This returns the GitHub error to the user when creating a new site with a non-existent or inaccessible repository. `.raw` contains the error object from the GitHub API.

```json
{
    "error": "E_UNKNOWN",
    "status": 500,
    "summary": "Encountered an unexpected error",
    "raw": {
        "message": "Not Found",
        "documentation_url": "https://developer.github.com/v3"
    }
}
```

Resolves #18 
