### PR TITLE
Fix table cell wrapping

### DIFF
--- a/assets/app/templates/site/builds.html
+++ b/assets/app/templates/site/builds.html
@@ -1,6 +1,6 @@
 <div class="usa-grid">
   <h1>Recent builds for <%- site.owner %> / <%- site.repository %></h1>
-  <table class="usa-table-borderless">
+  <table class="usa-table-borderless build-log-table">
     <thead>
       <tr>
         <th scope="col">Branch</th>

--- a/assets/styles/styles.scss
+++ b/assets/styles/styles.scss
@@ -148,3 +148,7 @@ footer {
   bottom: 0;
   z-index: 10;
 }
+
+.build-log-table td:last-child {
+    word-break: break-word;
+}

--- a/assets/styles/styles.scss
+++ b/assets/styles/styles.scss
@@ -150,5 +150,5 @@ footer {
 }
 
 .build-log-table td:last-child {
-    word-break: break-word;
+  word-break: break-word;
 }


### PR DESCRIPTION
Long build messages break the table layout. This fixes it.

<img width="784" alt="screen shot 2015-12-30 at 3 10 04 pm" src="https://cloud.githubusercontent.com/assets/170641/12056700/71135e52-af07-11e5-99b5-d751ca66ff5f.png">
