### PR TITLE
Remove old fork a repo implementation in server code

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -47,17 +47,6 @@ module.exports = {
     });
   },
 
-  fork: function forkSiteFromTemplate(req, res) {
-    if (!req.param('templateId')) return res.notFound();
-
-    var user = req.user,
-        templateId = req.param('templateId');
-    GitHub.forkRepository(user, templateId, function(err, newSite) {
-      if (err) return res.serverError(err);
-      res.send(newSite);
-    });
-  },
-
   lock: function lockEditing(req, res) {
     var roomName = req.param('file');
 


### PR DESCRIPTION
These fork methods were from an earlier implementation of the add a new site from a template mechanism and confused us earlier today. The cloning of a site is now taken care by the [front end app](https://github.com/18F/federalist/blob/master/assets/app/models/Github.js#L263) and some [federalist-docker-build code](https://github.com/18F/federalist-docker-build/blob/master/clone.sh#L8-L12)