### PR TITLE
Add draft workflow

### DIFF
--- a/assets/app/helpers/encoding.js
+++ b/assets/app/helpers/encoding.js
@@ -3,5 +3,9 @@ module.exports.encodeB64 = function(s) {
 };
 
 module.exports.decodeB64 = function(s) {
-  return decodeURIComponent(escape(window.atob(s)));
+  try {
+    return decodeURIComponent(escape(window.atob(s)));
+  } catch (e) {
+    return;
+  }
 };

--- a/assets/app/models/Github.js
+++ b/assets/app/models/Github.js
@@ -275,7 +275,7 @@ var GithubModel = Backbone.Model.extend({
       url: url,
       success: function(data) {
         self.drafts = _(data).chain().filter(function(branch) {
-          return branch.name.indexOf('_draft-') === 0;
+          return branch.name && branch.name.indexOf('_draft-') === 0;
         }).map(function(branch) {
           return decodeB64(branch.name.replace('_draft-', ''));
         }).compact().value();

--- a/assets/app/models/Github.js
+++ b/assets/app/models/Github.js
@@ -93,6 +93,7 @@ var GithubModel = Backbone.Model.extend({
           return done(e);
         }
 
+        self.attributes.json = self.attributes.json || {};
         self.attributes.json.sha = res.responseJSON.content.sha;
 
         // if this is an uploaded asset

--- a/assets/app/models/Github.js
+++ b/assets/app/models/Github.js
@@ -274,11 +274,12 @@ var GithubModel = Backbone.Model.extend({
     $.ajax({
       url: url,
       success: function(data) {
-        self.drafts = _(data).chain().filter(function(branch) {
+        var drafts = _(data).chain().filter(function(branch) {
           return branch.name && branch.name.indexOf('_draft-') === 0;
         }).map(function(branch) {
           return decodeB64(branch.name.replace('_draft-', ''));
         }).compact().value();
+        self.set('drafts', drafts);
         self.trigger('github:fetchDrafts:success');
       },
       error: function(res) {

--- a/assets/app/templates/editor/file.html
+++ b/assets/app/templates/editor/file.html
@@ -31,12 +31,6 @@
       <form id="content">
         <div data-target="content"></div>
       </form>
-      <% if (draft) { %>
-      <div>
-        <span class="usa-label">Draft</span>
-      </div>
-      <% } %>
-
     </div>
   </div>
 
@@ -48,7 +42,11 @@
           <label for="save-content-message">Make this a helpful save message for yourself and future collaborators.</label>
           <input type="text" class="form-control" id="save-content-message" value="Some changes to <%= fileName %>">
         </div>
-        <button class="usa-button usa-button-primary save-button" data-action="save-content">Save as Draft</button>
+        <% if (draft) { %>
+        <button class="usa-button-outline delete-button" data-action="delete-draft">Delete Draft</button>
+        <% } %>
+        <button class="usa-button-outline save-button" data-action="save-content">Save as Draft</button>
+        <button class="usa-button-primary publish-button" data-action="publish-content">Save & Publish</button>
         <span class="usa-label" id="save-status-result" style="display:none" ></span>
       </form>
     </div>

--- a/assets/app/templates/editor/file.html
+++ b/assets/app/templates/editor/file.html
@@ -48,7 +48,7 @@
           <label for="save-content-message">Make this a helpful save message for yourself and future collaborators.</label>
           <input type="text" class="form-control" id="save-content-message" value="Some changes to <%= fileName %>">
         </div>
-        <button class="usa-button usa-button-primary save-button" data-action="save-content">Save</button>
+        <button class="usa-button usa-button-primary save-button" data-action="save-content">Save as Draft</button>
         <span class="usa-label" id="save-status-result" style="display:none" ></span>
       </form>
     </div>

--- a/assets/app/templates/editor/file.html
+++ b/assets/app/templates/editor/file.html
@@ -31,6 +31,12 @@
       <form id="content">
         <div data-target="content"></div>
       </form>
+      <% if (draft) { %>
+      <div>
+        <span class="usa-label">Draft</span>
+      </div>
+      <% } %>
+
     </div>
   </div>
 

--- a/assets/app/templates/editor/main.html
+++ b/assets/app/templates/editor/main.html
@@ -3,7 +3,14 @@
     <h1>Edit content of <%- owner %> / <%- repo %></h1>
   </div>
   <div class="usa-width-one-third">
+    <% if (!file) { %>
     <a class="usa-button usa-button-big pull-right" id="add-page" alt="Add a new page" href="#" role="button">Add a new page</a>
+    <% } else if (draft) { %>
+    <div class="preview-buttons">
+      <a class="usa-button usa-button-big pull-right preview-button" href="/preview/<%- owner %>/<%- repo %>/<%- branch %>/" role="button">Preview Draft</a>
+      <button class="usa-button usa-button-disabled usa-button-big pull-right preview-button-disabled">Generating Preview...</button>
+    </div>
+    <% } %>
   </div>
 </div>
 <div class="usa-grid">

--- a/assets/app/templates/editor/page-list-item.html
+++ b/assets/app/templates/editor/page-list-item.html
@@ -2,6 +2,9 @@
   <div class="usa-grid">
     <div class="usa-width-two-thirds">
       <%- text %>
+      <% if (draft) { %>
+        <span class="usa-label label-success">Draft</span>
+      <% } %>
     </div>
     <div class="usa-width-one-third">
       <a class="usa-button usa-button-outline file-list-item-button" href="<%- href %>">Edit</a>

--- a/assets/app/templates/editor/page-list-item.html
+++ b/assets/app/templates/editor/page-list-item.html
@@ -3,7 +3,7 @@
     <div class="usa-width-two-thirds">
       <%- text %>
       <% if (draft) { %>
-        <span class="usa-label label-success">Draft</span>
+        <span class="usa-label">Draft</span>
       <% } %>
     </div>
     <div class="usa-width-one-third">

--- a/assets/app/views/editor/breadcrumb.js
+++ b/assets/app/views/editor/breadcrumb.js
@@ -26,9 +26,11 @@ var BreadcrumbView = Backbone.View.extend({
         branch  = this.model.get('branch'),
         file    = this.model.get('file'),
         type    = (this.model.configFiles['_navigation.json'].present) ? 'pages' : 'files',
-        filePath;
-
-    console.log('type', type);
+        filePath,
+        defaultBranch = federalist.sites.findWhere({
+          owner: owner,
+          repository: repo
+        }).get('defaultBranch');
 
     this.$el.empty();
 
@@ -52,7 +54,7 @@ var BreadcrumbView = Backbone.View.extend({
     else {
       this.$el.append(html({
         text: 'All pages',
-        link: ['#edit', owner, repo, branch].join('/')
+        link: ['#edit', owner, repo, defaultBranch].join('/')
       }));
     }
     return this;

--- a/assets/app/views/editor/breadcrumb.js
+++ b/assets/app/views/editor/breadcrumb.js
@@ -32,6 +32,8 @@ var BreadcrumbView = Backbone.View.extend({
           repository: repo
         }).get('defaultBranch');
 
+    this.model.set('defaultBranch', defaultBranch);
+
     this.$el.empty();
 
     if (!file) return this;

--- a/assets/app/views/editor/edit-file.js
+++ b/assets/app/views/editor/edit-file.js
@@ -27,7 +27,8 @@ var EditorView = Backbone.View.extend({
         file      = this.filePathFromModel(this.model),
         fileExt   = this.fileExtensionFromName(this.model.get('file')),
         html      = {
-          fileName: this.model.get('file')
+          fileName: this.model.get('file'),
+          draft: this.model.get('isDraft')
         };
 
     this.editors = {};
@@ -37,7 +38,6 @@ var EditorView = Backbone.View.extend({
 
     this.model.on('github:commit:success', this.saveSuccess.bind(this));
     this.model.on('github:commit:error', this.saveFailure.bind(this));
-
     this.doc = this.initializeDocument({
       fileExt: fileExt,
       isNewPage: this.isNewPage

--- a/assets/app/views/editor/edit-file.js
+++ b/assets/app/views/editor/edit-file.js
@@ -83,8 +83,9 @@ var EditorView = Backbone.View.extend({
       .reverse()
       .findWhere({ branch: this.model.get('branch') })
       .value();
+    var processing = (!build || !build.completedAt);
 
-    $('.preview-buttons').toggleClass('processing', !build.completedAt);
+    $('.preview-buttons').toggleClass('processing', processing);
   },
   initializeDocument: function (opts) {
     var fileExt = opts.fileExt,

--- a/assets/app/views/editor/edit-file.js
+++ b/assets/app/views/editor/edit-file.js
@@ -276,14 +276,6 @@ var EditorView = Backbone.View.extend({
     if (err) return this.saveFailure(err);
     document.body.scrollTop = 0;
 
-    this.$('#save-status-result').removeClass('label-danger');
-    this.$('#save-status-result').addClass('label-success');
-    this.$('#save-status-result').text('Yay, the save was successful!');
-
-    setTimeout(function() {
-      $('#save-status-result').hide();
-    }, 3000);
-
     var url = [
       '#edit',
       this.model.get('owner'),
@@ -308,10 +300,12 @@ var EditorView = Backbone.View.extend({
         },
         status = messages[e.response] || 'That hasn\'t happened before';
 
-    this.$('#save-status-result').removeClass('label-success');
-    this.$('#save-status-result').addClass('label-danger');
-
-    this.$('#save-status-result').text(status);
+    document.body.scrollTop = 0;
+    $('.alert-container').html(
+      '<div class="usa-grid"><div class="usa-alert usa-alert-info" role="alert">' +
+        status +
+      '</div></div>'
+    );
   },
   deleteDraft: function(e) {
     e.preventDefault();

--- a/assets/app/views/editor/edit-file.js
+++ b/assets/app/views/editor/edit-file.js
@@ -293,6 +293,11 @@ var EditorView = Backbone.View.extend({
     ].join('/');
 
     federalist.navigate(url, { trigger: true });
+    $('.alert-container').html(
+      '<div class="usa-grid"><div class="usa-alert usa-alert-info" role="alert">' +
+        'Your draft was saved.' +
+      '</div></div>'
+    );
   },
   saveFailure: function (e) {
     var messages = {
@@ -318,6 +323,11 @@ var EditorView = Backbone.View.extend({
         this.model.get('repoName'),
         this.model.get('defaultBranch')
       ].join('/'), { trigger: true });
+      $('.alert-container').html(
+        '<div class="usa-grid"><div class="usa-alert usa-alert-info" role="alert">' +
+          'Your draft was deleted.' +
+        '</div></div>'
+      );
     }.bind(this));
   },
   publishContent: function(e) {
@@ -330,6 +340,11 @@ var EditorView = Backbone.View.extend({
         this.model.get('repoName'),
         this.model.get('defaultBranch')
       ].join('/'), { trigger: true });
+      $('.alert-container').html(
+        '<div class="usa-grid"><div class="usa-alert usa-alert-info" role="alert">' +
+          'Your draft is being published.' +
+        '</div></div>'
+      );
     }.bind(this));
   },
   saveDocument: function (e, method, done) {

--- a/assets/app/views/editor/edit-main.js
+++ b/assets/app/views/editor/edit-main.js
@@ -24,10 +24,6 @@ var EditView = Backbone.View.extend({
   },
   initialize: function (opts) {
     if (!opts) return this;
-    var html = template({ owner: opts.owner, repo: opts.repo });
-
-    this.$el.html(html);
-    this.pageSwitcher = this.pageSwitcher || new ViewSwitcher(this.$('#edit-content')[0]);
 
     this.model = window.federalist.github = new Github({
       token: getToken(),
@@ -36,11 +32,6 @@ var EditView = Backbone.View.extend({
       branch: opts.branch,
       file: opts.file,
       site: opts.site
-    });
-
-    this.breadcrumb = new BreadcrumbView({
-      $el: this.$('ol.breadcrumb'),
-      model: this.model
     });
 
     this.model.on('sync', this.update.bind(this));
@@ -69,6 +60,23 @@ var EditView = Backbone.View.extend({
         '#edit', model.owner, model.name, draftBranch, model.file
       ].join('/'), { trigger: true });
     }
+
+    var html = template({
+      owner: model.get('owner'),
+      repo: model.get('repoName'),
+      draft: model.get('isDraft'),
+      file: model.get('file'),
+      branch: model.get('branch')
+    });
+
+    this.$el.html(html);
+    this.pageSwitcher = this.pageSwitcher || new ViewSwitcher(this.$('#edit-content')[0]);
+    this.breadcrumb = new BreadcrumbView({
+      $el: this.$('ol.breadcrumb'),
+      model: this.model
+    }).render();
+
+
 
     this.$('#edit-button').empty();
 

--- a/assets/app/views/editor/edit-main.js
+++ b/assets/app/views/editor/edit-main.js
@@ -54,14 +54,17 @@ var EditView = Backbone.View.extend({
         config = model.configFiles || {},
         childView, pages;
 
-    var isDraft = _.contains(this.model.get('drafts'), this.model.get('file'));
+    model.set('isDraft', _.contains(
+      this.model.get('drafts'),
+      this.model.get('file'))
+    );
 
-    if (isDraft) {
+    if (model.get('isDraft')) {
       var draftBranch = '_draft-' + encodeB64(model.file);
       var url = [
         '#edit', model.owner, model.name, draftBranch, model.file
       ].join('/');
-      window.Backbone = Backbone;
+
       if (url !== '#' + Backbone.history.getFragment()) return federalist.navigate([
         '#edit', model.owner, model.name, draftBranch, model.file
       ].join('/'), { trigger: true });

--- a/assets/app/views/editor/edit-main.js
+++ b/assets/app/views/editor/edit-main.js
@@ -4,6 +4,7 @@ var Backbone = require('backbone');
 var ViewSwitcher = require('ampersand-view-switcher');
 var _ = require('underscore');
 
+var encodeB64 = require('../../helpers/encoding').encodeB64;
 var decodeB64 = require('./../../helpers/encoding').decodeB64;
 
 var BreadcrumbView = require('./breadcrumb');
@@ -52,6 +53,19 @@ var EditView = Backbone.View.extend({
     var model = this.model,
         config = model.configFiles || {},
         childView, pages;
+
+    var isDraft = _.contains(this.model.get('drafts'), this.model.get('file'));
+
+    if (isDraft) {
+      var draftBranch = '_draft-' + encodeB64(model.file);
+      var url = [
+        '#edit', model.owner, model.name, draftBranch, model.file
+      ].join('/');
+      window.Backbone = Backbone;
+      if (url !== '#' + Backbone.history.getFragment()) return federalist.navigate([
+        '#edit', model.owner, model.name, draftBranch, model.file
+      ].join('/'), { trigger: true });
+    }
 
     this.$('#edit-button').empty();
 

--- a/assets/app/views/editor/pages.js
+++ b/assets/app/views/editor/pages.js
@@ -23,7 +23,11 @@ var PagesView = Backbone.View.extend({
     function addToList(list, item) {
       var m = self.model,
           href = ['/#edit', m.owner, m.name, m.branch, item.href].join('/'),
-          html = template({ text: item.text, href: href });
+          html = template({
+            text: item.text,
+            href: href,
+            draft: _.contains(m.get('drafts'), item.href)
+          });
       list.append(html);
     }
 

--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -78,6 +78,7 @@ var AppView = Backbone.View.extend({
     return this;
   },
   edit: function (owner, repo, branch, file) {
+    $('.alert-container').html('');
     if (!file) return this.sites.fetch({ success: loadView.bind(this) });
     loadView.call(this);
     return this;

--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -18,7 +18,10 @@ var AppView = Backbone.View.extend({
     // Initiate websocket subscription and fetch sites on build message
     io.socket.get('/v0/build?limit=0');
     io.socket.on('build', function() {
-      this.sites.fetch({ data: $.param({ limit: 50 }) });
+      this.sites.fetch({
+        data: $.param({ limit: 50 }),
+        success: function() {}
+      });
     }.bind(this));
 
     this.render();
@@ -75,16 +78,19 @@ var AppView = Backbone.View.extend({
     return this;
   },
   edit: function (owner, repo, branch, file) {
-    var editView = new EditorContainerView({
-      owner: owner,
-      repo: repo,
-      branch: branch,
-      file: file,
-      site: this.sites.findWhere({ owner: owner, repository: repo })
-    });
-    this.pageSwitcher.set(editView);
-
+    if (!file) return this.sites.fetch({ success: loadView.bind(this) });
+    loadView.call(this);
     return this;
+    function loadView() {
+      var editView = new EditorContainerView({
+        owner: owner,
+        repo: repo,
+        branch: branch,
+        file: file,
+        site: this.sites.findWhere({ owner: owner, repository: repo })
+      });
+      this.pageSwitcher.set(editView);
+    }
   },
   editSite: function(id) {
     var siteEditView = new SiteEditView({ model: this.sites.get(id) });

--- a/assets/app/views/site/add.js
+++ b/assets/app/views/site/add.js
@@ -84,8 +84,10 @@ var AddSiteView = Backbone.View.extend({
     this.trigger('site:save:success');
   },
   onError: function onError(e) {
-    var message = (e && e.responseJSON && e.responseJSON.raw) ?
-          e.responseJSON.raw : e.responseText;
+    var message = (e && e.responseJSON) ? e.responseJSON : e.responseText;
+    if (message && message.errors && message.errors.length > 0) {
+      message = 'We encountered an error while making your website: ' + _.chain(message.errors).pluck('message').compact().value().join(', ');
+    }
     $('.alert-container').html(
       '<div class="usa-grid"><div class="usa-alert usa-alert-error new-site-error" role="alert">' +
         message +

--- a/assets/styles/sass/_editors.scss
+++ b/assets/styles/sass/_editors.scss
@@ -11,3 +11,21 @@
   border: none;
   outline: none;
 }
+
+.preview-buttons {
+  .preview-button {
+    display: block;;
+  }
+  .preview-button-disabled {
+    display: none;
+  }
+}
+.preview-buttons.processing {
+  .preview-button {
+    display: none;
+  }
+  .preview-button-disabled {
+    display: block;
+  }
+
+}

--- a/test/browser/unit/models/Github.test.js
+++ b/test/browser/unit/models/Github.test.js
@@ -56,6 +56,9 @@ describe('Github model', function () {
       done();
     });
 
+    server.respondWith('GET', 'https://api.github.com/repos/18f/federalist/branches?access_token=FAKETOKEN&ref=master', helpers.mockResponse(JSON.stringify({}), 200));
+    server.respond();
+
     github.commit(commitOpts);
     server.respondWith('PUT', helpers.makeUrl('test.md'), helpers.mockResponse(mockCommitResponse, 201));
     server.respond();

--- a/test/browser/unit/models/Github.test.js
+++ b/test/browser/unit/models/Github.test.js
@@ -202,7 +202,7 @@ describe('Github model', function () {
 
     github.clone.cloneRepo(function(err) {
 
-      var json = querystring.parse(data.requestBody);
+      var json = JSON.parse(data.requestBody);
       assert.ifError(err);
       assert.equal(data.url, url);
       assert.deepEqual(json, {
@@ -235,7 +235,7 @@ describe('Github model', function () {
     github.clone(source, destination);
 
     github.clone.cloneRepo(function(err) {
-      var body = querystring.parse(data.requestBody);
+      var body = JSON.parse(data.requestBody);
       assert.ifError(err);
       assert.equal(data.url, url);
       assert.deepEqual(body, {


### PR DESCRIPTION
This PR adds a workflow for drafts following @GailSwanson's proposal in https://github.com/18F/federalist-design/blob/master/UX/FederalistEditorV2.0.pdf.

- User edits a page
- New edits are saved to a draft branch and a PR is opened
- Additional editors add to open draft branch
- Users can publish or delete drafts
- Preview link is available as previews are built

Closes #189 