### PR TITLE
Skip complete callback if model no longer exists

### DIFF
--- a/api/models/Build.js
+++ b/api/models/Build.js
@@ -104,7 +104,7 @@ module.exports = {
    * @param {Boolean} skipped build?
    */
   completeJob: function(err, model, skip) {
-
+    if (!model) return;
     sails.log.verbose('Completed job: ', model.id);
 
     // Reset associated models to ids


### PR DESCRIPTION
Bug fix following deploy of #279 