### PR TITLE
Decode b64 build status message

### DIFF
--- a/api/controllers/BuildController.js
+++ b/api/controllers/BuildController.js
@@ -5,14 +5,18 @@
  * @help        :: See http://links.sailsjs.org/docs/controllers
  */
 
+function decodeb64 (str) {
+  return new Buffer(str, 'base64').toString('utf8');
+}
+
 module.exports = {
 
   // Endpoint for status updates for builds by external builders
   status: function(req, res) {
-    var message = req.body.message;
+
+    var message = decodeb64(req.body.message);
 
     Build.findOne(req.param('id')).exec(function(err, build) {
-
       if (err) res.send(err);
 
       Build.completeJob(message, build);


### PR DESCRIPTION
To prevent problems with character encoding, the status message from the docker builder will be base 64 encoded as of 18f/federalist-docker-build@b43ee49.

Should be merged with 18f/federalist-docker-build#6