### PR TITLE
Remove trailing slash

### DIFF
--- a/assets/app/models/Github.js
+++ b/assets/app/models/Github.js
@@ -92,7 +92,7 @@ var GithubModel = Backbone.Model.extend({
         files = ['_navigation.json'];
 
     var getFiles = files.map(function(file) {
-      var bucketPath = /^http\:\/\/(.*)\.s3\-website\-(.*)\.amazonaws\.com\//,
+      var bucketPath = /^http\:\/\/(.*)\.s3\-website\-(.*)\.amazonaws\.com/,
           siteRoot = self.site.get('siteRoot'),
           match = siteRoot.match(bucketPath),
           bucket = match && match[1],


### PR DESCRIPTION
Fix the regex pattern for matching S3 buckets. I mistakenly added a trailing slash to the pattern.