### PR TITLE
Automatically update the UI when new builds take place

### DIFF
--- a/api/models/Build.js
+++ b/api/models/Build.js
@@ -34,8 +34,13 @@ module.exports = {
   },
 
   afterCreate: function(model, done) {
+    Build.publishCreate(model);
     this.addJob(model);
     if (done) return done();
+  },
+
+  afterUpdate: function(model) {
+    Build.publishUpdate(model.id, model);
   },
 
   /**

--- a/assets/app/templates/site/add.html
+++ b/assets/app/templates/site/add.html
@@ -20,7 +20,7 @@
           <h3 class="panel-title"><%= template.title %></h3>
         </div>
         <div class="panel-body">
-          <a href="#" class="thumbnail">
+          <a href="#" data-action="fork-template" class="thumbnail">
             <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMTcxIiBoZWlnaHQ9IjE4MCIgdmlld0JveD0iMCAwIDE3MSAxODAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzEwMCV4MTgwCkNyZWF0ZWQgd2l0aCBIb2xkZXIuanMgMi42LjAuCkxlYXJuIG1vcmUgYXQgaHR0cDovL2hvbGRlcmpzLmNvbQooYykgMjAxMi0yMDE1IEl2YW4gTWFsb3BpbnNreSAtIGh0dHA6Ly9pbXNreS5jbwotLT48ZGVmcz48c3R5bGUgdHlwZT0idGV4dC9jc3MiPjwhW0NEQVRBWyNob2xkZXJfMTRmNjFkZjM2YzIgdGV4dCB7IGZpbGw6I0FBQUFBQTtmb250LXdlaWdodDpib2xkO2ZvbnQtZmFtaWx5OkFyaWFsLCBIZWx2ZXRpY2EsIE9wZW4gU2Fucywgc2Fucy1zZXJpZiwgbW9ub3NwYWNlO2ZvbnQtc2l6ZToxMHB0IH0gXV0+PC9zdHlsZT48L2RlZnM+PGcgaWQ9ImhvbGRlcl8xNGY2MWRmMzZjMiI+PHJlY3Qgd2lkdGg9IjE3MSIgaGVpZ2h0PSIxODAiIGZpbGw9IiNFRUVFRUUiLz48Zz48dGV4dCB4PSI1OS41NDY4NzUiIHk9Ijk0LjUiPjE3MXgxODA8L3RleHQ+PC9nPjwvZz48L3N2Zz4=" alt="Thumbnail screenshot for the <%= template.title %> template">
           </a>
           <p><%= template.description %></p>

--- a/assets/app/templates/site/list-item.html
+++ b/assets/app/templates/site/list-item.html
@@ -1,16 +1,19 @@
-<div class="panel panel-default">
-  <div class="panel-heading"><%- repository %></div>
+<div class="panel panel-default %>">
+  <div class="panel-heading">
+    <%- repository %>
+    <%= statusLabel %>
+  </div>
   <div class="panel-body">
     <% if (!builds.length || !lastBuildTime) { %>
-    <p>This site has not been built yet. Please refresh the page to see new builds.</p>
+    <p>This site has not been published yet. Please wait while the site is built.</p>
     <% } else { %>
     <div class="row">
       <div class="col-md-6">
-        <p>The production version of this site was last built at <%- lastBuildTime %></p>
+        <p>This site was last published at <%- lastBuildTime %></p>
       </div>
       <div class="col-md-6">
         <div class="pull-right">
-          <a href="#site/<%- id %>/builds" class="btn btn-default btn-xs" data-action="site-builds" alt="show log of builds for <%- repository %>">Builds</a>
+          <a href="#site/<%- id %>/builds" class="btn btn-default btn-xs" data-action="site-builds" alt="show log of builds for <%- repository %>">Log</a>
           <a href="#site/<%- id %>/edit" class="btn btn-default btn-xs" data-action="edit-site-settings" alt="change settings for <%- repository %>">Settings</a>
           <a href="/#edit/<%- owner %>/<%- repository %>/<%- defaultBranch %>" class="btn btn-default btn-xs" data-action="edit-site-content" alt="edit the site <%- repository %>">Edit</a>
           <% if (builds.length) { %>

--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -14,6 +14,12 @@ var AppView = Backbone.View.extend({
     this.user = opts.user;
     this.sites = opts.collection;
 
+    // Initiate websocket subscription and fetch sites on build message
+    io.socket.get('/v0/build?limit=0');
+    io.socket.on('build', function() {
+      this.sites.fetch();
+    }.bind(this));
+
     this.render();
   },
   render: function () {

--- a/assets/app/views/site/list-item.js
+++ b/assets/app/views/site/list-item.js
@@ -25,6 +25,11 @@ var SiteListItemView = Backbone.View.extend({
       .format('L LT') : '';
     data.viewLink = data.domain ||
       data.siteRoot + '/site/' + data.owner + '/' + data.repository + '/';
+    data.statusLabel = !lastBuild ? '<span class="label label-warning">Publishing...</span>' :
+      lastBuild.state === 'error' ? '<span class="label label-danger">Error: see log for more information</span>' :
+      lastBuild.state === 'success' ? '<span class="label label-success">Published</span>' :
+      lastBuild.state === 'skipped' ? '<span class="label label-success">Published</span>' :
+      '<span class="label label-warning">Publishing...</span>';
     this.$el.html(this.template(data));
   }
 });

--- a/assets/app/views/site/list.js
+++ b/assets/app/views/site/list.js
@@ -11,6 +11,7 @@ var SiteListView = Backbone.View.extend({
   className: 'list',
   template: _.template(templateHtml),
   initialize: function initializeSiteListView(opts) {
+    this.listenTo(this.collection, 'change', this.render);
     this.listenTo(this.collection, 'update', this.render);
     return this;
   },

--- a/assets/index.html
+++ b/assets/index.html
@@ -25,6 +25,14 @@
     </nav>
     <main class="container"></main>
     <footer class="page-footer orange"></footer>
+    <script src="/js/dependencies/sails.io.js"></script>
+    <script>
+      io.sails.transports = ['websocket', 'polling'];
+      // CloudFoundry only accepts websockets over port 4443
+      if (/\.18f\.gov$/.test(location.hostname)) {
+        io.sails.url = location.protocol + '//' + location.hostname + ':4443';
+      }
+    </script>
     <script src="/js/bundle.js"></script>
   </body>
 </html>

--- a/assets/index.html
+++ b/assets/index.html
@@ -27,7 +27,8 @@
     <footer class="page-footer orange"></footer>
     <script src="/js/dependencies/sails.io.js"></script>
     <script>
-      io.sails.transports = ['websocket', 'polling'];
+      io.sails.transports = ['websocket'];
+      io.sails.useCORSRouteToGetCookie = false;
       // CloudFoundry only accepts websockets over port 4443
       if (/\.18f\.gov$/.test(location.hostname)) {
         io.sails.url = location.protocol + '//' + location.hostname + ':4443';

--- a/scripts/deploy-test.sh
+++ b/scripts/deploy-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Blue-green deployment script. Usage:
+#
+#   ./cf-blue-green <appname>
+#
+# !!! Only deploys new app — doesn't add it 
+# to load balancer or remove old app.
+
+set -e
+set -o pipefail
+set -x
+
+
+if [ $# -ne 1 ]; then
+	echo "Usage:\n\n\t./cf-blue-green <appname>\n"
+	exit 1
+fi
+
+
+BLUE=$1
+GREEN="${BLUE}-B"
+
+
+finally ()
+{
+  # we don't want to keep the sensitive information around
+  rm $MANIFEST
+}
+
+on_fail () {
+  finally
+  echo "DEPLOY FAILED - you may need to check 'cf apps' and 'cf routes' and do manual cleanup"
+}
+
+
+CF_VERSION=$(cf --version)
+# http://stackoverflow.com/a/229606/358804
+if [[ "$CF_VERSION" != *"6.12.0-"* ]] && [[ "$CF_VERSION" != *"6.12.1-"* ]]; then
+  echo "CF CLI version is not compatible. See\n\n\thttps://github.com/18F/cf-blue-green#cf-cli\n"
+  exit 1
+fi
+
+# pull the up-to-date manifest from the BLUE (existing) application
+MANIFEST=$(mktemp -t "${BLUE}_manifest.XXXXXXXXXX")
+cf create-app-manifest $BLUE -p $MANIFEST
+
+# set up try/catch
+# http://stackoverflow.com/a/185900/358804
+trap on_fail ERR
+
+DOMAIN=$(cat $MANIFEST | grep domain: | awk '{print $2}')
+
+# create the GREEN application
+cf push $GREEN -f $MANIFEST -n $GREEN
+# ensure it starts
+curl --fail -I "https://${GREEN}.${DOMAIN}"
+
+finally
+
+echo "DONE"


### PR DESCRIPTION
This smoothes out the user experience by updating the site listing when a new build takes place.

![add-site](https://cloud.githubusercontent.com/assets/170641/9790223/bf861ac8-57a2-11e5-9efa-e839c1209fdc.gif)

It uses websockets to listen for recent build events from the API and re-renders the API when they fire.

Also, this includes status labels on the site to let users know of the last build's status, and it replaces public-facing mentions of "build" with "publish" as it is a less wonky term.

<img width="1144" alt="screen shot 2015-09-10 at 9 57 01 am" src="https://cloud.githubusercontent.com/assets/170641/9790259/0984e8de-57a3-11e5-959e-5442d8e462f1.png">

Staged here to validate it on CloudFoundry, though this shares the same database as production, so don't edit any sites you're concerned about: https://federalist-b.18f.gov/
