### PR TITLE
Add commit details to site object

### DIFF
--- a/api/hooks/buildEngine/index.js
+++ b/api/hooks/buildEngine/index.js
@@ -23,7 +23,9 @@ var hook = {
       'rm -rf ${destination} || true',
       'mkdir -p ${source}',
       clone,
-      'echo "baseurl: ${baseurl}\nbranch: ${branch}\n${config}" > ' +
+      'git log -1 --pretty=format:\'commit: {%n "commit": "%H",%n "author": "%an <%ae>",%n "date": "%ad",%n "message": "%s"%n}\' > ' +
+        '${source}/_config_base.yml',
+      'echo "\nbaseurl: ${baseurl}\nbranch: ${branch}\n${config}" >> ' +
         '${source}/_config_base.yml',
       'bundle exec jekyll build --safe --config ${source}/_config.yml,${source}/_config_base.yml ' +
         '--source ${source} --destination ${source}/_site',


### PR DESCRIPTION
Adds commit details to the `site` object.

eg:

```json
commit: {
 "commit": "8ebcd8d344ac417288304ae7cba630fae3dbe1b6",
 "author": "Dave Cole <david.cole@gsa.gov>",
 "date": "Mon Jan 25 12:13:47 2016 -0500",
 "message": "Test message"
}
```

See also https://github.com/18F/federalist-docker-build/pull/4
Closes #136