### PR TITLE
Add support for error messages

### DIFF
--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -42,10 +42,6 @@ var AppView = Backbone.View.extend({
       $('.alert-container').html(
         '<div class="alert alert-danger" role="alert">' + message + '</div>'
       );
-      console.log(1, window.location.pathname + window.location.hash);
-      federalist.navigate(window.location.pathname + window.location.hash, {
-        trigger: true
-      });
     }
 
     var authenticateView = new AuthenticateView();

--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -1,5 +1,6 @@
 var Backbone = require('backbone');
 var ViewSwitcher = require('ampersand-view-switcher');
+var querystring = require('querystring');
 
 var AuthenticateView = require('./authenticate');
 var SiteEditView = require('./site/edit');
@@ -21,12 +22,30 @@ var AppView = Backbone.View.extend({
   },
   home: function () {
     federalist.navigate('');
-    var authed = this.user.isAuthenticated();
+    var authed = this.user.isAuthenticated(),
+        error = querystring.parse(window.location.search.slice(1)).error,
+        messages = {
+          'Error.Passport.Unauthorized': 'Your account is not set up to access Federalist. Have you signed up as a beta user? If have signed up and should have access, please let us know.',
+          'default': 'An unexpected error occured. Please try again. If you continue to see this message, please let us know.'
+        },
+        message = error && (messages[error] || messages['default']);
+
     if(authed) {
       var listView = new SiteListView({ collection: this.sites });
       this.pageSwitcher.set(listView);
 
       return this;
+    }
+
+    // Show alert message
+    if (message) {
+      $('.alert-container').html(
+        '<div class="alert alert-danger" role="alert">' + message + '</div>'
+      );
+      console.log(1, window.location.pathname + window.location.hash);
+      federalist.navigate(window.location.pathname + window.location.hash, {
+        trigger: true
+      });
     }
 
     var authenticateView = new AuthenticateView();

--- a/assets/index.html
+++ b/assets/index.html
@@ -23,6 +23,7 @@
         </div>
       </div>
     </nav>
+    <div class="alert-container container"></div>
     <main class="container"></main>
     <footer class="page-footer orange"></footer>
     <script src="/js/bundle.js"></script>


### PR DESCRIPTION
Sets a simple alert system and shows message for unauthorized GitHub users. 

Error keys are passed as an `error` query parameter. The main view checks for an error key, matches it to the `messages` object to get a human-readable error message, and shows the error message. If an unknown error key is passed, it will display a default error message.

Could be updated after #139 to include includes for feedback.

Closes #67 
