### PR TITLE
Use index to properly output all current sites

### DIFF
--- a/scripts/exportSitesAsCsv.js
+++ b/scripts/exportSitesAsCsv.js
@@ -35,12 +35,13 @@ function consolidateOnSiteId(sites) {
     return site.id;
   });
 
-  return ids.map(function(id) {
+  return ids.map(function(id, i) {
     var sitesById = _.where(sites, { id: id });
     var users = sitesById.map(function(site) {
       return site.users[0];
     });
-    return Object.assign({}, sites[0], { users: users });
+
+    return Object.assign({}, sites[i], { users: users });
   });
 }
 


### PR DESCRIPTION
Fixes the `npm run export:sites` script to properly output all the current users and sites as a CSV. I forgot to use a dynamic index so the exported sites were all copies of the first site.