### PR TITLE
Restrict users to a GitHub organization

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -6,52 +6,6 @@
  * the basics of Passport.js to work.
  */
 var AuthController = {
-  /**
-   * Render the login page
-   *
-   * The login form itself is just a simple HTML form:
-   *
-      <form role="form" action="/auth/local" method="post">
-        <input type="text" name="identifier" placeholder="Username or Email">
-        <input type="password" name="password" placeholder="Password">
-        <button type="submit">Sign in</button>
-      </form>
-   *
-   * You could optionally add CSRF-protection as outlined in the documentation:
-   * http://sailsjs.org/#!documentation/config.csrf
-   *
-   * A simple example of automatically listing all available providers in a
-   * Handlebars template would look like this:
-   *
-      {{#each providers}}
-        <a href="/auth/{{slug}}" role="button">{{name}}</a>
-      {{/each}}
-   *
-   * @param {Object} req
-   * @param {Object} res
-   */
-  login: function (req, res) {
-    var strategies = sails.config.passport,
-        providers  = {};
-
-    // Get a list of available providers for use in your templates.
-    Object.keys(strategies).forEach(function (key) {
-      if (key === 'local') {
-        return;
-      }
-
-      providers[key] = {
-        name: strategies[key].name,
-        slug: key
-      };
-    });
-
-    // Render the `auth/login.ext` view
-    res.view({
-      providers : providers,
-      errors    : req.flash('error')
-    });
-  },
 
   /**
    * Log out a user and return them to the homepage
@@ -74,27 +28,6 @@ var AuthController = {
     req.session.authenticated = false;
 
     res.redirect('/');
-  },
-
-  /**
-   * Render the registration page
-   *
-   * Just like the login form, the registration form is just simple HTML:
-   *
-      <form role="form" action="/auth/local/register" method="post">
-        <input type="text" name="username" placeholder="Username">
-        <input type="text" name="email" placeholder="Email">
-        <input type="password" name="password" placeholder="Password">
-        <button type="submit">Sign up</button>
-      </form>
-   *
-   * @param {Object} req
-   * @param {Object} res
-   */
-  register: function (req, res) {
-    res.view({
-      errors: req.flash('error')
-    });
   },
 
   /**

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -196,7 +196,7 @@ passport.endpoint = function (req, res) {
   // If a provider doesn't exist for this endpoint, send the user back to the
   // login page
   if (!strategies.hasOwnProperty(provider)) {
-    return res.redirect('/login');
+    return res.notFound('Provider does not exist');
   }
 
   // Attach scope if it has been set in the config

--- a/assets/app/app.js
+++ b/assets/app/app.js
@@ -29,7 +29,7 @@ dispatcher.listenTo(sites, 'change', function () {
 
 dispatcher.listenTo(newSiteView, 'success', function () {
   listView.collection.fetch();
-})
+});
 
 dispatcher.listenTo(listView, 'newsite', function () {
   newSiteView.toggleDisplay();

--- a/assets/app/views/SiteListView.js
+++ b/assets/app/views/SiteListView.js
@@ -27,7 +27,10 @@ var SiteListView = Backbone.View.extend({
       authenticated = opts.authenticated || false;
       this.authenticated = authenticated;
     }
-    html = this.template({ authenticated: this.authenticated , sitesCount: sitesCount});
+    html = this.template({
+      authenticated: this.authenticated,
+      sitesCount: sitesCount
+    });
     this.$el.html(html);
 
     if (sitesCount > 0) {

--- a/config/passport.js
+++ b/config/passport.js
@@ -40,8 +40,9 @@ module.exports.passport = {
     options: {
       clientID: 'your-client-id',
       clientSecret: 'your-client-secret',
-      scope: ['user', 'repo'] 
-    }
+      scope: ['user', 'repo']
+    },
+    organizations: [] // IDs for approved organizations
   },
   //
   // facebook: {

--- a/config/routes.js
+++ b/config/routes.js
@@ -40,9 +40,7 @@ module.exports.routes = {
   * https://github.com/kasperisager/sails-generate-auth#requirements
   *
   */
-  'get /login': 'AuthController.login',
   'get /logout': 'AuthController.logout',
-  'get /register': 'AuthController.register',
 
   'post /auth/local': 'AuthController.callback',
   'post /auth/local/:action': 'AuthController.callback',


### PR DESCRIPTION
This PR validates each new user and returning user before authentication to ensure they are a member of an approved GitHub organization. 

Approved GitHub organizations are specified in `config/passport.js`, `github.organizations` as an array of organizations IDs. These IDs are numerical — not the organization name — in case the organization changes its name. You can find these IDs through the API, or just look at the path for the organization's avatar image:

![screen shot 2015-06-16 at 1 40 37 pm](https://cloud.githubusercontent.com/assets/170641/8189913/5c4d0a2e-142d-11e5-96ea-c383d446e847.png)


This PR also removes unused routes (for displaying authentication forms as views) and makes sure authentication errors are passed through to the client as an `error` query string parameter.

Refs #49 
