### PR TITLE
Allow site-level config for preview visibility

### DIFF
--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -44,6 +44,10 @@ module.exports = {
     config: {
       type: 'string'
     },
+    publicPreview: {
+      type: 'boolean',
+      defaultsTo: false
+    },
     toJSON: function() {
       var obj = this.toObject(),
           config = sails.config.build || {};

--- a/api/policies/previewProxy.js
+++ b/api/policies/previewProxy.js
@@ -8,7 +8,8 @@ module.exports = function(req, res, next) {
     repository: req.param('repo')
   }).populate('users').exec(function(err, site) {
     if (err || !site) return res.badRequest();
-    var userHasAccess = _(site.users).pluck('id').contains(req.user.id);
+    var userHasAccess = site.publicPreview ||
+          _(site.users).pluck('id').contains(req.user.id);
     if (!userHasAccess) return res.badRequest();
     next();
   });

--- a/api/policies/previewProxy.js
+++ b/api/policies/previewProxy.js
@@ -8,8 +8,7 @@ module.exports = function(req, res, next) {
     repository: req.param('repo')
   }).populate('users').exec(function(err, site) {
     if (err || !site) return res.badRequest();
-    var userHasAccess = site.publicPreview ||
-          _(site.users).pluck('id').contains(req.user.id);
+    var userHasAccess = _(site.users).pluck('id').contains(req.user.id);
     if (!userHasAccess) return res.badRequest();
     next();
   });

--- a/api/policies/sessionAuth.js
+++ b/api/policies/sessionAuth.js
@@ -16,10 +16,25 @@ module.exports = function(req, res, next) {
   }
 
   if (req.path && req.path.indexOf('/preview/') === 0) {
-    return res.redirect('/?error=preview.login');
-  }
 
-  // User is not allowed
-  // (default res.forbidden() behavior can be overridden in `config/403.js`)
-  return res.forbidden('You are not permitted to perform this action. Are you sure you are logged in?');
+    if (!req.param('owner') || !req.param('repo') || !req.param('branch')) {
+      return res.redirect('/?error=preview.login');
+    }
+
+    Site.findOne({
+      owner: req.param('owner'),
+      repository: req.param('repo')
+    }).exec(function(err, site) {
+      if (err || !site) return res.badRequest();
+      if (!site.publicPreview) return res.redirect('/?error=preview.login');
+      next();
+    });
+
+  } else {
+
+    // User is not allowed
+    // (default res.forbidden() behavior can be overridden in `config/403.js`)
+    return res.forbidden('You are not permitted to perform this action. Are you sure you are logged in?');
+
+  }
 };

--- a/assets/app/templates/site/edit.html
+++ b/assets/app/templates/site/edit.html
@@ -14,6 +14,21 @@
     </div>
   </div>
   <div class="row">
+    <div class="col-md-12">
+      <div class="form-group">
+        <label>Draft previews</label>
+        <div class="radio">
+          <input type="radio" name="publicPreview" id="public" value="true" <% model.publicPreview && print('checked="true"') %>>
+          <label for="public">Allow anyone to see previews of draft sites</label>
+        </div>
+        <div class="radio">
+          <input type="radio" name="publicPreview" id="private" value="" <% model.publicPreview || print('checked="true"') %>>
+          <label for="private">Only users with Federalist accounts can see previews</label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-md-8">
       <div class="form-group">
         <label class="active" for="domain">Custom domain</label>

--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -86,7 +86,7 @@ var AppView = Backbone.View.extend({
     var siteEditView = new SiteEditView({ model: this.sites.get(id) });
     this.pageSwitcher.set(siteEditView);
     this.listenToOnce(siteEditView, 'site:save:success', function () {
-      this.home();
+      federalist.navigate('', { trigger: true });
     }.bind(this));
     return this;
   },

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -71,3 +71,10 @@ body {
 .list-group-item ul {
   padding-left:0;
 }
+
+.checkbox input[type=checkbox],
+.checkbox-inline input[type=checkbox],
+.radio input[type=radio],
+.radio-inline input[type=radio] {
+  margin-left: 0;
+}

--- a/migrations/20151119145913-add-site-publicPreview.js
+++ b/migrations/20151119145913-add-site-publicPreview.js
@@ -1,0 +1,17 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  var cmd = 'ALTER TABLE site ADD COLUMN "publicPreview" BOOLEAN DEFAULT FALSE';
+  db.runSql(cmd, function(err) {
+    if (err) throw err;
+    callback();
+  });
+};
+
+exports.down = function(db, callback) {
+  db.runSql('ALTER TABLE site DROP COLUMN "publicPreview"', function(err) {
+    if (err) throw err;
+    callback();
+  });
+};


### PR DESCRIPTION
This adds a user option to the site settings for specifying the visibility of draft site previews.

By default, previews continue to require authentication. If a user chooses, the preview may be visible to the public instead.

The setting is on the site settings page:

<img width="349" alt="screen shot 2015-11-19 at 9 43 51 am" src="https://cloud.githubusercontent.com/assets/170641/11274390/90fe56b2-8ea6-11e5-929a-4ea922f793b0.png">

Resolves #210