### PR TITLE
removes "static" option for building a site

### DIFF
--- a/assets/app/templates/add.html
+++ b/assets/app/templates/add.html
@@ -61,7 +61,7 @@
         <select name="engine" id="engine" class="form-control">
           <option selected value="jekyll">Jekyll</option>
           <option value="hugo">Hugo</option>
-          <option value="static">Static (just publish the files in the repository)</option>
+          <!-- <option value="static">Static (just publish the files in the repository)</option> -->
         </select>
       </div>
       <div class="form-group">


### PR DESCRIPTION
Other places this option is referenced: 
- https://github.com/18F/federalist/blob/master/test/browser/models/Github.test.js
- https://github.com/18F/federalist/blob/6bb931723fd7d12dae8a36515f0cab61a9478665/api/models/Site.js
- https://github.com/18F/federalist/blob/5e34487c769c067270f04cba15573489c69b1fdc/api/hooks/buildEngine/index.js

After this is merged, we should be able to move https://github.com/18F/federalist/issues/385 to "Done?"