### PR TITLE
Add support for custom domains and site configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-
+ruby '2.2.2'
 gem 'github-pages'

--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -10,7 +10,7 @@ module.exports = {
   schema: true,
 
   attributes: {
-    // The name of the GitHub user or organization that owns the site's repository 
+    // The name of the GitHub user or organization that owns the site's repository
     owner: {
       type:'string',
       required: true
@@ -38,6 +38,12 @@ module.exports = {
       collection: 'build',
       via: 'site'
     },
+    domain: {
+      type: 'string'
+    },
+    config: {
+      type: 'string'
+    },
     toJSON: function() {
       var obj = this.toObject(),
           config = sails.config.build || {};
@@ -63,6 +69,10 @@ module.exports = {
           };
           Build.create(build, done);
         });
+  },
+
+  afterUpdate: function() {
+    Site.afterCreate.apply(this, _.toArray(arguments));
   },
 
   registerSite: function(values, done) {

--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -62,6 +62,7 @@ module.exports = {
     Site.findOne({id: model.id }).populate('users')
         .exec(function(err, site) {
           if (err) return done(err);
+          if (!site.users[0]) return done();
           var build = {
               user: site.users[0].id,
               site: model.id,

--- a/api/services/buildEngines.js
+++ b/api/services/buildEngines.js
@@ -16,7 +16,7 @@ module.exports = {
       'mkdir -p ${source}',
       'git clone -b ${branch} --single-branch ' +
         'https://${token}@github.com/${owner}/${repository}.git ${source}',
-      'echo "baseurl: /${root}/${owner}/${repository}${branchURL}" > ' +
+      'echo "baseurl: ${baseurl}\n${config}" > ' +
         '${source}/_config_base.yml',
       'jekyll build --safe --config ${source}/_config.yml,${source}/_config_base.yml ' +
         '--source ${source} --destination ${source}/_site',
@@ -36,7 +36,7 @@ module.exports = {
       'mkdir -p ${source}',
       'git clone -b ${branch} --single-branch ' +
         'https://${token}@github.com/${owner}/${repository}.git ${source}',
-      'hugo --baseUrl=/${root}/${owner}/${repository}${branchURL} ' +
+      'hugo --baseUrl=${baseurl} ' +
         '--source=${source}',
       'rm -rf ${destination}',
       'mkdir -p ${destination}',
@@ -82,7 +82,8 @@ module.exports = {
         tokens = {
           branch: model.branch,
           branchURL: defaultBranch ? '' : '/' + model.branch,
-          root: defaultBranch ? 'site' : 'preview'
+          root: defaultBranch ? 'site' : 'preview',
+          config: model.site.config
         },
         template = _.template(cmd.join(' && '));
 
@@ -106,6 +107,8 @@ module.exports = {
       tokens.owner = model.site.owner;
       tokens.token = (model.user.passport) ?
         model.user.passport.tokens.accessToken : '';
+      tokens.baseurl = '/' + tokens.root + '/' + tokens.owner +
+        '/' + tokens.repository + tokens.branchURL;
 
       // Set up source and destination paths
       tokens.source = sails.config.build.tempDir + '/source/' +

--- a/api/services/buildEngines.js
+++ b/api/services/buildEngines.js
@@ -107,7 +107,8 @@ module.exports = {
       tokens.owner = model.site.owner;
       tokens.token = (model.user.passport) ?
         model.user.passport.tokens.accessToken : '';
-      tokens.baseurl = '/' + tokens.root + '/' + tokens.owner +
+      tokens.baseurl = (model.site.domain && defaultBranch) ? "''" :
+        '/' + tokens.root + '/' + tokens.owner +
         '/' + tokens.repository + tokens.branchURL;
 
       // Set up source and destination paths

--- a/assets/app/app.js
+++ b/assets/app/app.js
@@ -23,6 +23,7 @@ var Router = Backbone.Router.extend({
   routes: {
     '': 'home',
     'new': 'new',
+    'site/:id/edit': 'siteEdit',
     'edit(/)*path': 'edit'
   },
   home: function () {
@@ -31,6 +32,10 @@ var Router = Backbone.Router.extend({
   },
   new: function () {
     this.mainView.new();
+    return this;
+  },
+  siteEdit: function(id) {
+    this.mainView.siteEdit(id);
     return this;
   },
   edit: function (path) {

--- a/assets/app/templates/AddSiteTemplate.html
+++ b/assets/app/templates/AddSiteTemplate.html
@@ -47,7 +47,7 @@
       <div class="row">
         <div class="col s6">
           <label for="engine">engine</label>
-          <select name="engine" id="engine">
+          <select name="engine" id="engine" class="browser-default">
             <option selected value="jekyll">Jekyll</option>
             <option value="hugo">Hugo</option>
             <option value="static">Static (just publish the files in the repository)</option>

--- a/assets/app/templates/SiteEditTemplate.html
+++ b/assets/app/templates/SiteEditTemplate.html
@@ -47,7 +47,7 @@
              <input readonly type="text" value="<%- model.siteRoot || window.location.origin %>/site/<%- model.owner %>/<%- model.repository %>/"></p>
          </div>
          <div class="card-action">
-           <a href="#">Detailed instructions</a>
+           <a href="http://docs.aws.amazon.com/gettingstarted/latest/swh/getting-started-create-cfdist.html" target="_blank">Detailed instructions</a>
          </div>
        </div>
      </div>

--- a/assets/app/templates/SiteEditTemplate.html
+++ b/assets/app/templates/SiteEditTemplate.html
@@ -24,8 +24,8 @@
       </div>
       <div class="row">
         <div class="input-field col s12">
-          <input name="domain" type="text" value="<%- model.domain %>">
-          <label for="domain">Custom domain</label>
+          <input name="domain" type="text" placeholder="https://example.com" value="<%- model.domain %>">
+          <label class="active" for="domain">Custom domain</label>
         </div>
       </div>
       <% if (model.engine === 'jekyll') { %>
@@ -43,7 +43,8 @@
       <div class="card grey lighten-1">
          <div class="card-content">
            <span class="card-title">Custom domain</span>
-           <p>Tell us your custom domain, such as: <code>https://example.com</code></p>
+           <p>Use a custom domain by setting an <code>ALIAS</code> record with your DNS provider that points this origin:
+             <input readonly type="text" value="<%- model.siteRoot || window.location.origin %>/site/<%- model.owner %>/<%- model.repository %>/"></p>
          </div>
          <div class="card-action">
            <a href="#">Detailed instructions</a>

--- a/assets/app/templates/SiteEditTemplate.html
+++ b/assets/app/templates/SiteEditTemplate.html
@@ -1,0 +1,62 @@
+<div class="row">
+  <div class="col s6">
+    <h5><%- model.owner %> / <%- model.repository %></h5>
+  </div>
+  <div class="col s6 right-align">
+    <a href="#" class="cancel-add-action btn red accent-3">Cancel</a>
+  </div>
+</div>
+<div class="row">
+  <div class="col s12">
+    <p>Edit the settings for your site.</p>
+  </div>
+</div>
+<div class="row">
+  <form id="site-edit" class="col s8">
+      <div class="row">
+        <div class="input-field col s12">
+          <input name="defaultBranch" type="text"
+            value="<%- model.defaultBranch %>">
+          <label for="defaultBranch"
+            class="<%- model.defaultBranch ? 'active' : '' %>">
+            Default branch</label>
+        </div>
+      </div>
+      <div class="row">
+        <div class="input-field col s12">
+          <input name="domain" type="text" value="<%- model.domain %>">
+          <label for="domain">Custom domain</label>
+        </div>
+      </div>
+      <% if (model.engine === 'jekyll') { %>
+      <div class="row">
+        <div class="input-field col s12">
+          <textarea name="config" class="materialize-textarea monospace"><%- model.config %></textarea>
+          <label for="config"
+            class="<%- model.config ? 'active' : '' %>">Custom configuration</label>
+        </div>
+      </div>
+      <% } %>
+      <input type="submit" class="btn green" value="Save">
+    </form>
+    <div class="col s4">
+      <div class="card grey lighten-1">
+         <div class="card-content">
+           <span class="card-title">Custom domain</span>
+           <p>Tell us your custom domain, such as: <code>https://example.com</code></p>
+         </div>
+         <div class="card-action">
+           <a href="#">Detailed instructions</a>
+         </div>
+       </div>
+     </div>
+   <div class="col s4">
+     <div class="card grey lighten-1">
+        <div class="card-content">
+          <span class="card-title">Configuration</span>
+          <p>Add additional configuration in yaml to be added to your <code>_config.yml</code> file when we render your site.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/assets/app/templates/SiteListItemTemplate.html
+++ b/assets/app/templates/SiteListItemTemplate.html
@@ -1,15 +1,16 @@
 <div class="collapsible-header active"><%- repository %>
   <span class="right">
     <!-- <a href="/#edit/<%- owner %>/<%- repository %>/<%- defaultBranch %>/README.md" class="edit" alt="edit the site <%- repository %> using prose.io"><i class="mdi-editor-mode-edit"></i></a> -->
+    <a href="#site/<%- id %>/edit" class="settings" alt="change settings for <%- repository %>"><i class="mdi-action-settings"></i></a>
     <a href="http://prose.io/#<%- owner %>/<%- repository %>/tree/<%- defaultBranch %>" target="_blank" class="edit" alt="edit the site <%- repository %> using prose.io"><i class="mdi-editor-mode-edit"></i></a>
     <a href="#" class="delete" alt="delete the site <%- repository %>"><i class="mdi-action-delete"></i></a>
     <% if (builds.length) { %>
-    <a href="<%- siteRoot %>/site/<%- owner %>/<%- repository %>/" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
+    <a href="<%- viewLink %>" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank"><i class="mdi-action-open-in-new"></i></a>
     <% } %>
   </span>
 </div>
 <div class="collapsible-body">
-  <% if (!builds.length) { %>
+  <% if (!builds.length || !lastBuildTime) { %>
   <p>This site has not been built yet. Please refresh the page to see new builds.</p>
   <% } else { %>
   <p> This site was last built at <%- lastBuildTime %></p>

--- a/assets/app/views/MainContainerView.js
+++ b/assets/app/views/MainContainerView.js
@@ -48,6 +48,9 @@ var AppView = Backbone.View.extend({
   siteEdit: function(id) {
     var siteEditView = new SiteEditView({ model: this.sites.get(id) });
     this.pageSwitcher.set(siteEditView);
+    this.listenToOnce(siteEditView, 'site:save:success', function () {
+      this.home();
+    }.bind(this));
     return this;
   },
   edit: function (path) {

--- a/assets/app/views/MainContainerView.js
+++ b/assets/app/views/MainContainerView.js
@@ -2,6 +2,7 @@ var Backbone = require('backbone');
 var ViewSwitcher = require('ampersand-view-switcher');
 
 var AuthenticateView = require('./AuthenticateView');
+var SiteEditView = require('./SiteEditView');
 var SiteListView = require('./SiteListView');
 var AddSiteView = require('./AddSiteView');
 var EditView = require('./EditView');
@@ -42,6 +43,11 @@ var AppView = Backbone.View.extend({
       this.home();
     }.bind(this));
 
+    return this;
+  },
+  siteEdit: function(id) {
+    var siteEditView = new SiteEditView({ model: this.sites.get(id) });
+    this.pageSwitcher.set(siteEditView);
     return this;
   },
   edit: function (path) {

--- a/assets/app/views/SiteEditView.js
+++ b/assets/app/views/SiteEditView.js
@@ -25,8 +25,14 @@ var SiteEditView = Backbone.View.extend({
     var data = _(this.$('form').serializeArray()).reduce(function(memo, value) {
           memo[value.name] = value.value;
           return memo;
-        }, {});
-    this.model.save(data, { attrs: data });
+        }, {}),
+        view = this;
+    this.model.save(data, {
+      attrs: data,
+      success: function() {
+        view.trigger('site:save:success');
+      }
+    });
   }
 
 });

--- a/assets/app/views/SiteEditView.js
+++ b/assets/app/views/SiteEditView.js
@@ -1,0 +1,34 @@
+var fs = require('fs');
+
+var Backbone = require('backbone');
+var _ = require('underscore');
+
+var templateHtml = fs.readFileSync(__dirname + '/../templates/SiteEditTemplate.html').toString();
+
+var SiteEditView = Backbone.View.extend({
+
+  template: _.template(templateHtml, { variable: 'model' }),
+
+  events: {
+    'submit': 'save'
+  },
+
+  render: function renderSiteEditView() {
+    if (!this.model) return this;
+    var data = this.model.toJSON();
+    this.$el.html(this.template(data));
+    return this;
+  },
+
+  save: function saveSiteEditView(e) {
+    e.preventDefault();
+    var data = _(this.$('form').serializeArray()).reduce(function(memo, value) {
+          memo[value.name] = value.value;
+          return memo;
+        }, {});
+    this.model.save(data, { attrs: data });
+  }
+
+});
+
+module.exports = SiteEditView;

--- a/assets/app/views/SiteListItemView.js
+++ b/assets/app/views/SiteListItemView.js
@@ -36,7 +36,9 @@ var SiteListItemView = Backbone.View.extend({
       succes: this.onDeleteSuccess.bind(this),
       error: this.onDeleteError.bind(this)
     };
-    this.model.destroy(opts);
+    if (window.confirm('Are you sure you want to delete this site?')) {
+      this.model.destroy(opts);
+    }
   },
   onDeleteSuccess: function onDeleteSuccess() {
     console.log('delete success');

--- a/assets/app/views/SiteListItemView.js
+++ b/assets/app/views/SiteListItemView.js
@@ -19,12 +19,15 @@ var SiteListItemView = Backbone.View.extend({
   },
   render: function renderSiteView() {
     var data = this.model.toJSON(),
-        lastBuildTime = new Date(_(data.builds).chain().where({
+        lastBuild = _(data.builds).chain().where({
           branch: data.defaultBranch
         }).filter(function(build) {
           return build.completedAt;
-        }).last().value().completedAt);
-    data.lastBuildTime = moment(lastBuildTime).format('L LT');
+        }).last().value();
+    data.lastBuildTime = lastBuild ? moment(new Date(lastBuild.completedAt))
+      .format('L LT') : '';
+    data.viewLink = data.domain ||
+      data.siteRoot + '/site/' + data.owner + '/' + data.repository + '/';
     this.$el.html(this.template(data));
   },
 

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -14,6 +14,9 @@ nav {
 main {
   flex: 1 0 auto;
 }
+.monospace {
+  font-family: monospace;
+}
 .stage-bug {
   display: block;
   background: #f3f3f3;
@@ -28,21 +31,16 @@ main {
 .btn, .btn-large {
   text-transform: capitalize !important; /* if we're gonna do it, we're gonna do it */
 }
-input[type=text] {
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding-left: 5px;
-}
 select {
   display: block;
-  border: 1px solid #ccc;
+  border: 1px solid #9e9e9e;
 }
-.card .card-title {
+.card.grey .card-title {
   color: black;
   font-size: 18px;
   font-weight: 400;
 }
-.card .card-content .card-title {
+.card.grey .card-content .card-title {
   line-height: 1em;
 }
 .card .card-action a {
@@ -51,7 +49,7 @@ select {
 .collapsible-body {
   display: block;
 }
-.card .card-action a {
+.card.grey .card-action a {
   margin-right: 0;
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# Blue-green deployment script. Usage:
+#
+#   ./script/deploy <appname>
+#
+# Based on
+#   http://www.cloudfoundry.rocks/blue-green-deployment-with-cloudfoundry/
+#   http://docs.pivotal.io/pivotalcf/devguide/deploy-apps/blue-green.html
+#   https://github.com/dlapiduz/step-cloud-foundry-deploy/blob/master/run.sh
+
+set -e
+set -o pipefail
+set -x
+
+BLUE=$1
+GREEN="${BLUE}-B"
+
+
+finally ()
+{
+  # we don't want to keep the sensitive information around
+  rm $MANIFEST
+}
+
+on_fail () {
+  finally
+  echo "DEPLOY FAILED - you may need to check 'cf apps' and 'cf routes' and do manual cleanup"
+}
+
+
+# pull the up-to-date manifest from the BLUE (existing) application
+MANIFEST=$(mktemp -t "${BLUE}_manifest")
+cf create-app-manifest $BLUE -p $MANIFEST
+
+# set up try/catch
+# http://stackoverflow.com/a/185900/358804
+trap on_fail ERR
+
+DOMAIN=$(cat $MANIFEST | grep domain: | awk '{print $2}')
+
+# create the GREEN application
+cf push $GREEN -f $MANIFEST -n $GREEN
+# ensure it starts
+curl --fail -I "https://${GREEN}.${DOMAIN}"
+
+# add the GREEN application to each BLUE route to be load-balanced
+# TODO this output parsing seems a bit fragile...find a way to use more structured output
+cf routes | grep $BLUE | awk '{print $3" -n "$2}' | xargs -n 3 cf map-route $GREEN
+
+# cleanup
+# TODO consider 'stop'-ing the BLUE instead of deleting it, so that depedencies are cached for next time
+cf delete $BLUE -f
+cf rename $GREEN $BLUE
+cf delete-route $DOMAIN -n $GREEN -f
+finally
+
+echo "DONE"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,8 @@
 ---
 applications:
 - name: federalist
-  buildpack: https://github.com/cloudfoundry/nodejs-buildpack
-  domain: 18f.gov
+buildpack: https://github.com/ozzyjohnson/heroku-buildpack-multi
+domain: 18f.gov
+services:
+- federalist-database
+- s3-sb-federalist.18f.gov

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
 - name: federalist
-  buildpack: https://github.com/ozzyjohnson/heroku-buildpack-multi.git
+  buildpack: https://github.com/cloudfoundry/nodejs-buildpack
   domain: 18f.gov

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
 - name: federalist
-  buildpack: https://github.com/ddollar/heroku-buildpack-multi.git
+  buildpack: https://github.com/ozzyjohnson/heroku-buildpack-multi.git
   domain: 18f.gov

--- a/migrations/20150730173826-site-domain-config.js
+++ b/migrations/20150730173826-site-domain-config.js
@@ -1,0 +1,16 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  db.runSql('ALTER TABLE site ADD COLUMN domain text, ADD COLUMN config text', function(err) {
+    if (err) throw err;
+    callback();
+  });
+};
+
+exports.down = function(db, callback) {
+  db.runSql('ALTER TABLE site DROP COLUMN domain, DROP COLUMN config', function(err) {
+    if (err) throw err;
+    callback();
+  });
+};


### PR DESCRIPTION
Support for custom domains and site configuration data by adding additional data to the Site model and presenting it to users with a site edit view.

Setting custom configuration works by adding the `site.config` data to a `_config.yml` file used while rendering the Jekyll site.

Open ends:

- [x] Migration script for new site model attribute
- [x] display the origin url on the UI for custom domains
- [x] write detailed instructions for configuring a custom domain
- [x] update the “view site” link on the site list item view
- [x] adjust `baseurl` to use `site.domain`

<img width="718" alt="screen shot 2015-07-27 at 3 55 27 pm" src="https://cloud.githubusercontent.com/assets/170641/8916198/efbbaada-3477-11e5-8d29-8e68479223ba.png">

Closes #94 
Closes #93 
