### PR TITLE
Allow non-authorized users to trigger builds on public sites

### DIFF
--- a/api/controllers/WebhookController.js
+++ b/api/controllers/WebhookController.js
@@ -36,9 +36,8 @@ module.exports = {
 
       // Find a matching user
       user: function(next) {
-        User.findOne({
-          username: payload.sender.login
-        }, next);
+        var record = { username: payload.sender.login };
+        User.findOrCreate(record, record, next);
       },
 
       // Find a matching site

--- a/api/services/buildEngines.js
+++ b/api/services/buildEngines.js
@@ -104,7 +104,8 @@ module.exports = {
       // Set populated token values
       tokens.repository = model.site.repository;
       tokens.owner = model.site.owner;
-      tokens.token = model.user.passport.tokens.accessToken;
+      tokens.token = (model.user.passport) ?
+        model.user.passport.tokens.accessToken : '';
 
       // Set up source and destination paths
       tokens.source = sails.config.build.tempDir + '/source/' +


### PR DESCRIPTION
Previously, Federalist tried to clone a site on build with the oauth token from the user who pushed the change. If that user hadn't authorized through federalist, and therefore had no oauth token, builds would fail. Builds would also fail because `build.user` is required, and those users wouldn't have a user record in the database.

This fixes the problem by doing two things:

- Creates a new user if one is missing when creating a build.
- Builds a site without a token if none is available

For public repos, this will work. For private repos, any user wanting to trigger a build of the site will need to authorize their account with Federalist for builds to work. Errors from unauthorized access attempts on private repos will be logged to the `build.error` field of the build record. Eventually, we could send emails to users letting them know their build failed because they need to authorize with a link to do so.