### PR TITLE
Add safe flag for Jekyll builds

### DIFF
--- a/api/services/buildEngines.js
+++ b/api/services/buildEngines.js
@@ -18,7 +18,7 @@ module.exports = {
         'https://${token}@github.com/${owner}/${repository}.git ${source}',
       'echo "baseurl: /${root}/${owner}/${repository}/${branch}" > ' +
         '${source}/_config_base.yml',
-      'jekyll build --config ${source}/_config.yml,${source}/_config_base.yml ' +
+      'jekyll build --safe --config ${source}/_config.yml,${source}/_config_base.yml ' +
         '--source ${source} --destination ${source}/_site',
       'rm -rf ${destination}',
       'mkdir -p ${destination}',


### PR DESCRIPTION
For now, let's just prevent plugins. They are dangerous because a user could make a plugin that exposes environment vars or runs some dangerous code on the server.

I'd like to revisit this later though, either with a white-list of safe plugins or some what to allow custom plugins without risk (maybe build in containers?)

Refs #49