### PR TITLE
Build default and preview sites separately based on branch

### DIFF
--- a/api/controllers/PreviewController.js
+++ b/api/controllers/PreviewController.js
@@ -18,6 +18,9 @@ module.exports = {
           res.set(headers);
         }),
         stream = object.createReadStream().on('error', function(error) {
+          var file = key.split('/').pop().indexOf('.') !== -1,
+              notFound = error.statusCode === 404;
+          if (!file && notFound) return res.redirect(req.path + '/');
           res.send(error.statusCode, error.message);
         }).pipe(res);
   }

--- a/api/controllers/PreviewController.js
+++ b/api/controllers/PreviewController.js
@@ -1,0 +1,25 @@
+var AWS = require('aws-sdk'),
+    s3 = new AWS.S3();
+
+module.exports = {
+
+  /*
+   * Proxies requires from S3 for so those requests can be authenticated
+   *
+   */
+  proxy: function(req, res) {
+    var key = req.path.slice(1);
+    if ((key).slice(-1) === '/') key = key + 'index.html';
+
+    var object = s3.getObject({
+          Bucket: sails.config.build.s3Bucket,
+          Key: key
+        }).on('httpHeaders', function(statusCode, headers) {
+          res.set(headers);
+        }),
+        stream = object.createReadStream().on('error', function(error) {
+          res.send(error.statusCode, error.message);
+        }).pipe(res);
+  }
+
+};

