### PR TITLE
[FED-372]: Attempt to fix function call on undefined permalink

### DIFF
--- a/assets/app/views/site/pages/pages.js
+++ b/assets/app/views/site/pages/pages.js
@@ -101,16 +101,23 @@ var EditView = Backbone.View.extend({
       file: model.get('file'),
       branch: model.get('branch')
     };
-    var r = new RegExp(/\//g);
-    var n;
+    var navigationJSON = model.configFiles['_navigation.json'];
+    // matches all '/' in a string.
+    var matchSlashes = new RegExp(/\//g);
+    var currentPageObj;
 
     if (data.draft) {
       data.draftBranch = model.formatDraftBranchName(data.file);
     }
 
-    if (model.configFiles['_navigation.json'].present) {
-      n = _.where(model.configFiles['_navigation.json'].json, { href: data.file });
-      data.permalink = n.length ? n[0].permalink.replace(r, '') : n;
+    // If there is no file, we are on the tree page, and there won't be any
+    // permalink to compare to.
+    if (navigationJSON.present && data.file) {
+      var permalink;
+
+      currentPageObj = _.findWhere(navigationJSON.json, { href: data.file });
+      permalink = (currentPageObj && currentPageObj.permalink) || '';
+      data.permalink = permalink.replace(matchSlashes, '');
     }
 
     return data;


### PR DESCRIPTION

References issue https://github.com/18F/federalist/issues/372

I couldn't load an actual copy of the customer's site, but I did go in and clean up some of the code around setting a permalink on the template data object. The changes should make the code a bit more failsafe, but I don't know if it will fix the error without more information.

* Checks for existence of data.file and defined `permalink` property on navigation object