### PR TITLE
Clone new sites instead of forking them

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -7,6 +7,32 @@
 
 module.exports = {
 
+  clone: function cloneSite(req, res) {
+    var data = {
+      owner: req.body.destinationOrg || req.user.username,
+      repository: req.body.destinationRepo,
+      defaultBranch: req.body.destinationBranch,
+      engine: req.body.engine,
+      user: req.user
+    };
+    Site.create(data).populate('users').exec(function(err, site) {
+      if (err) return res.serverError(err);
+      var build = {
+        user: site.users[0].id,
+        site: model.id,
+        branch: model.defaultBranch,
+        source: {
+          repository: req.body.sourceRepo,
+          owner: req.body.sourceOwner
+        }
+      };
+      Build.create(build, function(err) {
+        if (err) return res.serverError(err);
+        res.send(site);
+      });
+    });
+  },
+
   fork: function forkSiteFromTemplate(req, res) {
     if (!req.param('templateId')) return res.notFound();
 

--- a/api/hooks/buildEngine/index.js
+++ b/api/hooks/buildEngine/index.js
@@ -9,14 +9,20 @@ var exec = require('child_process').exec;
 var hook = {
 
   jekyll: function(model, done) {
+    var clone = (model.source) ?
+      'git clone -b ${branch} --single-branch ' +
+        'https://${token}@github.com/${source_owner}/${source_repo}.git ${source} && ' +
+        'git remote add destination https://${token}@github.com/${owner}/${repository}.git && ' +
+        'git push destination ${branch}' :
+      'git clone -b ${branch} --single-branch ' +
+        'https://${token}@github.com/${owner}/${repository}.git ${source}';
 
     // Run command template
     this._run([
       'rm -rf ${source} || true',
       'rm -rf ${destination} || true',
       'mkdir -p ${source}',
-      'git clone -b ${branch} --single-branch ' +
-        'https://${token}@github.com/${owner}/${repository}.git ${source}',
+      clone,
       'echo "baseurl: ${baseurl}\nbranch: ${branch}\n${config}" > ' +
         '${source}/_config_base.yml',
       'bundle exec jekyll build --safe --config ${source}/_config.yml,${source}/_config_base.yml ' +
@@ -100,6 +106,9 @@ var hook = {
       tokens.baseurl = (model.site.domain && defaultBranch) ? "''" :
         '/' + tokens.root + '/' + tokens.owner +
         '/' + tokens.repository + tokens.branchURL;
+
+      tokens.source_repo = model.source && model.source.repository;
+      tokens.source_owner = model.source && model.source.owner;
 
       // Set up source and destination paths
       tokens.source = sails.config.build.tempDir + '/source/' +

--- a/api/hooks/buildEngine/index.js
+++ b/api/hooks/buildEngine/index.js
@@ -10,10 +10,10 @@ var hook = {
 
   jekyll: function(model, done) {
     var clone = (model.source) ?
-      'git clone -b ${branch} --single-branch ' +
-        'https://${token}@github.com/${source_owner}/${source_repo}.git ${source} && ' +
+      'cd ${source} && git clone -b ${branch} --single-branch ' +
+        'https://${token}@github.com/${source_owner}/${source_repo}.git . && ' +
         'git remote add destination https://${token}@github.com/${owner}/${repository}.git && ' +
-        'git push destination ${branch}' :
+        'git push destination ${branch} && cd -' :
       'git clone -b ${branch} --single-branch ' +
         'https://${token}@github.com/${owner}/${repository}.git ${source}';
 

--- a/api/models/Build.js
+++ b/api/models/Build.js
@@ -30,6 +30,9 @@ module.exports = {
     user: {
       model: 'user',
       required: true
+    },
+    source: {
+      type: 'json'
     }
   },
 

--- a/api/models/Build.js
+++ b/api/models/Build.js
@@ -141,7 +141,9 @@ module.exports = {
       model.error = error;
 
       // Save updated model
-      model.save();
+      model.save(function(err) {
+        // We expect an error on first build after clone so do nothing
+      });
 
     }
 

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -18,8 +18,8 @@ module.exports = {
           config: model.site.config,
           repository: model.site.repository,
           owner: model.site.owner,
-          sourceRepo: model.source.repository,
-          sourceOwner: model.source.owner,
+          sourceRepo: model.source && model.source.repository,
+          sourceOwner: model.source && model.source.owner,
           token: (model.user.passport) ?
             model.user.passport.tokens.accessToken : ''
         },
@@ -48,8 +48,6 @@ module.exports = {
             { "name": "OWNER", "value": tokens.owner },
             { "name": "PREFIX", "value": tokens.prefix },
             { "name": "GITHUB_TOKEN", "value": tokens.token },
-            { "name": "SOURCE_REPO", "value": tokens.sourceRepo },
-            { "name": "SOURCE_OWNER", "value": tokens.sourceOwner },
             { "name": "GENERATOR", "value": tokens.engine }
           ],
           name: sails.config.build.containerName
@@ -58,6 +56,15 @@ module.exports = {
           QueueUrl: queueUrl,
           MessageBody: JSON.stringify(body)
         };
+
+    if (tokens.sourceRepo) body.environment.push({
+      "name": "SOURCE_REPO",
+      "value": tokens.sourceRepo
+    });
+    if (tokens.sourceOwner) body.environment.push({
+      "name": "SOURCE_OWNER",
+      "value": tokens.sourceOwner
+    });
 
     sqs.sendMessage(params, function(err, data) {
       if (err) error(err, model);

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -18,6 +18,8 @@ module.exports = {
           config: model.site.config,
           repository: model.site.repository,
           owner: model.site.owner,
+          sourceRepo: model.source.repository,
+          sourceOwner: model.source.owner,
           token: (model.user.passport) ?
             model.user.passport.tokens.accessToken : ''
         },
@@ -46,6 +48,8 @@ module.exports = {
             { "name": "OWNER", "value": tokens.owner },
             { "name": "PREFIX", "value": tokens.prefix },
             { "name": "GITHUB_TOKEN", "value": tokens.token },
+            { "name": "SOURCE_REPO", "value": tokens.sourceRepo },
+            { "name": "SOURCE_OWNER", "value": tokens.sourceOwner },
             { "name": "GENERATOR", "value": tokens.engine }
           ],
           name: sails.config.build.containerName

--- a/assets/app/models/Github.js
+++ b/assets/app/models/Github.js
@@ -109,6 +109,8 @@ var GithubModel = Backbone.Model.extend({
    * @param {Object} destination - The destination repository.
    * @param {string} destination.repository - The destination repo's name.
    * @param {string} destination.organization - The destination repo's owner org (optional).
+   * @param {string} destination.branch - The destination repo's branch (optional).
+   * @param {string} destination.engine - The destination repo's build engine (optional).
    * @param {function} done - The callback function.
    */
   clone: function clone(source, destination, done) {
@@ -158,26 +160,26 @@ var GithubModel = Backbone.Model.extend({
         sourceRepo: source.repository,
         destinationOrg: destination.organization,
         destinationRepo: destination.repository,
-        destinationBranch: destination.branch,
+        destinationBranch: destination.branch || this.branch,
         engine: destination.engine || 'jekyll'
       };
-
       $.ajax({
         method: 'POST',
         dataType: 'json',
-        data: JSON.stringify(data),
+        data: data,
         url: url,
         success: done.bind(this, null),
         error: done
       });
-
     };
 
     if (done) async.series([
-      method.checkSource,
-      method.createRepo,
-      method.cloneRepo
+      method.checkSource.bind(this),
+      method.createRepo.bind(this),
+      method.cloneRepo.bind(this)
     ], done);
+
+    return this;
   },
   s3ConfigUrl: function (file) {
     var bucketPath = /^http\:\/\/(.*)\.s3\-website\-(.*)\.amazonaws\.com/,

--- a/assets/app/models/Github.js
+++ b/assets/app/models/Github.js
@@ -157,7 +157,9 @@ var GithubModel = Backbone.Model.extend({
         sourceOwner: source.owner,
         sourceRepo: source.repository,
         destinationOrg: destination.organization,
-        destinationRepo: destination.repository
+        destinationRepo: destination.repository,
+        destinationBranch: destination.branch,
+        engine: destination.engine || 'jekyll'
       };
 
       $.ajax({

--- a/assets/app/models/Github.js
+++ b/assets/app/models/Github.js
@@ -7,7 +7,7 @@ var encodeB64 = require('../helpers/encoding').encodeB64;
 
 var GithubModel = Backbone.Model.extend({
   initialize: function (opts) {
-    var opts = opts || {};
+    opts = opts || {};
     if (!opts.token) throw new Error('Must provide Github OAuth token');
 
     this.owner = opts.owner;
@@ -29,14 +29,14 @@ var GithubModel = Backbone.Model.extend({
     return this;
   },
   url: function (opts) {
-    var opts = opts || {},
-        ghUrl = 'https://api.github.com/repos',
+    var ghUrl = 'https://api.github.com/repos',
         baseUrl   = [ghUrl, this.owner, this.name, 'contents'],
         qs = $.param({
           access_token: this.token,
           ref: this.branch,
           z: 6543
         });
+    opts = opts || {};
 
     if (opts.root) return [baseUrl.join('/'), qs].join('?');
 
@@ -134,14 +134,14 @@ var GithubModel = Backbone.Model.extend({
               //json: res.responseJSON || yaml.parse(res.responseText)
             };
             try {
-              r.json = res.responseJSON || yaml.parse(res.responseText)
+              r.json = res.responseJSON || yaml.parse(res.responseText);
             } catch (e) {
-              r.json = []
+              r.json = [];
             }
             callback(null, r);
           }
         });
-      }
+      };
     });
 
     async.parallel(getFiles, function (err, results) {
@@ -156,7 +156,7 @@ var GithubModel = Backbone.Model.extend({
         };
       });
 
-      self.trigger('github:fetchConfig:success')
+      self.trigger('github:fetchConfig:success');
     });
 
     return this;

--- a/assets/app/templates/site/add.html
+++ b/assets/app/templates/site/add.html
@@ -15,19 +15,26 @@
 </div>
 <div class="usa-grid">
   <% for (var templateKey in siteTemplates) { %>
-    <div class="usa-width-one-third template-block" data-template="<%- templateKey %>">
     <% template = siteTemplates[templateKey]; %>
+    <div class="usa-width-one-third template-block" data-template='<% print(JSON.stringify(template)) %>'>
       <div class="usa-alert usa-alert-info">
         <div class="usa-alert-heading">
           <h3><%= template.title %></h3>
         </div>
         <div class="usa-alert-text">
-          <a href="#" data-action="fork-template" class="thumbnail">
+          <a data-action="name-site" class="thumbnail">
             <img src="/images/<%= templateKey %>.thumb.png" alt="Thumbnail screenshot for the <%= template.title %> template">
           </a>
           <p><%= template.description %></p>
-          <a class="usa-button usa-button-outline" href="<%= template.example %>" target="_blank" role="button">Example</a>
-          <a class="usa-button usa-button-primary" data-action="fork-template" role="button">Use this template</a>
+          <div class="button_wrapper">
+            <a class="usa-button usa-button-outline" href="<%= template.example %>" target="_blank" role="button">Example</a>
+            <a class="usa-button" data-action="name-site" role="button">Use this template</a>
+          </div>
+          <form class="new-site-form" aria-hidden="true">
+            <label for="site-name">Name your new site</label>
+            <input name="site-name" type="text">
+            <input type="submit" value="Create site">
+          </form>
         </div>
       </div>
     </div>

--- a/assets/app/views/editor/edit-main.js
+++ b/assets/app/views/editor/edit-main.js
@@ -100,7 +100,7 @@ var EditView = Backbone.View.extend({
           };
 
       self.model.commit(commit);
-    }
+    };
 
     fileReader.readAsDataURL(e);
   }

--- a/assets/app/views/site/add.js
+++ b/assets/app/views/site/add.js
@@ -16,7 +16,8 @@ var AddSiteView = Backbone.View.extend({
   template: _.template(templateHtml),
   events: {
     'click a[type=submit]': 'onSubmitGithubRepo',
-    'click [data-action=fork-template]': 'onTemplateSelection'
+    'submit .new-site-form': 'onTemplateSelection',
+    'click [data-action=name-site]': 'showNewSiteForm'
   },
   initialize: function initializeSiteView(opts) {
     this.user = opts.user;
@@ -40,14 +41,20 @@ var AddSiteView = Backbone.View.extend({
     });
   },
   onTemplateSelection: function onTemplateSelection(e) {
-    var templateId = $(e.target).parents('.template-block').data('template');
-    var data = { templateId: templateId };
-    $.ajax('/v0/site/fork', {
-      method: 'POST',
-      data: data,
-      success: this.onSuccess.bind(this),
-      error: this.onError.bind(this)
-    });
+    e.preventDefault();
+    var data = $(e.target).parents('.template-block').data('template');
+    // initialize GitHub Model
+    // call github.clone()
+    // handle errors
+  },
+  showNewSiteForm: function showNewSiteForm(e) {
+    var $form = $('.new-site-form', $(e.target).parents('.template-block'));
+    var state = $form.attr('aria-hidden') === 'true';
+    $('.new-site-form').attr('aria-hidden', 'true');
+    if (state) {
+      $form.attr('aria-hidden', 'false');
+      $('[name="site-name"]', $(e.target).parents('.template-block')).focus();
+    }
   },
   onSuccess: function onSuccess(e) {
     this.collection.add(e);

--- a/config/policies.js
+++ b/config/policies.js
@@ -63,6 +63,7 @@ module.exports.policies = {
     'destroy': ['passport', 'sessionAuth', 'filterCurrentUser'],
     'find': ['passport', 'sessionAuth', 'filterCurrentUser'],
     'findOne': ['passport', 'sessionAuth', 'filterCurrentUser'],
+    'clone': ['passport', 'sessionAuth'],
     'fork': ['passport', 'sessionAuth'],
     'lock': ['passport', 'sessionAuth'],
     'unlock': ['passport', 'sessionAuth'],

--- a/config/templates.js
+++ b/config/templates.js
@@ -1,20 +1,26 @@
 module.exports.templates = {
   'microsite': {
-    repo: 'https://github.com/USG-Website-Templates/microsite-template',
+    owner: 'USG-Website-Templates',
+    branch: 'gh-pages',
+    repo: 'microsite-template',
     example: 'https://usg-website-templates.github.io/microsite-template/',
     title: 'A simple microsite',
     description: 'A quick little site template'
   },
   'developer': {
-    repo: 'https://github.com/USG-Website-Templates/developer-hub',
+    owner: 'USG-Website-Templates',
+    branch: 'gh-pages',
+    repo: 'developer-hub',
     example: 'http://usg-website-templates.github.io/developer-hub/',
     title: 'A developer hub for API documentation',
     description: 'A template for building developer hubs and API docs'
   },
   'team': {
-    repo: 'https://github.com/18f/federalist-modern-team-template',
+    owner: '18f',
+    branch: 'master',
+    repo: 'federalist-modern-team-template',
     example: 'https://pages.18f.gov/federalist-modern-team-template/',
     title: 'A clean template for teams and agencies',
     description: 'This is a Jekyll site. It is a simple site to showcase the work of an organization with a few different page types'
   }
-}
+};

--- a/migrations/20160107191852-build-source.js
+++ b/migrations/20160107191852-build-source.js
@@ -1,0 +1,20 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  var cmd = 'ALTER TABLE build ADD COLUMN "source" JSON';
+  db.runSql(cmd, function(err) {
+    if (err) throw err;
+    callback();
+  });
+
+};
+
+exports.down = function(db, callback) {
+  var cmd = 'ALTER TABLE build DROP COLUMN "source"';
+  db.runSql(cmd, function(err) {
+    if (err) throw err;
+    callback();
+  });
+
+};

--- a/test/api/unit/models/Build.test.js
+++ b/test/api/unit/models/Build.test.js
@@ -22,10 +22,11 @@ describe('Build Model', function() {
 
   describe('.addJob', function() {
     it('should add job to queue', function(done) {
-      sinon.spy(Build.queue, 'push');
+      var original = Build.queue;
+      sails.hooks[sails.config.build.engine].jekyll = function() {
+        return done();
+      };
       Build.addJob({ id: 1, site: { engine: 'jekyll' }, user: {}});
-      Build.queue.push.restore();
-      done();
     });
   });
 
@@ -36,8 +37,9 @@ describe('Build Model', function() {
         assert(Build.findOne.called);
         Build.findOne = findOne;
         done();
+        return { exec: function() { } };
       });
-      Build.addJob({ id: 1 });
+      Build.completeJob(null, { id: 1, user: {}, site: {} });
     });
   });
 

--- a/test/browser/unit/models/Github.test.js
+++ b/test/browser/unit/models/Github.test.js
@@ -64,6 +64,7 @@ describe('Github model', function () {
         github = new Github(getOpts());
 
     function url(o) { return github.url(o).replace(root, '').split('?')[0]; }
+    function param(o) { return querystring.parse(github.url(o).split('?')[1]); }
 
     // content URL with path
     assert.equal('repos/18f/federalist/contents/test.md', url({ path: 'test.md' }));
@@ -80,6 +81,9 @@ describe('Github model', function () {
       owner: 'own',
       repository: 'repo'
     }));
+
+    // add a param
+    assert.equal('bar', param({ path: 'test.md', params: { foo: 'bar'} }).foo);
 
     done();
   });

--- a/test/browser/unit/models/Github.test.js
+++ b/test/browser/unit/models/Github.test.js
@@ -184,7 +184,11 @@ describe('Github model', function () {
     var url = '/v0/site/clone';
     var github = new Github(getOpts());
     var source = { owner: '18f', repository: 'federalist' },
-        destination = { repository: 'test-repo' },
+        destination = {
+          repository: 'test-repo',
+          branch: 'test-branch',
+          engine: 'static'
+        },
         data;
 
     server.respondWith('POST', url, [200, {}, '{}']);
@@ -198,7 +202,9 @@ describe('Github model', function () {
       assert.deepEqual(json, {
         sourceOwner: source.owner,
         sourceRepo: source.repository,
-        destinationRepo: destination.repository
+        destinationRepo: destination.repository,
+        destinationBranch: destination.branch,
+        engine: destination.engine
       });
       assert(!json.destinationOrg);
       done();
@@ -211,7 +217,11 @@ describe('Github model', function () {
     var url = '/v0/site/clone';
     var github = new Github(getOpts());
     var source = { owner: '18f', repository: 'federalist' },
-        destination = { organization: '18f', repository: 'test-repo' },
+        destination = {
+          organization: '18f',
+          repository: 'test-repo',
+          branch: 'test-branch'
+        },
         data;
 
     server.respondWith('POST', url, [200, {}, '{}']);
@@ -226,7 +236,9 @@ describe('Github model', function () {
         sourceOwner: source.owner,
         sourceRepo: source.repository,
         destinationOrg: destination.organization,
-        destinationRepo: destination.repository
+        destinationRepo: destination.repository,
+        destinationBranch: destination.branch,
+        engine: 'jekyll'
       });
       done();
     });

--- a/test/browser/unit/models/Github.test.js
+++ b/test/browser/unit/models/Github.test.js
@@ -196,7 +196,8 @@ describe('Github model', function () {
     github.clone(source, destination);
 
     github.clone.cloneRepo(function(err) {
-      var json = JSON.parse(data.requestBody);
+
+      var json = querystring.parse(data.requestBody);
       assert.ifError(err);
       assert.equal(data.url, url);
       assert.deepEqual(json, {
@@ -229,7 +230,7 @@ describe('Github model', function () {
     github.clone(source, destination);
 
     github.clone.cloneRepo(function(err) {
-      var body = JSON.parse(data.requestBody);
+      var body = querystring.parse(data.requestBody);
       assert.ifError(err);
       assert.equal(data.url, url);
       assert.deepEqual(body, {


### PR DESCRIPTION
This adds support for cloning sites through the client-side GitHub model and a `/site/clone` API endpoint.

The process works by checking permissions and creating a new repo on the client, then triggering a special build with source repository information. The source build pulls from the source repo and pushes to the destination repo before building.

- [x] Depends on https://github.com/18F/federalist-docker-build/pull/3
- [x] Needs a front-end form for capturing the new site's name

Resolves #138 