### PR TITLE
Build support and instructions for Windows and Azure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
+    RedCloth (4.2.9-x86-mingw32)
     activesupport (4.2.3)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -24,6 +25,7 @@ GEM
     execjs (2.6.0)
     fast-stemmer (1.0.2)
     ffi (1.9.10)
+    ffi (1.9.10-x86-mingw32)
     gemoji (2.1.0)
     github-pages (39)
       RedCloth (= 4.2.9)
@@ -50,6 +52,7 @@ GEM
       public_suffix (~> 1.4)
       typhoeus (~> 0.7)
     hitimes (1.2.2)
+    hitimes (1.2.2-x86-mingw32)
     html-pipeline (1.9.0)
       activesupport (>= 2)
       nokogiri (~> 1.4)
@@ -102,6 +105,8 @@ GEM
     net-dns (0.8.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.2-x86-mingw32)
+      mini_portile (~> 0.6.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.11)
@@ -130,9 +135,10 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.10.4
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ***Under active development. Everything is subject to change. Interested in talking to us? [Join our public chat](https://chat.18f.gov/) room (select `federalist-public` from the dropdown).***
 
-Federalist is a unified interface for publishing static government websites. It automates common tasks for integrating GitHub, [Prose](https://github.com/prose/prose), and Amazon Web Services to provide a simple way for developers to launch new websites or more easily manage existing ones.
+Federalist is a unified interface for publishing static government websites. It automates common tasks for integrating GitHub, [Prose](https://github.com/prose/prose), Amazon Web Services and Microsoft Azure to provide a simple way for developers to launch new websites or more easily manage existing ones.
 
 This project received funding through GSA's Great Pitch, a "pilot program to support the exploration and testing of new, good-for-government product or service ideas that positively impact Citizen Experience, Smarter IT Delivery, Open Government, or Secure Cloud, which can prove their value by end of the fiscal year."
 
@@ -26,6 +26,7 @@ We have a few environment variables that the application uses, here is a list of
 * `GITHUB_CLIENT_ID` **required** - get this when you register your app with Github
 * `GITHUB_CLIENT_SECRET` **required** - you'll also get this when you register your app
 * `GITHUB_CLIENT_CALLBACK_URL` - for dev you'll probably want to use http://localhost:1337/auth/github/callback
+* `FEDERALIST_BUILD_ENGINE` - defines an alternate build engine to use if running Federalist on Windows
 * `FEDERALIST_TEMP_DIR` - where files will be temporarily built
 * `FEDERALIST_PUBLISH_DIR` - where to publish files if not S3
 * `FEDERALIST_S3_BUCKET` - bucket ID to push files to on S3
@@ -127,6 +128,18 @@ models: {
 }
 ```
 
+### Building on Windows
+
+The same dependencies and steps as described above can be used to install and run Federalist on Windows. Running the platform on Windows also requires the installation of the [sails-hook-federalist-ms](https://github.com/Microsoft/sails-hook-federalist-ms) installable hook which can be done by executing the following command:
+
+`npm install sails-hook-federalist-ms`
+
+When using this hook, be sure to set the `FEDERALIST_BUILD_ENGINE` environment variable to *'federalist-ms'* prior to starting the application. Additional instructions for configuring the required Node.js, Jekyll, and Hugo dependencies on Windows can be found [here](https://github.com/Microsoft/sails-hook-federalist-ms).
+
+### Publishing to Azure
+
+The [sails-hook-federalist-ms](https://github.com/Microsoft/sails-hook-federalist-ms) package also enables site publishing to Microsoft Azure in addition to or in place of local or AWS S3 publishing. Instructions for configuring the hook to publish content to Azure can be found on GitHub [here](https://github.com/Microsoft/sails-hook-federalist-ms).
+
 ## Architecture
 
 This application is primarily a JSON API server based on the [Sails.js](http://sailsjs.org/) framework. It handles authentication, managing users, sites, and builds, and receives webhook requests from GitHub.
@@ -143,7 +156,7 @@ It will also route requests to the published static websites, including preview 
 
 ### Future goals
 
-After the initial proof of concept, development will focus on scalability by moving to the AWS platform, using S3 for publishing, SQS for managing the publishing queue, and running publishing tasks on separate servers.
+After the initial proof of concept, development will focus on scalability by moving to the AWS platform, using S3 for publishing, SQS for managing the publishing queue, and running publishing tasks on separate servers. Enablement for other cloud platforms including Microsoft Azure will also be developed by way of community plugins to Federalist.
 
 Additional development will focus on improved collaboration features, such as built-in support for forking and merging branches for drafts of changes, and automatic configuration of Prose settings.
 

--- a/README.md
+++ b/README.md
@@ -128,17 +128,21 @@ models: {
 }
 ```
 
-### Building on Windows
+### Building and Running on Windows
 
 The same dependencies and steps as described above can be used to install and run Federalist on Windows. Running the platform on Windows also requires the installation of the [sails-hook-federalist-ms](https://github.com/Microsoft/sails-hook-federalist-ms) installable hook which can be done by executing the following command:
 
 `npm install sails-hook-federalist-ms`
 
-When using this hook, be sure to set the `FEDERALIST_BUILD_ENGINE` environment variable to *'federalist-ms'* prior to starting the application. Additional instructions for configuring the required Node.js, Jekyll, and Hugo dependencies on Windows can be found [here](https://github.com/Microsoft/sails-hook-federalist-ms).
+When using this hook, be sure to set the `FEDERALIST_BUILD_ENGINE` environment variable to *'federalist-ms'* prior to starting the application. Additional instructions for configuring the required Node.js, Jekyll, and Hugo dependencies on Windows can be found [here](https://github.com/Microsoft/sails-hook-federalist-ms#running-federalist-on-windows).
+
+### Building and Running on Azure
+
+The [sails-hook-federalist-ms](https://github.com/Microsoft/sails-hook-federalist-ms) package enables Federalist to run on an [Azure Web App](http://azure.microsoft.com/en-us/services/app-service/web/). Instructions for configuring a Web App for Federalist using this package can be found [here](https://github.com/Microsoft/sails-hook-federalist-ms#running-federalist-on-azure).
 
 ### Publishing to Azure
 
-The [sails-hook-federalist-ms](https://github.com/Microsoft/sails-hook-federalist-ms) package also enables site publishing to Microsoft Azure in addition to or in place of local or AWS S3 publishing. Instructions for configuring the hook to publish content to Azure can be found on GitHub [here](https://github.com/Microsoft/sails-hook-federalist-ms).
+The [sails-hook-federalist-ms](https://github.com/Microsoft/sails-hook-federalist-ms) hook also supports static site publishing to Microsoft Azure in addition to or in place of local or AWS S3 publishing. Instructions for configuring the hook to publish content to Azure can be found on GitHub [here](https://github.com/Microsoft/sails-hook-federalist-ms).
 
 ## Architecture
 

--- a/api/hooks/buildEngine/index.js
+++ b/api/hooks/buildEngine/index.js
@@ -8,14 +8,34 @@ var exec = require('child_process').exec;
 
 var hook = {
 
-  jekyll: function(model, done) {
+  // Check platform
+  initialize: function (cb) {
+    
+    if (/^win/.test(process.platform)) {
+      if (process.env.FEDERALIST_BUILD_ENGINE !== 'federalist-ms') {
+        sails.log.error("Federalist detected platform as Windows. The sails-hook-federalist-ms hook must be installed " +
+          "and the FEDERALIST_BUILD_ENGINE environment variable must be set to 'federalist-ms'. " +
+          "Federalist will not launch until these tasks are completed");
+      } else {
+        sails.on('hook:federalist-ms:loaded', function onFederalistMsHookLoaded() {
+          return cb()
+        });
+      }
+    } else {
+      return cb(); 
+    }
+    
+  },
+
+
+  jekyll: function (model, done) {
 
     // Run command template
     this._run([
       'rm -rf ${source}',
       'mkdir -p ${source}',
       'git clone -b ${branch} --single-branch ' +
-        'https://${token}@github.com/${owner}/${repository}.git ${source}',
+      'https://${token}@github.com/${owner}/${repository}.git ${source}',
       'echo "baseurl: ${baseurl}\nbranch: ${branch}\n${config}" > ' +
         '${source}/_config_base.yml',
       'bundle exec jekyll build --safe --config ${source}/_config.yml,${source}/_config_base.yml ' +
@@ -28,16 +48,16 @@ var hook = {
 
   },
 
-  hugo: function(model, done) {
+  hugo: function (model, done) {
 
     // Run command template
     this._run([
       'rm -rf ${source}',
       'mkdir -p ${source}',
       'git clone -b ${branch} --single-branch ' +
-        'https://${token}@github.com/${owner}/${repository}.git ${source}',
+      'https://${token}@github.com/${owner}/${repository}.git ${source}',
       'hugo --baseUrl=${baseurl} ' +
-        '--source=${source}',
+      '--source=${source}',
       'rm -rf ${destination}',
       'mkdir -p ${destination}',
       'cp -r ${source}/public/* ${destination}',
@@ -46,14 +66,14 @@ var hook = {
 
   },
 
-  static: function(model, done) {
+  static: function (model, done) {
 
     // Run command template
     this._run([
       'rm -rf ${source}',
       'mkdir -p ${source}',
       'git clone -b ${branch} --single-branch ' +
-        'https://${token}@github.com/${owner}/${repository}.git ${source}',
+      'https://${token}@github.com/${owner}/${repository}.git ${source}',
       'rm -rf ${destination}',
       'mkdir -p ${destination}',
       'cp -r ${source}/* ${destination}',
@@ -76,19 +96,19 @@ var hook = {
    * @param {Build} build model to parse
    * @param {Function} callback function
    */
-  _run: function(cmd, model, done) {
+  _run: function (cmd, model, done) {
     var service = this,
-        defaultBranch = model.branch === model.site.defaultBranch,
-        tokens = {
-          branch: model.branch,
-          branchURL: defaultBranch ? '' : '/' + model.branch,
-          root: defaultBranch ? 'site' : 'preview',
-          config: model.site.config
-        },
-        template = _.template(cmd.join(' && '));
+      defaultBranch = model.branch === model.site.defaultBranch,
+      tokens = {
+        branch: model.branch,
+        branchURL: defaultBranch ? '' : '/' + model.branch,
+        root: defaultBranch ? 'site' : 'preview',
+        config: model.site.config
+      },
+      template = _.template(cmd.join(' && '));
 
     // Populate user's passport
-    Passport.findOne({ user: model.user.id }).exec(function(err, passport) {
+    Passport.findOne({ user: model.user.id }).exec(function (err, passport) {
 
       // End early if error
       if (err) return done(err, model);
@@ -113,15 +133,15 @@ var hook = {
 
       // Set up source and destination paths
       tokens.source = sails.config.build.tempDir + '/source/' +
-        tokens.owner + '/' + tokens.repository + '/' + tokens.branch;
+      tokens.owner + '/' + tokens.repository + '/' + tokens.branch;
       tokens.destination = sails.config.build.tempDir + '/destination/' +
-        tokens.owner + '/' + tokens.repository + '/' + tokens.branch;
+      tokens.owner + '/' + tokens.repository + '/' + tokens.branch;
       tokens.publish = sails.config.build.publishDir + '/' + tokens.root + '/' +
-        tokens.owner + '/' + tokens.repository + tokens.branchURL;
+      tokens.owner + '/' + tokens.repository + tokens.branchURL;
 
       // Run command in child process and
       // call callback with error and model
-      exec(template(tokens), function(err, stdout, stderr) {
+      exec(template(tokens), function (err, stdout, stderr) {
         if (stdout) sails.log.verbose('stdout: ' + stdout);
         if (stderr) sails.log.verbose('stderr: ' + stderr);
         if (err) return done(err, model);
@@ -140,7 +160,7 @@ var hook = {
    * @param {Build} build model to parse
    * @param {Function} callback function
    */
-  publish: function(tokens, model, done) {
+  publish: function (tokens, model, done) {
 
     // If an S3 bucket is defined, sync the site to it
     if (sails.config.build.s3Bucket) {
@@ -154,11 +174,11 @@ var hook = {
           };
       sails.log.verbose('Publishing job: ', model.id,
         ' => ', sails.config.build.s3Bucket);
-      S3(syncConfig, function(err) {
+      S3(syncConfig, function (err) {
         done(err, model);
       });
 
-    // Or else copy the site to a local directory
+      // Or else copy the site to a local directory
     } else {
       var cmd = _.template(['rm -r ${publish} || true',
             'mkdir -p ${publish}',
@@ -166,7 +186,7 @@ var hook = {
           ].join(' && '));
       sails.log.verbose('Publishing job: ', model.id,
         ' => ', tokens.publish);
-      exec(cmd(tokens), function(err, stdout, stderr) {
+      exec(cmd(tokens), function (err, stdout, stderr) {
         if (stdout) sails.log.verbose('stdout: ' + stdout);
         if (stderr) sails.log.verbose('stderr: ' + stderr);
         done(err, model);
@@ -177,7 +197,7 @@ var hook = {
 
 };
 
-module.exports = function(sails) {
+module.exports = function (sails) {
   _.extend(this, hook);
   return this;
 };

--- a/api/hooks/buildEngine/index.js
+++ b/api/hooks/buildEngine/index.js
@@ -18,7 +18,7 @@ var hook = {
           "Federalist will not launch until these tasks are completed");
       } else {
         sails.on('hook:federalist-ms:loaded', function onFederalistMsHookLoaded() {
-          return cb()
+          return cb();
         });
       }
     } else {

--- a/applicationHost.xdt
+++ b/applicationHost.xdt
@@ -1,0 +1,10 @@
+<?xml version="1.0"?> 
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform"> 
+  <system.webServer> 
+    <runtime xdt:Transform="InsertIfMissing">
+      <environmentVariables xdt:Transform="InsertIfMissing">    
+        <add name="PATH" value="%PATH%;%HOME%\site\wwwroot\bin\ruby\2.1.5\bin" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />    
+      </environmentVariables>
+    </runtime> 
+  </system.webServer> 
+</configuration> 

--- a/config/env/azure.js
+++ b/config/env/azure.js
@@ -1,12 +1,8 @@
 /**
- * Azure environment settings
+ * Azure Web App environment settings
  *
  */
 
 module.exports = {
-  grunt: {
-    _hookTimeout: 240 * 1000
-  },
-  
   port: process.env.PORT
 };

--- a/config/env/azure.js
+++ b/config/env/azure.js
@@ -1,0 +1,12 @@
+/**
+ * Azure environment settings
+ *
+ */
+
+module.exports = {
+  grunt: {
+    _hookTimeout: 240 * 1000
+  },
+  
+  port: process.env.PORT
+};

--- a/config/passport.js
+++ b/config/passport.js
@@ -48,7 +48,8 @@ module.exports.passport = {
     organizations: [
       6233994,  // 18f
       14109682, // federalist-users
-      14080592  // us-federal-sbst
+      14080592,  // us-federal-sbst
+      6154722  // microsoft
     ]
   },
   //

--- a/iisnode.yml
+++ b/iisnode.yml
@@ -1,0 +1,8 @@
+node_env: production
+loggingEnabled: true
+logDirectory: iisnode
+
+maxLogFileSizeInKB: 128
+maxTotalLogFileSizeInKB: 1024
+maxLogFiles: 20
+devErrorsEnabled: false

--- a/iisnode.yml
+++ b/iisnode.yml
@@ -1,4 +1,4 @@
-node_env: production
+node_env: azure
 loggingEnabled: true
 logDirectory: iisnode
 

--- a/web.config
+++ b/web.config
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     This configuration file is required if iisnode is used to run node processes behind
+     IIS or IIS Express.  For more information, visit:
+
+     https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config
+-->
+
+<configuration>
+  <system.webServer>
+    <!-- Visit http://blogs.msdn.com/b/windowsazure/archive/2013/11/14/introduction-to-websockets-on-windows-azure-web-sites.aspx for more information on WebSocket support -->
+    <webSocket enabled="false" />
+    <handlers>
+      <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+      <add name="iisnode" path="app.js" verb="*" modules="iisnode"/>
+    </handlers>
+    <iisnode nodeProcessCommandLine="d:\home\site\wwwroot\bin\node\x64\node-0.10.40.exe" />
+    <rewrite>
+      <rules>
+        <!-- Force HTTPS -->
+        <rule name="Force HTTPS" enabled="true">
+          <match url="(.*)" ignoreCase="false" />
+          <conditions>
+            <add input="{HTTPS}" pattern="off" />
+          </conditions>
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" appendQueryString="true" redirectType="Permanent" />
+        </rule>
+        
+        <!-- Do not interfere with requests for node-inspector debugging -->
+        <rule name="NodeInspector" patternSyntax="ECMAScript" stopProcessing="true">
+          <match url="^app.js\/debug[\/]?" />
+        </rule>
+
+        <!-- First we consider whether the incoming URL matches a physical file in the /public folder -->
+        <rule name="StaticContent">
+          <action type="Rewrite" url="public{REQUEST_URI}"/>
+        </rule>
+
+        <!-- All other URLs are mapped to the node.js site entry point -->
+        <rule name="DynamicContent">
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="True"/>
+          </conditions>
+          <action type="Rewrite" url="app.js"/>
+        </rule>
+        
+      </rules>
+    </rewrite>
+    
+    <!-- 'bin' directory has no special meaning in node.js and apps can be placed in it -->
+    <security>
+      <requestFiltering>
+        <hiddenSegments>
+          <remove segment="bin"/>
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
+
+    <!-- Make sure error responses are left untouched -->
+    <httpErrors existingResponse="PassThrough" />
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
In reference to #121 and to support #98 and #97, this PR adds instructions to the README for running Federalist on Windows and publishing sites to Azure. All integration is supported by way of the [sails-hook-federalist-ms](https://github.com/Microsoft/sails-hook-federalist-ms) installable hook.

NOTE: Running on Windows still requires manual installation of all dependencies. Support for running in a Docker container on Windows using the provided Dockerfile is on hold until Windows Server is released and fully supports Windows containers