### PR TITLE
Try using error.message for webhook error objects

### DIFF
--- a/api/models/Build.js
+++ b/api/models/Build.js
@@ -115,7 +115,7 @@ module.exports = {
       model.state = (err) ? 'error' : (skip) ? 'skipped' : 'success';
 
       // Add error message if it exists
-      if (err) model.error = err;
+      if (err) model.error = err.message || err;
 
       // Save updated model
       model.save();


### PR DESCRIPTION
If available, use `error.message` for webhook errors. We want the webhook error property to be a consistent datatype so we can easily display it to the user.

Resolves #20 