### PR TITLE
Add homepage with sign-up for private beta

### DIFF
--- a/assets/app/templates/authenticate.html
+++ b/assets/app/templates/authenticate.html
@@ -1,7 +1,0 @@
-<div class="row">
-  <div class="jumbotron">
-    <h1>Welcome to Federalist</h1>
-    <p>Federalist is super cool and useful for publishing websites. But first, we need access to your Github account.</p>
-    <p><a class="btn btn-primary btn-lg" href="/auth/github" role="button">Authenticate with GitHub</a></p>
-  </div>
-</div>

--- a/assets/app/templates/home.html
+++ b/assets/app/templates/home.html
@@ -1,0 +1,32 @@
+<div class="row">
+  <div class="jumbotron text-center">
+    <h1>Welcome to Federalist.</h1>
+    <p>Federalist is a unified interface for publishing static government websites.</p>
+    <p>Have an account? <a class="btn btn-primary btn-lg" href="/auth/github" role="button">Log in now</a></p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-4">
+    <h2>Secure and scalable</h2>
+    <p>Federalist websites offer the highest level of security and scalability. They are generated static sites hosted on cloud infrastructure.</p>
+  </div>
+  <div class="col-md-4">
+    <h2>Easy to maintain</h2>
+    <p>Get started with a new website right away by selecting from a template and adding your content with a web-based editor.</p>
+ </div>
+  <div class="col-md-4">
+    <h2>Fully customizable</h2>
+    <p>Build completely custom templates that take advantage of Federalist's scalable static site architecture and web-based editor.</p>
+  </div>
+</div>
+
+<hr>
+
+<div class="row">
+  <div class="col-md-8 col-md-offset-2">
+    <h2>Federalist is in private alpha</h2>
+    <p>We're rapidly developing Federalist to help deliver high-quality websites for departments and agencies across the US federal government. During our <a href="https://18f.gsa.gov/dashboard/stages/" target="_blank">alpha period</a>, we are accepting a limited number of users.</p>
+    <p>Are you responsible for a federal website and interested in learn more? <a class="btn btn-default" href="https://docs.google.com/forms/d/1iB8aW7c9r1QH3s8XElQCrnXRGjAiPUYpWG1CMeEqGIo/viewform" role="button">Sign up now</a></p>
+  </div>
+</div>

--- a/assets/app/templates/home.html
+++ b/assets/app/templates/home.html
@@ -27,6 +27,6 @@
   <div class="col-md-8 col-md-offset-2">
     <h2>Federalist is in private alpha</h2>
     <p>We're rapidly developing Federalist to help deliver high-quality websites for departments and agencies across the US federal government. During our <a href="https://18f.gsa.gov/dashboard/stages/" target="_blank">alpha period</a>, we are accepting a limited number of users.</p>
-    <p>Are you responsible for a federal website and interested in learn more? <a class="btn btn-default" href="https://docs.google.com/forms/d/1iB8aW7c9r1QH3s8XElQCrnXRGjAiPUYpWG1CMeEqGIo/viewform" role="button">Sign up now</a></p>
+    <p>Are you responsible for a federal website and interested in learning more? <a class="btn btn-default" href="https://docs.google.com/forms/d/1iB8aW7c9r1QH3s8XElQCrnXRGjAiPUYpWG1CMeEqGIo/viewform" role="button">Sign up now</a></p>
   </div>
 </div>

--- a/assets/app/templates/nav.html
+++ b/assets/app/templates/nav.html
@@ -1,8 +1,8 @@
 <ul class="nav navbar-nav navbar-right" id="nav-mobile">
 <% if(username) {%>
-  <li><a>hey <%- username %>!</a></li>
-  <li><a id="logout">logout</a></li>
+  <li><p class="navbar-text">Welcome <%- username %>!</p></li>
+  <li><a href="#" id="logout">Done? Log out</a></li>
 <% } else { %>
-  <li><a href="/auth/github">login</a></li>
+  <li><a href="/auth/github">Have an account? Log in now</a></li>
 <% } %>
 </ul>

--- a/assets/app/views/authenticate.js
+++ b/assets/app/views/authenticate.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var Backbone = require('backbone');
 var _ = require('underscore');
 
-var templateHtml = fs.readFileSync(__dirname + '/../templates/authenticate.html').toString();
+var templateHtml = fs.readFileSync(__dirname + '/../templates/home.html').toString();
 
 var AuthenticateView = Backbone.View.extend({
   tagName: 'div',


### PR DESCRIPTION
In advance of next week's blog post, this adds a simple home page with some general audience content about Federalist as well as a link to a Google form to sign up as a beta user.

![screen shot 2015-09-09 at 1 35 46 pm](https://cloud.githubusercontent.com/assets/170641/9769366/b42b2f20-56f7-11e5-83df-8a6753e61fe9.png)

![screen shot 2015-09-09 at 1 33 46 pm](https://cloud.githubusercontent.com/assets/170641/9769338/909051a8-56f7-11e5-9c2b-f433a0d00f37.png)
