### PR TITLE
Users can add, edit and remove YAML front matter from documents

### DIFF
--- a/assets/app/models/Document.js
+++ b/assets/app/models/Document.js
@@ -22,7 +22,7 @@ var DocumentModel = Backbone.Model.extend({
   toMarkdown: function () {
     var y = yaml.safeDump(this.frontMatter),
         x = '---\n';
-    return [x, y, x + '\n', this.content].join('');
+    return [x, y, x, this.content].join('');
   },
   toSirTrevorJson: function () {
     var blocks = [],
@@ -43,6 +43,11 @@ var DocumentModel = Backbone.Model.extend({
       return htmlString;
     }).join('\n');
     this.content = htmlToMarkdown(result);
+  },
+  updateFrontMatter: function (frontMatter) {
+    if (!frontMatter) return this;
+    this.frontMatter = frontMatter;
+    return this;
   }
 });
 

--- a/assets/app/templates/EditorTemplate.html
+++ b/assets/app/templates/EditorTemplate.html
@@ -13,9 +13,25 @@
        </div>
     </div>
   </div>
+  <button data-show-area id="showContent">Content</button>
+  <button data-show-area id="showMetaData">Settings</button>
+  <form id="metadata" style="display:none;">
+    <h2>Settings</h2>
+    <div class="meta-data-rows">
+      <% _.each(frontMatter, function(v, k) { %>
+        <div class="row">
+          <div class="col s5"><input type="text" class="front-matter-key" value="<%= k %>"></div>
+          <div class="col s5"><input type="text" class="front-matter-value" value="<%= v %>"></div>
+          <div class="col s2"><button class="front-matter-delete">Delete</button></div>
+        </div>
+      <% }); %>
+    </div>
+    <button id="add-front-matter-row">Add key/value pair</button>
+  </form>
   <div class="row">
     <div class="col s12">
-      <form>
+      <form id="content">
+        <h2>Content</h2>
         <textarea class="js-st-instance"></textarea>
       </form>
     </div>

--- a/assets/app/views/EditorView.js
+++ b/assets/app/views/EditorView.js
@@ -21,10 +21,13 @@ var templateHtml = fs.readFileSync(__dirname + '/../templates/EditorTemplate.htm
 var EditorView = Backbone.View.extend({
   tagName: 'div',
   events: {
-    'click #save-content-action': 'saveDocument'
+    'click [data-show-area]': 'toggleAreas',
+    'click #save-content-action': 'saveDocument',
+    'click .front-matter-delete': 'deleteMetaDataRow',
+    'click #add-front-matter-row': 'addMetaDataRow'
   },
   initialize: function (opts) {
-    this.doc = new Document({ markdown: opts.content });
+    this.doc = window.d = new Document({ markdown: opts.content });
     this.fileName = opts.file;
     return this;
   },
@@ -33,7 +36,7 @@ var EditorView = Backbone.View.extend({
         blocks  = [],
         editor, mdTree;
 
-    this.$el.html(_.template(templateHtml)({ fileName: this.fileName }));
+    this.$el.html(_.template(templateHtml)({ fileName: this.fileName, frontMatter: this.doc.frontMatter }));
     this.editor = new SirTrevor.Editor({
       el: this.$('.js-st-instance'),
       blockTypes: ["H1", "H2", "H3", "Text", "Unordered", "Ordered"]
@@ -41,16 +44,45 @@ var EditorView = Backbone.View.extend({
 
     this.$('.js-st-instance').text(doc.toSirTrevorJsonString());
     this.editor.reinitialize();
-
+    $('form#metadata').hide();
     return this;
   },
+  toggleAreas: function () {
+    $('form#metadata').toggle();
+    $('form#content').toggle();
+  },
   saveDocument: function (e) {
+    var formFrontMatter = {};
     SirTrevor.onBeforeSubmit();
+    $('form#metadata .row').each(function(index, row) {
+      var key   = $(row).find('.front-matter-key').val(),
+          value = $(row).find('.front-matter-value').val();
+
+      if (key) {
+        formFrontMatter[key] = value;
+      }
+    });
+
+    this.doc.updateFrontMatter(formFrontMatter);
     this.doc.updateContentFromSirTrevorJson(this.editor.store.retrieve());
+
     this.trigger('edit:save', {
         md: this.doc.toMarkdown(),
         msg: this.$('#save-content-message').val()
     });
+    return this;
+  },
+  deleteMetaDataRow: function (e) {
+    e.preventDefault();
+    $(e.target).parents('.meta-data-rows .row').remove();
+
+    return this;
+  },
+  addMetaDataRow: function (e) {
+    e.preventDefault();
+    var rowTemplate = _.template('<div class="row"><div class="col s5"><input type="text" class="front-matter-key" placeholder="key"></div><div class="col s5"><input type="text" class="front-matter-value" placeholder="value"></div><div class="col s2"><button class="front-matter-delete">Delete</button></div></div>')();
+    $('.meta-data-rows').append(rowTemplate);
+
     return this;
   }
 });

--- a/assets/app/views/EditorView.js
+++ b/assets/app/views/EditorView.js
@@ -27,7 +27,7 @@ var EditorView = Backbone.View.extend({
     'click #add-front-matter-row': 'addMetaDataRow'
   },
   initialize: function (opts) {
-    this.doc = window.d = new Document({ markdown: opts.content });
+    this.doc = new Document({ markdown: opts.content });
     this.fileName = opts.file;
     return this;
   },


### PR DESCRIPTION
This PR adds meta data editing functionality so that users can add, edit and remove meta data from their documents. There is a tabbed interface on the editor for the user to toggle between content and "Settings", which is a more user friendly name for the YAML over "front matter" or "meta data".

The save button saves both the front matter and the content to Github with every successful click.

To close #126 