### PR TITLE
Fix missing collection error

### DIFF
--- a/assets/app/views/AddSiteView.js
+++ b/assets/app/views/AddSiteView.js
@@ -51,6 +51,7 @@ var AddSiteView = Backbone.View.extend({
     });
   },
   onSuccess: function onSuccess(e) {
+    this.collection.add(e);
     console.log('winning', e);
     this.trigger('site:save:success');
   },

--- a/assets/app/views/MainContainerView.js
+++ b/assets/app/views/MainContainerView.js
@@ -18,6 +18,7 @@ var AppView = Backbone.View.extend({
     this.pageSwitcher = this.pageSwitcher || new ViewSwitcher(this.el);
   },
   home: function () {
+    federalist.navigate('');
     var authed = this.user.isAuthenticated();
     if(authed) {
       var listView = new SiteListView({ collection: this.sites });

--- a/assets/app/views/MainContainerView.js
+++ b/assets/app/views/MainContainerView.js
@@ -31,7 +31,10 @@ var AppView = Backbone.View.extend({
     return this;
   },
   new: function () {
-    var addSiteView = new AddSiteView({ user: this.user });
+    var addSiteView = new AddSiteView({
+          user: this.user,
+          collection: this.sites
+        });
     this.pageSwitcher.set(addSiteView);
 
     this.listenToOnce(addSiteView, 'site:save:success', function () {


### PR DESCRIPTION
Each new site model needs to know it's collection. This sets that collection to the view, so it can set it on the new site. Fixes #101 