### PR TITLE
README setup fix for `local.js` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ npm install
       options: {
         clientID: '<<use the value from Github here>>',
         clientSecret: '<<use the value from Github here>>',
-        callbackUrl: 'http://localhost:1337/auth/github/callback'
+        callbackURL: 'http://localhost:1337/auth/github/callback'
       }
     }
   }
@@ -65,7 +65,7 @@ module.exports = {
       options: {
         clientID: '<<get from github>>',
         clientSecret: '<<get from github>>',
-        callbackUrl: 'http://localhost:1337/auth/github/callback'
+        callbackURL: 'http://localhost:1337/auth/github/callback'
       }
     }
   },


### PR DESCRIPTION
The current README has a bug in that it tells you to use `callbackUrl` instead of `callbackURL` when setting up `local.js`. This is wrong and is pretty frustrating since it breaks the app on first run.

This PR changes the README so that when a new dev copies and pastes it just works (well they still have to enter their app creds).