### PR TITLE
Fix missing path error in session policy

### DIFF
--- a/api/policies/sessionAuth.js
+++ b/api/policies/sessionAuth.js
@@ -15,7 +15,7 @@ module.exports = function(req, res, next) {
     return next();
   }
 
-  if (req.path.indexOf('/preview/') === 0) {
+  if (req.path && req.path.indexOf('/preview/') === 0) {
     return res.redirect('/');
   }
 


### PR DESCRIPTION
Fixes an error found in the logs:

```
2015-09-11T22:55:35.73-0400 [App/0]      ERR Sending 500 ("Server Error") response: 
2015-09-11T22:55:35.73-0400 [App/0]      ERR  TypeError: Cannot read property 'indexOf' of undefined
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at module.exports (/home/vcap/app/api/policies/sessionAuth.js:18:15)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at routeTargetFnWrapper (/home/vcap/app/node_modules/sails/lib/router/bind.js:179:5)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at callbacks (/home/vcap/app/node_modules/sails/node_modules/express/lib/router/index.js:164:37)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at param (/home/vcap/app/node_modules/sails/node_modules/express/lib/router/index.js:138:11)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at pass (/home/vcap/app/node_modules/sails/node_modules/express/lib/router/index.js:145:5)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at nextRoute (/home/vcap/app/node_modules/sails/node_modules/express/lib/router/index.js:100:7)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at callbacks (/home/vcap/app/node_modules/sails/node_modules/express/lib/router/index.js:167:11)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at /home/vcap/app/node_modules/sails/lib/router/bind.js:187:7
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at /home/vcap/app/api/policies/passport.js:32:7
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at SessionStrategy.strategy.pass (/home/vcap/app/node_modules/passport/lib/middleware/authenticate.js:318:9)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at SessionStrategy.authenticate (/home/vcap/app/node_modules/passport/lib/strategies/session.js:67:10)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at attempt (/home/vcap/app/node_modules/passport/lib/middleware/authenticate.js:341:16)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at authenticate (/home/vcap/app/node_modules/passport/lib/middleware/authenticate.js:342:7)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at /home/vcap/app/api/policies/passport.js:28:23
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at initialize (/home/vcap/app/node_modules/passport/lib/middleware/initialize.js:62:5)
2015-09-11T22:55:35.73-0400 [App/0]      ERR     at module.exports (/home/vcap/app/api/policies/passport.js:26:24) [TypeError: Cannot read property 'indexOf' of undefined]
```