--- a/api/controllers/PreviewController.js
+++ b/api/controllers/PreviewController.js
@@ -4,10 +4,14 @@ var AWS = require('aws-sdk'),
 module.exports = {
 
   /*
-   * Proxies requires from S3 for so those requests can be authenticated
-   *
+   * Proxies requests so they can be authenticated
    */
-  proxy: function(req, res) {
+  proxy: function(req, res, next) {
+
+    // If not using S3, pass through to static asset middleware
+    if (!sails.config.build.s3Bucket) return next();
+
+    // For S3, proxy requests from S3 bucket
     var key = req.path.slice(1);
     if ((key).slice(-1) === '/') key = key + 'index.html';
 

--- a/api/models/Build.js
+++ b/api/models/Build.js
@@ -55,24 +55,7 @@ module.exports = {
         sails.log.verbose('Starting job: ', model.id);
 
         // Run the build with the appropriate engine and the model
-        buildEngines[model.site.engine](model, function(err, tokens) {
-          if (err) return done(err, model);
-          if (!sails.config.build.s3Bucket) return done(null, model);
-
-          var syncConfig = {
-                prefix: 'site/' +
-                  tokens.owner + '/' +
-                  tokens.repository + '/' +
-                  tokens.branch,
-                directory: tokens.destination
-              };
-
-          sails.log.verbose('Syncing job: ', model.id);
-
-          S3(syncConfig, function(err) {
-            done(err, model);
-          });
-        });
+        buildEngines[model.site.engine](model, done);
 
       });
 

--- a/api/policies/previewProxy.js
+++ b/api/policies/previewProxy.js
@@ -1,0 +1,16 @@
+module.exports = function(req, res, next) {
+  if (!req.param('owner') || !req.param('repo') || !req.param('branch')) {
+    return res.badRequest();
+  }
+
+  Site.findOne({
+    owner: req.param('owner'),
+    repository: req.param('repo')
+  }).populate('users').exec(function(err, site) {
+    if (err || !site) return res.badRequest();
+    var userHasAccess = _(site.users).pluck('id').contains(req.user.id);
+    if (!userHasAccess) return res.badRequest();
+    next();
+  });
+
+};

--- a/api/services/buildEngines.js
+++ b/api/services/buildEngines.js
@@ -16,7 +16,7 @@ module.exports = {
       'mkdir -p ${source}',
       'git clone -b ${branch} --single-branch ' +
         'https://${token}@github.com/${owner}/${repository}.git ${source}',
-      'echo "baseurl: /${root}/${owner}/${repository}/${branch}" > ' +
+      'echo "baseurl: /${root}/${owner}/${repository}${branchURL}" > ' +
         '${source}/_config_base.yml',
       'jekyll build --safe --config ${source}/_config.yml,${source}/_config_base.yml ' +
         '--source ${source} --destination ${source}/_site',
@@ -36,7 +36,7 @@ module.exports = {
       'mkdir -p ${source}',
       'git clone -b ${branch} --single-branch ' +
         'https://${token}@github.com/${owner}/${repository}.git ${source}',
-      'hugo --baseUrl=/${root}/${owner}/${repository}/${branch} ' +
+      'hugo --baseUrl=/${root}/${owner}/${repository}${branchURL} ' +
         '--source=${source}',
       'rm -rf ${destination}',
       'mkdir -p ${destination}',
@@ -77,10 +77,12 @@ module.exports = {
    * @param {Function} callback function
    */
   _run: function(cmd, model, done) {
-
-    var tokens = {
+    var service = this,
+        defaultBranch = model.branch === model.site.defaultBranch,
+        tokens = {
           branch: model.branch,
-          root: sails.config.build.destinationRoot.replace('assets/', '')
+          branchURL: defaultBranch ? '' : '/' + model.branch,
+          root: defaultBranch ? 'site' : 'preview'
         },
         template = _.template(cmd.join(' && '));
 
@@ -105,19 +107,64 @@ module.exports = {
       tokens.token = model.user.passport.tokens.accessToken;
 
       // Set up source and destination paths
-      tokens.source = sails.config.build.sourceRoot + '/' +
+      tokens.source = sails.config.build.tempDir + '/source/' +
         tokens.owner + '/' + tokens.repository + '/' + tokens.branch;
-      tokens.destination = sails.config.build.destinationRoot + '/' +
+      tokens.destination = sails.config.build.tempDir + '/destination/' +
         tokens.owner + '/' + tokens.repository + '/' + tokens.branch;
+      tokens.publish = sails.config.build.publishDir + '/' + tokens.root + '/' +
+        tokens.owner + '/' + tokens.repository + tokens.branchURL;
 
       // Run command in child process and
       // call callback with error and model
       exec(template(tokens), function(err, stdout, stderr) {
         if (stdout) sails.log.verbose('stdout: ' + stdout);
         if (stderr) sails.log.verbose('stderr: ' + stderr);
-        done(err, tokens);
+        if (err) return done(err, model);
+        service.publish(tokens, model, done);
       });
 
+    }
+
+  },
+
+  /*
+   * Publish a built site by copying it to its publish directory
+   * or syncing it to an S3 bucket.
+   *
+   * @param {Object} tokens from the _run command
+   * @param {Build} build model to parse
+   * @param {Function} callback function
+   */
+  publish: function(tokens, model, done) {
+
+    // If an S3 bucket is defined, sync the site to it
+    if (sails.config.build.s3Bucket) {
+      var syncConfig = {
+            prefix: tokens.root + '/' +
+              tokens.owner + '/' +
+              tokens.repository +
+              tokens.branchURL,
+            directory: tokens.destination
+          };
+      sails.log.verbose('Publishing job: ', model.id,
+        ' => ', sails.config.build.s3Bucket);
+      S3(syncConfig, function(err) {
+        done(err, model);
+      });
+
+    // Or else copy the site to a local directory
+    } else {
+      var cmd = _.template(['rm -r ${publish} || true',
+            'mkdir -p ${publish}',
+            'cp -r ${destination}/ ${publish}',
+          ].join(' && '));
+      sails.log.verbose('Publishing job: ', model.id,
+        ' => ', tokens.publish);
+      exec(cmd(tokens), function(err, stdout, stderr) {
+        if (stdout) sails.log.verbose('stdout: ' + stdout);
+        if (stderr) sails.log.verbose('stderr: ' + stderr);
+        done(err, model);
+      });
     }
 
   }

--- a/assets/app/templates/SiteListItemTemplate.html
+++ b/assets/app/templates/SiteListItemTemplate.html
@@ -22,14 +22,18 @@
   <p><em>Recent branches</em></p>
   <% } %>
   <ul>
-    <% _(builds).filter(function(build) {
+    <%
+    _(builds).chain().filter(function(build) {
       return build.branch !== defaultBranch;
-    }).forEach(function(build, index) {
-        if (index > 4) return;
+    }).unique(function(build) {
+      return build.branch;
+    }).first(5).forEach(function(build, index) {
     %>
     <li><p>
       <%- build.branch %>
       <% if (build.state === 'success') { %>
+      <a href="http://prose.io/#<%- owner %>/<%- repository %>/tree/<%- build.branch %>" target="_blank" class="edit" alt="edit the site <%- repository %> using prose.io"><i class="mdi-editor-mode-edit"></i></a>
+
       <a href="/preview/<%- owner %>/<%- repository %>/<%- build.branch %>/" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
       <% } else if (build.status === 'error') { %>
       <code><%- build.error %></code>

--- a/assets/app/templates/SiteListItemTemplate.html
+++ b/assets/app/templates/SiteListItemTemplate.html
@@ -3,7 +3,7 @@
     <a href="http://prose.io/#<%- owner %>/<%- repository %>" target="_blank" class="edit" alt="edit the site <%- repository %> using prose.io"><i class="mdi-editor-mode-edit"></i></a>
     <a href="#" class="delete" alt="delete the site <%- repository %>"><i class="mdi-action-delete"></i></a>
     <% if (builds.length != 0) { %>
-      <a href="<%- siteRoot %>/site/<%- owner %>/<%- repository %>/<%- defaultBranch %>" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
+      <a href="<%- siteRoot %>/site/<%- owner %>/<%- repository %>/" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
     <% } %>
   </span>
 </div>

--- a/assets/app/templates/SiteListItemTemplate.html
+++ b/assets/app/templates/SiteListItemTemplate.html
@@ -2,12 +2,41 @@
   <span class="right">
     <a href="http://prose.io/#<%- owner %>/<%- repository %>" target="_blank" class="edit" alt="edit the site <%- repository %> using prose.io"><i class="mdi-editor-mode-edit"></i></a>
     <a href="#" class="delete" alt="delete the site <%- repository %>"><i class="mdi-action-delete"></i></a>
-    <% if (builds.length != 0) { %>
-      <a href="<%- siteRoot %>/site/<%- owner %>/<%- repository %>/" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
+    <% if (builds.length) { %>
+    <a href="<%- siteRoot %>/site/<%- owner %>/<%- repository %>/" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
     <% } %>
   </span>
 </div>
 <div class="collapsible-body">
-  <p>This is uses <%- engine %> as a build engine and has been built <%= builds.length %> times</p>
+  <% if (!builds.length) { %>
+  <p>This site has not been built yet. Please refresh the page to see new builds.</p>
+  <% } else { %>
+  <%
+    var lastBuildTime = new Date(_(builds).findWhere({branch: defaultBranch}).completedAt);
+  %>
+  <p> This site was last built at <%- lastBuildTime %></p>
+  <% if (_(builds).filter(function(build) {
+      return build.branch !== defaultBranch;
+    }).length) {
+  %>
+  <p><em>Recent branches</em></p>
+  <% } %>
+  <ul>
+    <% _(builds).filter(function(build) {
+      return build.branch !== defaultBranch;
+    }).forEach(function(build, index) {
+        if (index > 4) return;
+    %>
+    <li><p>
+      <%- build.branch %>
+      <% if (build.state === 'success') { %>
+      <a href="/preview/<%- owner %>/<%- repository %>/<%- build.branch %>/" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
+      <% } else if (build.status === 'error') { %>
+      <code><%- build.error %></code>
+      <% } %>
+    </p></li>
+    <% }); %>
+  </ul>
+  <% } %>
 
 </div>

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -64,3 +64,7 @@ select {
 .card .card-action a {
   margin-right: 0;
 }
+.collapsible-body p {
+  margin: 20px;
+  padding: 0;
+}

--- a/config/build.js
+++ b/config/build.js
@@ -2,7 +2,7 @@
  * Settings the build process
  */
 module.exports.build = {
-  sourceRoot: '/tmp/federalist',
-  destinationRoot: 'assets/site',
-  s3Bucket: process.env.S3_BUCKET
+  tempDir: process.env.FEDERALIST_TEMP_DIR || './.tmp',
+  publishDir: process.env.FEDERALIST_PUBLISH_DIR || './assets',
+  s3Bucket: process.env.FEDERALIST_S3_BUCKET
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,6 +1,8 @@
-var cfenv = require('cfenv'),
-    appEnv = cfenv.getAppEnv();
-    dbURL = appEnv.getServiceURL('federalist-database');
+var AWS = require('aws-sdk'),
+    cfenv = require('cfenv'),
+    appEnv = cfenv.getAppEnv(),
+    dbURL = appEnv.getServiceURL('federalist-database'),
+    s3Creds = appEnv.getServiceCreds('s3-sb-federalist.18f.gov');
 
 /**
  * Production environment settings
@@ -40,4 +42,12 @@ if (dbURL) {
   module.exports.models = {
     connection: 'postgres'
   };
+}
+
+// If running in Cloud Foundry with an S3 credential service available
+if (s3Creds) {
+  AWS.config.update({
+    accessKeyId: s3Creds.access_key,
+    secretAccessKey: s3Creds.secret_key
+  });
 }

--- a/config/policies.js
+++ b/config/policies.js
@@ -73,6 +73,10 @@ module.exports.policies = {
     'populate': ['passport', 'sessionAuth', 'filterSelfOnly']
   },
 
+  PreviewController: {
+    '*': ['passport', 'sessionAuth', 'previewProxy']
+  },
+
   WebhookController: true
 
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -34,6 +34,9 @@ module.exports.routes = {
 
   'post /webhook/github': 'WebhookController.github',
 
+  'get /preview/:owner/:repo/:branch': 'PreviewController.proxy',
+  'get /preview/:owner/:repo/:branch/*': 'PreviewController.proxy',
+
   /*
   *
   * Passport routes


### PR DESCRIPTION
This sets up separating publishing processes for the main site (when building from the default branch) and draft preview sites (any other branch).

By default, these will publish to `/site/[owner]/[repo]/` for main sites and `/preview/[owner]/[repo]/[branch]/` for preview sites.

The same pattern applies when publishing to S3. To restrict public access to main sites only and not preview sites, we're using the following bucket policy:

```json
{
	"Version": "2012-10-17",
	"Statement": [
		{
			"Sid": "PublicReadGetObject",
			"Effect": "Allow",
			"Principal": "*",
			"Action": "s3:GetObject",
			"Resource": "arn:aws:s3:::federalist.18f.gov/site/*"
		}
	]
}
```

Next steps:

- [x] proxy preview sites from S3 with an authentication policy that checks to make sure the user has access to the site
- [x] add links to the published site and drafts to the user interface