### PR TITLE
Add a log of recent builds

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -6,5 +6,16 @@
  */
 
 module.exports = {
-
+  /*
+   * Return an object of usernames
+   */
+  usernames: function(req, res) {
+    User.find({}).exec(function(err, users) {
+      if (err) return res.serverError(err);
+      res.send(_.reduce(users, function(memo, user) {
+        memo[user.id] = user.username;
+        return memo;
+      }, {}));
+    });
+  }
 };

--- a/assets/app/app.js
+++ b/assets/app/app.js
@@ -29,6 +29,7 @@ var Router = Backbone.Router.extend({
     'new': 'new',
     'edit/:owner/:repo/:branch(/)*file': 'edit',
     'site/:id/edit': 'siteEdit',
+    'site/:id/builds': 'builds'
   },
   home: function () {
     this.mainView.home();
@@ -44,6 +45,10 @@ var Router = Backbone.Router.extend({
   },
   siteEdit: function(id) {
     this.mainView.siteEdit(id);
+    return this;
+  },
+  builds: function(id) {
+    this.mainView.builds(id);
     return this;
   }
 });

--- a/assets/app/templates/site/builds.html
+++ b/assets/app/templates/site/builds.html
@@ -1,0 +1,15 @@
+<% _.each(site.builds, function(build) { %>
+<% var panelClass = build.state === 'error' ? 'danger' :
+  build.state === 'success' ? 'success' : 'info'; %>
+<div class="panel panel-<%- panelClass %>">
+  <div class="panel-heading">
+    <%- build.branch %> (<%- build.username %>)
+    <span class="pull-right"><%- build.completedAtFormatted || 'Processing' %></span>
+  </div>
+  <div class="panel-body"><%
+    build.state === 'error' ?
+    print(build.error) :
+    print('The build completed successfully.')
+  %></div>
+</div>
+<% }); %>

--- a/assets/app/templates/site/builds.html
+++ b/assets/app/templates/site/builds.html
@@ -1,3 +1,6 @@
+<div class="page-header">
+  <h1>Recent builds for your site</h1>
+</div>
 <% _.each(site.builds, function(build) { %>
 <% var panelClass = build.state === 'error' ? 'danger' :
   build.state === 'success' ? 'success' : 'info'; %>

--- a/assets/app/templates/site/edit.html
+++ b/assets/app/templates/site/edit.html
@@ -51,9 +51,15 @@
   </div>
   <div class="row">
     <div class="col-md-12">
-      <a href="#" class="btn btn-danger" role="button">Cancel</a>
+      <a href="#" class="btn btn-default" role="button">Cancel</a>
       <button class="btn btn-primary" data-action="save-site-settings">Save</button>
     </div>
   </div>
   </form>
+  <hr>
+  <div class="alert alert-danger" role="alert">
+    Delete this site from Federalist?
+    <a href="#" class="btn btn-danger" data-action="delete-site" alt="delete the site <%- model.repository %>">Delete</a>
+  </div>
+
 </div>

--- a/assets/app/templates/site/list-item.html
+++ b/assets/app/templates/site/list-item.html
@@ -10,9 +10,9 @@
       </div>
       <div class="col-md-6">
         <div class="pull-right">
+          <a href="#site/<%- id %>/builds" class="btn btn-default btn-xs" data-action="site-builds" alt="show log of builds for <%- repository %>">Builds</a>
           <a href="#site/<%- id %>/edit" class="btn btn-default btn-xs" data-action="edit-site-settings" alt="change settings for <%- repository %>">Settings</a>
           <a href="/#edit/<%- owner %>/<%- repository %>/<%- defaultBranch %>" class="btn btn-default btn-xs" data-action="edit-site-content" alt="edit the site <%- repository %>">Edit</a>
-          <a href="#" class="btn btn-danger btn-xs" data-action="delete-site" alt="delete the site <%- repository %>">Delete</a>
           <% if (builds.length) { %>
           <a href="<%- viewLink %>" class="view" alt="go to the site <%- repository %> in a new tab" target="_blank">View</a>
           <% } %>
@@ -25,7 +25,7 @@
     %>
     <p><em>Recent drafts</em></p>
     <% } %>
-    <ul>
+    <ul class="list-unstyled">
       <%
       _(builds).chain().filter(function(build) {
         return build.branch !== defaultBranch;

--- a/assets/app/templates/site/list.html
+++ b/assets/app/templates/site/list.html
@@ -1,16 +1,20 @@
 <div class="page-header">
-  <h1>Your current sites</h1>
+  <h1>
+    Your sites
+    <% if (sitesCount) { %>
+      <a href="#new" class="btn btn-primary pull-right" alt="add a new site" role="button">Add a new site</a>
+    <% } %>
+  </h1>
 </div>
 <% if (sitesCount === 0) { %>
   <div class="row center-block">
     <p>Welcome! You don't have any sites registered with Federalist just yet. Let's go ahead and change that.</p>
-    <a class="btn btn-primary" href="#new" role="button">Add your first site now</a>
+    <a class="btn btn-primary btn-lg" href="#new" role="button">Add your first site now</a>
   </div>
 <% } else { %>
   <div class="row">
     <div class="col-md-12">
       <ul class="sites"></ul>
-      <a href="#new" class="btn btn-primary" alt="add a new site" role="button">Add a new site</a>
     </div>
   </div>
 <% } %>

--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -5,6 +5,7 @@ var AuthenticateView = require('./authenticate');
 var SiteEditView = require('./site/edit');
 var SiteListView = require('./site/list');
 var AddSiteView = require('./site/add');
+var BuildsView = require('./site/builds');
 var EditorContainerView = require('./editor/edit-main');
 
 var AppView = Backbone.View.extend({
@@ -63,6 +64,11 @@ var AppView = Backbone.View.extend({
     this.listenToOnce(siteEditView, 'site:save:success', function () {
       this.home();
     }.bind(this));
+    return this;
+  },
+  builds: function(id) {
+    var buildsView = new BuildsView({ model: this.sites.get(id) });
+    this.pageSwitcher.set(buildsView);
     return this;
   }
 });

--- a/assets/app/views/site/builds.js
+++ b/assets/app/views/site/builds.js
@@ -1,0 +1,29 @@
+var fs = require('fs');
+
+var Backbone = require('backbone');
+var _ = require('underscore');
+var moment = require('moment');
+
+var templateHtml = fs.readFileSync(__dirname + '/../../templates/site/builds.html').toString();
+
+var BuildsView = Backbone.View.extend({
+  tagName: 'div',
+  className: 'list',
+  template: _.template(templateHtml, { variable: 'site' }),
+  render: function() {
+    if (!this.model) return this;
+    var data = this.model.toJSON(),
+        view = this;
+    $.getJSON('/v0/user/usernames', function(users) {
+      data.builds = _(data.builds).chain().map(function(build) {
+        build.username = users[build.user];
+        build.completedAtFormatted = new Date(build.completedAt) ?
+          moment(new Date(build.completedAt)).format('L LT') : undefined;
+        return build;
+      }).sortBy('createdAt').value().reverse();
+      view.$el.html(view.template(data));
+    });
+    return this;
+  }
+});
+module.exports = BuildsView;

--- a/assets/app/views/site/edit.js
+++ b/assets/app/views/site/edit.js
@@ -10,7 +10,8 @@ var SiteEditView = Backbone.View.extend({
   template: _.template(templateHtml, { variable: 'model' }),
 
   events: {
-    'submit': 'save'
+    'submit': 'save',
+    'click [data-action=delete-site]': 'onDelete'
   },
 
   render: function renderSiteEditView() {
@@ -33,6 +34,22 @@ var SiteEditView = Backbone.View.extend({
         view.trigger('site:save:success');
       }
     });
+  },
+
+  onDelete: function onDelete() {
+    var opts = {
+      success: this.onDeleteSuccess.bind(this),
+      error: this.onDeleteError.bind(this)
+    };
+    if (window.confirm('Are you sure you want to delete this site?')) {
+      this.model.destroy(opts);
+    }
+  },
+  onDeleteSuccess: function onDeleteSuccess() {
+    console.log('delete success');
+  },
+  onDeleteError: function onDeleteError() {
+    console.log('delete failure');
   }
 
 });

--- a/assets/app/views/site/list-item.js
+++ b/assets/app/views/site/list-item.js
@@ -11,9 +11,6 @@ var SiteListItemView = Backbone.View.extend({
   tagName: 'li',
   model: SiteModel,
   template: _.template(templateHtml),
-  events: {
-    'click [data-action=delete-site]': 'onDelete'
-  },
   initialize: function initializeSiteView() {
     this.render();
   },
@@ -29,22 +26,6 @@ var SiteListItemView = Backbone.View.extend({
     data.viewLink = data.domain ||
       data.siteRoot + '/site/' + data.owner + '/' + data.repository + '/';
     this.$el.html(this.template(data));
-  },
-
-  onDelete: function onDelete() {
-    var opts = {
-      succes: this.onDeleteSuccess.bind(this),
-      error: this.onDeleteError.bind(this)
-    };
-    if (window.confirm('Are you sure you want to delete this site?')) {
-      this.model.destroy(opts);
-    }
-  },
-  onDeleteSuccess: function onDeleteSuccess() {
-    console.log('delete success');
-  },
-  onDeleteError: function onDeleteError() {
-    console.log('delete failure');
   }
 });
 

--- a/config/policies.js
+++ b/config/policies.js
@@ -70,7 +70,8 @@ module.exports.policies = {
   UserController: {
     'find': ['passport', 'sessionAuth', 'filterSelfOnly'],
     'findOne': ['passport', 'sessionAuth', 'filterSelfOnly'],
-    'populate': ['passport', 'sessionAuth', 'filterSelfOnly']
+    'populate': ['passport', 'sessionAuth', 'filterSelfOnly'],
+    'usernames': ['passport', 'sessionAuth']
   },
 
   PreviewController: {


### PR DESCRIPTION
Lets site owners see builds from their site. Adds a button for "builds" to the main site listing and a new view listing the recent builds and any error messages.

![screen shot 2015-08-26 at 12 44 31 pm](https://cloud.githubusercontent.com/assets/170641/9499941/7462ca18-4bf0-11e5-8f5f-7d21320f5a0c.png)

![screen shot 2015-08-26 at 12 44 14 pm](https://cloud.githubusercontent.com/assets/170641/9499946/7a2535da-4bf0-11e5-9ca4-ae4d9a1c5e8b.png)

Also moves the delete button to the bottom of the settings page to keep it out of the way.

![screen shot 2015-08-26 at 12 44 42 pm](https://cloud.githubusercontent.com/assets/170641/9499951/7f5221c6-4bf0-11e5-9dcf-a8f3af44979e.png)

Could definitely use some more formatting on the list and error messages, but my goal here is to ship all the basic functionality we're missing and improve the look as we have time.