### PR TITLE
Add branch to the site config file

### DIFF
--- a/api/hooks/buildEngine/index.js
+++ b/api/hooks/buildEngine/index.js
@@ -16,7 +16,7 @@ var hook = {
       'mkdir -p ${source}',
       'git clone -b ${branch} --single-branch ' +
         'https://${token}@github.com/${owner}/${repository}.git ${source}',
-      'echo "baseurl: ${baseurl}\n${config}" > ' +
+      'echo "baseurl: ${baseurl}\nbranch: ${branch}\n${config}" > ' +
         '${source}/_config_base.yml',
       'jekyll build --safe --config ${source}/_config.yml,${source}/_config_base.yml ' +
         '--source ${source} --destination ${source}/_site',


### PR DESCRIPTION
This adds the `branch` value to the extended `_config_base.yml` file, so `site.branch` is available to templates. This config file is layered on top of the repository's `_config.yml` so it will override any value set there.

Resolves #116
