### PR TITLE
Fix fork route policy

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -8,6 +8,8 @@
 module.exports = {
 
   fork: function forkSiteFromTemplate(req, res) {
+    if (!req.param('templateId')) return res.notFound();
+
     var user = req.user,
         templateId = req.param('templateId');
     GitHub.forkRepository(user, templateId, function(err, newSite) {

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -14,8 +14,12 @@ module.exports = {
    * @param {Function} callback function
    */
   forkRepository: function(user, templateId, done) {
+    var template = sails.config.templates[templateId];
+
+    if (!template) return done(new Error('Invalid template ID'));
+
     Passport.findOne({ user: user.id }).exec(function(err, passport) {
-      var repoUrl = url.parse(sails.config.templates[templateId].repo),
+      var repoUrl = url.parse(template.repo),
           repoOwner = repoUrl.pathname.split('/')[1],
           repoName = repoUrl.pathname.split('/')[2],
           data = {

--- a/config/policies.js
+++ b/config/policies.js
@@ -50,7 +50,10 @@ module.exports.policies = {
 	// }
 
   BuildController: ['passport', 'sessionAuth', 'filterCurrentUser'],
-  SiteController: ['passport', 'sessionAuth', 'filterCurrentUser'],
+  SiteController: {
+    '*': ['passport', 'sessionAuth', 'filterCurrentUser'],
+    'fork': ['passport', 'sessionAuth']
+  },
   UserController: ['passport', 'sessionAuth', 'filterSelfOnly'],
 
   WebhookController: true


### PR DESCRIPTION
The previous policy work was blocking `/v0/site/fork`. This fixes that and handles some possible errors with a missing or invalid `templateID`