### PR TITLE
Always use HTTPS for S3 urls

### DIFF
--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -48,7 +48,7 @@ module.exports = {
       var obj = this.toObject(),
           config = sails.config.build || {};
       // Add siteRoot to the API response for previews
-      obj.siteRoot = config.s3Bucket ? 'http://' + config.s3Bucket +
+      obj.siteRoot = config.s3Bucket ? 'https://' + config.s3Bucket +
         '.s3-website-us-east-1.amazonaws.com': '';
       return obj;
     }


### PR DESCRIPTION
We were instructing the application to try and access the `_navigation.json` over `http` instead of `https`. This resulted in a mixed content warning and the JavaScript would throw an error. The user facing result was a blank view instead of a page listing.

Now all S3 URLs in the `/site` API response will be using `https`.

@dhcole - to you for review