### PR TITLE
Add script to export all current sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "uswds:images": "cp -r node_modules/uswds/dist/img/ ./assets/images/uswds",
     "uswds:fonts": "cp node_modules/uswds/dist/fonts/* ./assets/fonts",
     "codemirror": "cp node_modules/codemirror/lib/codemirror.css assets/styles/",
-    "prosemirror": "cd node_modules/prosemirror && npm run dist"
+    "prosemirror": "cd node_modules/prosemirror && npm run dist",
+    "export:sites": "node ./scripts/exportSitesAsCsv.js"
   },
   "main": "app.js",
   "repository": {
@@ -107,6 +108,7 @@
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "jsdom": "3.1.2",
+    "json-to-csv": "^1.0.0",
     "mocha": "2.3.4",
     "nodemon": "^1.3.7",
     "selenium-standalone": "^4.9.0",

--- a/scripts/exportSitesAsCsv.js
+++ b/scripts/exportSitesAsCsv.js
@@ -1,0 +1,83 @@
+var path = require('path');
+
+var _ = require('underscore');
+var jsonToCSV = require('json-to-csv');
+var sails = require('sails');
+
+function resolveDestination(d) {
+  var relativePathRegex = /^\.\//;
+  var fullPathRegex = /^[~/]/;
+  var destination = d;
+  if (d.match(relativePathRegex)) {
+    destination = ['..', d].join('/');
+    return path.resolve([__dirname, destination].join('/'));
+  } else if (d.match(fullPathRegex)) {
+    return destination;
+  }
+  return destination;
+}
+
+function sitesFromUsers(users) {
+  return _.flatten(users.map(function(user) {
+    return user.sites.map(function(site) {
+      return {
+        id: site.id,
+        github: [site.owner, site.repository].join('/'),
+        domain: site.domain,
+        users: [user.username]
+      };
+    });
+  }));
+}
+
+function consolidateOnSiteId(sites) {
+  var ids = sites.map(function(site) {
+    return site.id;
+  });
+
+  return ids.map(function(id) {
+    var sitesById = _.where(sites, { id: id });
+    var users = sitesById.map(function(site) {
+      return site.users[0];
+    });
+    return Object.assign({}, sites[0], { users: users });
+  });
+}
+
+function main(err, app) {
+  var args = Array.prototype.slice.call(process.argv);
+  var destination = resolveDestination(args[2] || './current-sites.csv');
+
+  if (err) return console.log('Error occurred lifting Sails app', err);
+
+  console.log('Final output can be found at', destination);
+  console.log('\tUse npm run export -- /other/path/file.csv to change');
+
+  return User.find({})
+    .populate('sites')
+    .then(sitesFromUsers)
+    .then(consolidateOnSiteId)
+    .then(function(sites) {
+      return sites.map(function(site) {
+        return Object.assign({}, site, { users: site.users.join(', ') })
+      });
+    })
+    .then(function(sites) {
+      console.log('Found ' + sites.length + ' unique sites');
+      return sites;
+    })
+    .then(function(sites) {
+      return jsonToCSV(sites, destination)
+    })
+    .then(function() {
+      console.log('Current sites written to file', destination);
+    })
+    .then(function() {
+      sails.lower();
+    })
+    .catch(function(err) {
+      console.log('An error occurred', err);
+    });
+}
+
+sails.lift({}, main);


### PR DESCRIPTION
There is a business need to know which sites are currently on Federalist and which users we should get in touch with regarding downtime or maintenance.

I have added a script that is executable with `npm run export:sites`. You can pass an optional path after `--` to have the outputted CSV written to a location of your choice. Since we will be running this on cloud.gov instances we probably just want to use the default which is `./current-sites.csv`

I don’t think we can get into production cloud.gov postgres instances from the outside, so we’ll have to run this script on a throwaway instance using something like `cf-ssh` and then run the script with `npm run export:sites`. We can then retrieve the file with [these instructions](https://docs.cloud.gov/apps/databases/#accessing-files-created-on-the-server-using-cf-files) and throwaway the instance.

This one is for you @wslack so let me know if this is useful.