### PR TITLE
Update prosemirror ref to 18f repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "passport-github": "^0.1.5",
     "passport-local": "^1.0.0",
     "pg": "^4.4.0",
-    "prosemirror": "git+https://github.com/ProseMirror/prosemirror.git",
+    "prosemirror": "git+https://github.com/18f/prosemirror.git",
     "rc": "~0.5.0",
     "request": "^2.61.0",
     "s3": "^4.4.0",


### PR DESCRIPTION
Our ProseMirror dependency (the nice text editor in Federalist) is pointed to its Github repository because the author has not yet published a version to NPM. The repository is also not using release tags, so we were pointing our `prosemirror` dependency straight to `master` of `ProseMirror/prosemirror` which was subject to have breaking changes without much notice. Our tests wouldn't capture this, and we could push broken code to production.

In order to have better control about the rate of change on that library, I forked it to the 18F organization. I also updated `package.json` to use this new repository.

@dhcole - ready whenever.