### PR TITLE
Use xhr polling instead of websockets

### DIFF
--- a/assets/app/views/editor/edit-file.js
+++ b/assets/app/views/editor/edit-file.js
@@ -59,7 +59,7 @@ var EditorView = Backbone.View.extend({
       self.socket = data.id;
 
       // Apply the lock
-      self.lockContent.bind(self);
+      self.lockContent.call(self, data);
 
       // On any change events (others open or leave the page), reapply the lock
       io.socket.on('change', self.lockContent.bind(self));

--- a/assets/index.html
+++ b/assets/index.html
@@ -76,12 +76,7 @@
 
     <script src="/js/dependencies/sails.io.js"></script>
     <script>
-      io.sails.transports = ['websocket'];
-      io.sails.useCORSRouteToGetCookie = false;
-      // CloudFoundry only accepts websockets over port 4443
-      if (/\.18f\.gov$/.test(location.hostname)) {
-        io.sails.url = location.protocol + '//' + location.hostname + ':4443';
-      }
+      io.sails.transports = ['polling'];
     </script>
     <script src="/js/bundle.js"></script>
     <script>

--- a/config/sockets.js
+++ b/config/sockets.js
@@ -126,7 +126,7 @@ module.exports.sockets = {
   // },
 
 
-
+  transports: ['polling']
 
 
   // More configuration options for Sails+Socket.io:


### PR DESCRIPTION
Our production environment seems to have some trouble with websockets, but we probably don't need them anyway. This also fixes an issue where the page lock wasn't being set on first load.

Fixes #300 