### PR TITLE
Fix S3 sync bug

### DIFF
--- a/api/services/S3.js
+++ b/api/services/S3.js
@@ -25,7 +25,7 @@ AWS.util.update(AWS.S3.prototype, {
 
 module.exports = function(config, done) {
 
-  config.compress = 'html|css|js|json';
+  config.compress = 'html|css|js|json|svg';
 
   // Loop through all files and selectively encode them
   walk(config.directory, function(err, results) {


### PR DESCRIPTION
Bug reported in #151 seems to be related to files over 1mb failing to upload with the aws-sdk. This implements a workaround. 

It also raises the maxSockets as recommended by `node-s3`, and it removes the callback in the `error` event handler, in case an error is not actually the end and the library wants to retry the upload.

Finally, this also adds SVGs to the list of files to gzip.