### PR TITLE
link directly to the chat room

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We're so glad you're thinking about contributing to an 18F open source project! 
 We aspire to create a welcoming environment for collaboration on this project.
 To that end, we follow the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and ask that all contributors do the same.
 
-Join our team on Slack by signing up for the #federalist-public channel at https://chat.18f.gov/.
+Join our team on Slack by [signing up for the #federalist-public channel](https://chat.18f.gov/?channel=federalist-public).
 
 Before contributing, we encourage you to read our CONTRIBUTING policy (you are here), our LICENSE, and our README, all of which should be in this repository. If you have any questions, or want to read more about our underlying policies, you can consult the 18F Open Source Policy GitHub repository at https://github.com/18f/open-source-policy, or just shoot us an email/official government letterhead note to [18f@gsa.gov](mailto:18f@gsa.gov).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Federalist
 [![Build Status](https://travis-ci.org/18F/federalist.svg?branch=master)](https://travis-ci.org/18F/federalist)
 
-***Under active development. Everything is subject to change. Interested in talking to us? [Join our public chat](https://chat.18f.gov/) room (select `federalist-public` from the dropdown).***
+***Under active development. Everything is subject to change. Interested in talking to us? [Join our public chat room](https://chat.18f.gov/?channel=federalist-public).***
 
 Federalist is a unified interface for publishing static government websites. It automates common tasks for integrating GitHub, [Prose](https://github.com/prose/prose), and Amazon Web Services to provide a simple way for developers to launch new websites or more easily manage existing ones.
 

--- a/assets/app/views/main.js
+++ b/assets/app/views/main.js
@@ -40,9 +40,9 @@ var AppView = Backbone.View.extend({
   },
   parseDashboardErrorFromURL: function (url) {
     var messages = {
-      'Error.Passport.Unauthorized': 'Your account is not set up to access Federalist. Have you signed up as a beta user? If you have signed up and should have access, please let us know. You can reach us in our public chat room. Please select "federalist-public" from the drop-down menu at https://chat.18f.gov',
+      'Error.Passport.Unauthorized': 'Your account is not set up to access Federalist. Have you signed up as a beta user? If you have signed up and should have access, please let us know. You can reach us in our public chat room: https://chat.18f.gov/?channel=federalist-public',
       'preview.login': 'Please log in to preview this site',
-      'default': 'An unexpected error occured. Please try again. If you continue to see this message, please let us know. You can reach us in our public chat room. Please select "federalist-public" from the drop-down menu at https://chat.18f.gov'
+      'default': 'An unexpected error occured. Please try again. If you continue to see this message, please let us know. You can reach us in our public chat room: https://chat.18f.gov/?channel=federalist-public'
     };
     var error = querystring.parse(url.search.slice(1)).error;
     var message = error && (messages[error] || messages['default']);


### PR DESCRIPTION
https://chat.18f.gov now supports linking directly to the channel! See https://github.com/18F/chat/pull/5 for more information.