### PR TITLE
Pin node to known working version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: true
 node_js:
-- stable
+- "0.10"
 env:
   global:
   - CF_APP=federalist

--- a/package.json
+++ b/package.json
@@ -80,5 +80,9 @@
     "nodemon": "^1.3.7",
     "sinon": "^1.14.1",
     "watchify": "^3.2.2"
+  },
+  "engines": {
+   "node" : "0.10.x",
+   "npm": "2.1.x"
   }
 }


### PR DESCRIPTION
This pins node to the version I'm using locally. We could update it to 0.12, but let's get this working first and revisit when we have a need for it.