### PR TITLE
Move node-sass to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mime": "^1.3.4",
     "moment": "^2.10.3",
     "newrelic": "^1.22.0",
+    "node-sass": "^3.4.2",
     "passport": "^0.2.1",
     "passport-github": "^0.1.5",
     "passport-local": "^1.0.0",
@@ -102,7 +103,6 @@
   "devDependencies": {
     "jsdom": "^3.1.2",
     "mocha": "^2.2.5",
-    "node-sass": "^3.4.2",
     "nodemon": "^1.3.7",
     "sinon": "^1.14.1",
     "watchify": "^3.2.2"


### PR DESCRIPTION
Our production servers don't install devDependencies, so we're getting an error that node-sass is not available.