### PR TITLE
Update .buildpacks

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/cloudfoundry/nodejs-buildpack#v1.5.0
+https://github.com/cloudfoundry/nodejs-buildpack#v1.5.4
 https://github.com/cloudfoundry/ruby-buildpack#v1.6.8


### PR DESCRIPTION
Getting an error on a missing version of node. Let's see if this solves the issue.

```
-----> Installing binaries
       engines.node (package.json):  0.10.x
       engines.npm (package.json):   2.1.x
       Resolving node version 0.10.x via semver.io...
       Downloading and installing node 0.10.41...
curl: no URL specified!
```