### PR TITLE
Add a 'need help?' link to header

### DIFF
--- a/assets/app/templates/nav.html
+++ b/assets/app/templates/nav.html
@@ -1,6 +1,7 @@
 <ul class="nav navbar-nav navbar-right" id="nav-mobile">
 <% if(username) {%>
   <li><p class="navbar-text">Welcome <%- username %>!</p></li>
+  <li><a href="https://github.com/18F/federalist/issues/new" target="_blank">Need help? Report an issue</a></li>
   <li><a href="#" id="logout">Done? Log out</a></li>
 <% } else { %>
   <li><a href="/auth/github">Have an account? Log in now</a></li>


### PR DESCRIPTION
The navigation bar now shows a 'need help?' link to authenticated users. 

![screen shot 2015-09-09 at 5 41 48 pm](https://cloud.githubusercontent.com/assets/170641/9775050/4baed9f6-571a-11e5-84bd-857af1e4686e.png)


Closed #139 

