### PR TITLE
Remove version check

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,13 +31,6 @@ on_fail () {
 }
 
 
-CF_VERSION=$(cf --version)
-# http://stackoverflow.com/a/229606/358804
-if [[ "$CF_VERSION" != *"6.12.0-"* ]] && [[ "$CF_VERSION" != *"6.12.1-"* ]]; then
-  echo "CF CLI version is not compatible. See\n\n\thttps://github.com/18F/cf-blue-green#cf-cli\n"
-  exit 1
-fi
-
 # pull the up-to-date manifest from the BLUE (existing) application
 MANIFEST=$(mktemp -t "${BLUE}_manifest.XXXXXXXXXX")
 cf create-app-manifest $BLUE -p $MANIFEST


### PR DESCRIPTION
Fixes broken deployments by removing a now-obsolete `cf-cli` version check.