### PR TITLE
Add SBST and generic federalist-users organization

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -45,7 +45,11 @@ module.exports.passport = {
     },
     // IDs for approved organizations
     // Includes the 18F organization by default
-    organizations: [6233994]
+    organizations: [
+      6233994,  // 18f
+      14109682, // federalist-users
+      14080592  // us-federal-sbst
+    ]
   },
   //
   // facebook: {


### PR DESCRIPTION
Allows users in the generic [federalist-users](https://github.com/orgs/federalist-users/teams/users) and [us-federalist-sbst](https://github.com/us-federal-sbst) organizations to access Federalist.