### PR TITLE
Change uswds branch to latest v0.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "socket.io-redis": "^0.1.4",
     "to-markdown": "^1.2.1",
     "underscore": "^1.8.3",
-    "uswds": "git+https://github.com/18f/web-design-standards.git#18f-pages-staging",
+    "uswds": "git+https://github.com/18f/web-design-standards.git#v0.9.x",
     "validator": "^3.39.0",
     "yamljs": "^0.2.4"
   },


### PR DESCRIPTION
Running `npm install` was failing using the uswds `18f-pages-staging` branch as configured in `package.json`. Changing it to `v0.9.x` per @jeremiak suggestion, and it runs without failing now.