### PR TITLE
Add page layout to options if not already there

### DIFF
--- a/assets/app/views/editor/edit-file.js
+++ b/assets/app/views/editor/edit-file.js
@@ -143,7 +143,10 @@ var EditorView = Backbone.View.extend({
         type: self.settingsFields[k].type,
         value: y[k]
       };
-      if (r.type === 'select') r.options = self.settingsFields[k].options;
+      if (r.type === 'select') {
+        r.options = self.settingsFields[k].options;
+        if (!_(r.options).contains(r.value)) r.options.push(r.value);
+      }
       delete y[k];
       return r;
     });


### PR DESCRIPTION
The editor should never prevent you from saving the document in the same same state that it was retrieved in. It wasn’t passing along the current value of the layout value so if it wasn’t configured in the defaults, the editor would change the value to “default”.

@dhcole ready for your review