### PR TITLE
Pin buildpack versions

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/cloudfoundry/nodejs-buildpack
-https://github.com/cloudfoundry/ruby-buildpack
+https://github.com/cloudfoundry/nodejs-buildpack#v1.5.0
+https://github.com/cloudfoundry/ruby-buildpack#v1.6.8


### PR DESCRIPTION
I noticed that the CF team pushed a new release of the node buildpack a few days ago, and it doesn't seem to compile on our setup. This patch pins the node buildpack to the last working version, and the ruby buildpack to the current version, since I'm not aware of any problems with it. In general, it's probably a good idea to pin versions of all custom buildpacks (and any dependencies installed straight from github).