### PR TITLE
Automatically set redirect objects based on custom domain

### DIFF
--- a/api/hooks/buildEngine/index.js
+++ b/api/hooks/buildEngine/index.js
@@ -149,7 +149,8 @@ var hook = {
               tokens.owner + '/' +
               tokens.repository +
               tokens.branchURL,
-            directory: tokens.destination
+            directory: tokens.destination,
+            baseurl: tokens.baseurl === "''" ? '' : tokens.baseurl
           };
       sails.log.verbose('Publishing job: ', model.id,
         ' => ', sails.config.build.s3Bucket);


### PR DESCRIPTION
Discussed in and fixes #160 

Automatically sets empty objects with redirect headers for directories. The redirects default to `/site/:user/:repo/[:branch]/path => /site/:user/:repo/[:branch]/path/` and switch to `/site/:user/:repo/[:branch]/path => /path/` for sites with custom domains. This second part is what S3 was not doing on its own, so setting these redirects ourselves gets around S3's default behavior and avoids the need for global redirect rules.