### PR TITLE
Use redis service in production for sessions and sockets

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -2,7 +2,8 @@ var AWS = require('aws-sdk'),
     cfenv = require('cfenv'),
     appEnv = cfenv.getAppEnv(),
     dbURL = appEnv.getServiceURL('federalist-database'),
-    s3Creds = appEnv.getServiceCreds('s3-sb-federalist.18f.gov');
+    s3Creds = appEnv.getServiceCreds('s3-sb-federalist.18f.gov'),
+    redisCreds = appEnv.getServiceCreds('federalist-redis');
 
 /**
  * Production environment settings
@@ -41,4 +42,22 @@ if (s3Creds) {
     accessKeyId: s3Creds.access_key,
     secretAccessKey: s3Creds.secret_key
   });
+}
+
+// If running in Cloud Foundry with a redis service
+if (redisCreds) {
+  module.exports.session = {
+    adapter: 'redis',
+    host: redisCreds.hostname,
+    port: redisCreds.port,
+    db: 0,
+    pass: redisCreds.password
+  };
+  module.exports.sockets = {
+    adapter: 'socket.io-redis',
+    host: redisCreds.hostname,
+    port: redisCreds.port,
+    db: 1,
+    pass: redisCreds.password
+  };
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,4 @@ domain: 18f.gov
 services:
 - federalist-database
 - s3-sb-federalist.18f.gov
+- federalist-redis

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "browserify": "^10.2.4",
     "cfenv": "^1.0.0",
     "codemirror": "^5.6.0",
+    "connect-redis": "1.4.5",
     "db-migrate": "^0.9.17",
     "ejs": "~0.8.4",
     "express-force-ssl": "^0.2.12",
@@ -54,6 +55,7 @@
     "sails-db-migrate": "^0.7.0",
     "sails-disk": "~0.10.0",
     "sails-postgresql": "^0.10.15",
+    "socket.io-redis": "^0.1.4",
     "to-markdown": "^1.2.1",
     "underscore": "^1.8.3",
     "validator": "^3.39.0"


### PR DESCRIPTION
This uses a redis service as a shared store for sessions and socket.io identifiers. It allows for sessions to stay active across multiple instances, giving us the ability to scale the API by adding more instances, and avoiding logging out users when a server instance is restarted.

Closes #123 

## Steps to test locally:

1. install redis `$ brew install redis`
2. start redis: `$ redis-server`
3. add the following to `/config/local.js`

    ```js
    module.exports.session = {
      adapter: 'redis',
      db: 0
    };
    module.exports.sockets = {
      adapter: 'socket.io-redis',
      db: 1
    };
    ```
4. start up the server as usual (`npm start`)

You should be able to log in, restart the server, and still be logged in.

@jeremiak this is ready for your review.

After we merge, and the blue-green deploy finishes successfully, we should check to make sure we don't need to manually deploy to update the manifest.