### PR TITLE
If an AWS redirect header is present on preview, redirect the request

### DIFF
--- a/api/controllers/PreviewController.js
+++ b/api/controllers/PreviewController.js
@@ -19,6 +19,9 @@ module.exports = {
           Bucket: sails.config.build.s3Bucket,
           Key: key
         }).on('httpHeaders', function(statusCode, headers) {
+          var redirect = headers['x-amz-website-redirect-location'] ||
+            headers['X-Amz-Website-Redirect-Location'];
+          if (redirect) return res.redirect(redirect);
           res.set(headers);
         }),
         stream = object.createReadStream().on('error', function(error) {


### PR DESCRIPTION
For the preview proxy, this looks for the AWS S3 redirect header and issues an actual redirect if present.

Fixes #236