### PR TITLE
Fix page listing for S3 configured Federalist

### DIFF
--- a/assets/app/models/Github.js
+++ b/assets/app/models/Github.js
@@ -13,6 +13,7 @@ var GithubModel = Backbone.Model.extend({
     this.branch = opts.branch;
     this.token = opts.token;
     this.file = opts.file;
+    this.site = opts.site;
 
     this.once('model:getConfig:success', function () {
       self.fetch();
@@ -91,7 +92,13 @@ var GithubModel = Backbone.Model.extend({
         files = ['_navigation.json'];
 
     var getFiles = files.map(function(file) {
-      var url = ['', 'site', self.owner, self.name, file].join('/');
+      var url = [
+            self.site.get('siteRoot'),
+            'site',
+            self.owner,
+            self.name,
+            file
+          ].join('/');
 
       return function(callback) {
         $.ajax({

--- a/assets/app/views/editor/edit-main.js
+++ b/assets/app/views/editor/edit-main.js
@@ -26,7 +26,8 @@ var EditView = Backbone.View.extend({
       owner: opts.owner,
       repoName: opts.repo,
       branch: opts.branch,
-      file: opts.file
+      file: opts.file,
+      site: opts.site
     });
 
     this.breadcrumb = new BreadcrumbView({

--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -75,7 +75,8 @@ var AppView = Backbone.View.extend({
       owner: owner,
       repo: repo,
       branch: branch,
-      file: file
+      file: file,
+      site: this.sites.findWhere({ owner: owner, repository: repo })
     });
     this.pageSwitcher.set(editView);
 


### PR DESCRIPTION
When Federalist uses S3 to host a site, the site is not available at `/site/...`, so we need to add the `siteRoot` to the URL for `_navigation.json`. This should address that.