### PR TITLE
Update prosemirror library and wrap in component

### DIFF
--- a/assets/app/components/site/editor/codemirror.js
+++ b/assets/app/components/site/editor/codemirror.js
@@ -1,0 +1,43 @@
+
+import React from 'react';
+import codemirror from 'codemirror';
+
+const propTypes = {
+  initialYmlContent: React.PropTypes.string
+};
+
+const defaultProps = {
+  initialYmlContent: ''
+};
+
+class Codemirror extends React.Component {
+  componentDidMount() {
+    const target = document.querySelector('#js-codemirror-target');
+    this.editor = codemirror(target, {
+      lineNumbers: true,
+      mode: 'yaml',
+      value: this.props.initialYmlContent
+    });
+
+    this.editor.on('change', (event) => {
+      console.log('change event from codemirror', event);
+    });
+  }
+
+  componentWillUnmount() {
+    this.editor.off('change');
+  }
+
+  render() {
+    return (
+      <div>
+        <div id="js-codemirror-target"></div>
+      </div>
+    )
+  }
+}
+
+Codemirror.propTypes = propTypes;
+Codemirror.defaultProps = defaultProps;
+
+export default Codemirror;

--- a/assets/app/components/site/editor/editorContainer.js
+++ b/assets/app/components/site/editor/editorContainer.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import Codemirror from './codemirror';
+import Prosemirror from './prosemirror';
+
+import siteActions from '../../../actions/siteActions';
+
+const propTypes = {
+  site: React.PropTypes.object
+};
+
+class Editor extends React.Component {
+  render() {
+    return (
+      <div>
+        <Codemirror />
+        <Prosemirror />
+      </div>
+    );
+  }
+}
+
+Editor.propTypes = propTypes;
+
+export default Editor;

--- a/assets/app/components/site/editor/prosemirror.js
+++ b/assets/app/components/site/editor/prosemirror.js
@@ -11,14 +11,16 @@ const menu = buildMenuItems(schema);
 class Prosemirror extends React.Component {
   constructor(props) {
     super(props);
-
+    this.state = {
+      doc: null
+    };
     this.toMarkdown = this.toMarkdown.bind(this);
   }
 
   componentDidMount() {
     this.editor = new prosemirror.ProseMirror({
       doc: defaultMarkdownParser.parse(this.props.initialMarkdownContent),
-      place: document.querySelector('#js-prosemirror-target'),
+      place: document.getElementById('js-prosemirror-target'),
       schema: schema,
       plugins: [
         menuBar.config({ content: menu.fullMenu })
@@ -28,6 +30,13 @@ class Prosemirror extends React.Component {
     this.editor.on.change.add(() => {
       const doc = this.editor.doc.toJSON();
       this.setState({ doc });
+    });
+  }
+
+  componentWillUnmount() {
+    const changeHandlers = this.editor.on.change.handlers;
+    changeHandlers.forEach((handler) => {
+      this.editor.on.change.remove(handler.fn);
     });
   }
 

--- a/assets/app/components/site/editor/prosemirror.js
+++ b/assets/app/components/site/editor/prosemirror.js
@@ -1,0 +1,55 @@
+
+import React from 'react';
+import prosemirror from 'prosemirror';
+import { exampleSetup, buildMenuItems } from 'prosemirror/dist/example-setup'
+import { defaultMarkdownParser, defaultMarkdownSerializer } from 'prosemirror/dist/markdown';
+import { menuBar } from 'prosemirror/dist/menu';
+import { schema } from 'prosemirror/dist/schema-basic';
+
+const menu = buildMenuItems(schema);
+
+class Prosemirror extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.toMarkdown = this.toMarkdown.bind(this);
+  }
+
+  componentDidMount() {
+    this.editor = new prosemirror.ProseMirror({
+      doc: defaultMarkdownParser.parse(this.props.initialMarkdownContent),
+      place: document.querySelector('#js-prosemirror-target'),
+      schema: schema,
+      plugins: [
+        menuBar.config({ content: menu.fullMenu })
+      ]
+    });
+
+    this.editor.on.change.add(() => {
+      const doc = this.editor.doc.toJSON();
+      this.setState({ doc });
+    });
+  }
+
+  toMarkdown() {
+    return defaultMarkdownSerializer.serialize(this.editor.doc);
+  }
+
+  render() {
+    return (
+      <div>
+        <div id="js-prosemirror-target"></div>
+      </div>
+    )
+  }
+}
+
+Prosemirror.defaultProps = {
+  initialMarkdownContent: '*yo*\nhey there'
+};
+
+Prosemirror.propTypes = {
+  initialMarkdownContent: React.PropTypes.string
+};
+
+export default Prosemirror;

--- a/assets/app/routes.js
+++ b/assets/app/routes.js
@@ -5,6 +5,7 @@ import App from './components/app';
 import Dashboard from './components/Dashboard/siteList';
 import SiteContainer from './components/siteContainer';
 import SitePagesContainer from './components/site/Pages/pagesContainer';
+import SiteEditorContainer from './components/site/editor/editorContainer';
 import SiteLogs from './components/site/siteLogs';
 import SiteMediaContainer from './components/site/siteMediaContainer';
 import SiteSettings from './components/site/siteSettings';
@@ -24,7 +25,7 @@ export default (
         <Route path="settings" component={SiteSettings}/>
         <Route path="media" component={SiteMediaContainer}/>
         <Route path="logs" component={SiteLogs}/>
-        <Route path="edit/:branch/:fileName" component={Stub}/>
+        <Route path="edit/:branch/:fileName" component={SiteEditorContainer}/>
       </Route>
       <Redirect from="*" to="/not-found"/>
     </Route>

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "yamljs": "^0.2.4"
   },
   "scripts": {
-    "install": "npm run uswds && npm run codemirror && npm run prosemirror && npm run migrate:up",
+    "install": "npm run uswds && npm run codemirror && npm run migrate:up",
     "build": "npm run browserify && npm run sass && npm run autoprefixer",
     "start": "npm run build && node app.js",
     "debug": "node debug app.js",
@@ -91,7 +91,6 @@
     "uswds:images": "cp -r node_modules/uswds/dist/img/ ./assets/images/uswds",
     "uswds:fonts": "cp node_modules/uswds/dist/fonts/* ./assets/fonts",
     "codemirror": "cp node_modules/codemirror/lib/codemirror.css assets/styles/",
-    "prosemirror": "cd node_modules/prosemirror && npm run dist",
     "export:sites": "node ./scripts/exportSitesAsCsv.js"
   },
   "main": "app.js",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "passport-local": "^1.0.0",
     "pg": "^4.4.0",
     "postcss-cli": "^2.3.2",
-    "prosemirror": "git+https://github.com/18f/prosemirror.git",
+    "prosemirror": "^0.8.3",
     "rc": "~0.5.0",
     "react-router": "^2.4.1",
     "request": "^2.61.0",


### PR DESCRIPTION
After all the work last week to deal with prosemirror build problems, I wanted to see how easy it was to upgrade the library. We originally had to fork it because we were using it before it was published to the npm registry.

It was easy to install the library and I wrapped it in a component for ease of use within React. I did the same for the codemirror library and made an editor container object to hold both of them.

I'm not sure I named the files correctly, since there seems to be kind of a mix of capitalization usages when it comes to components and directories. Maybe we should just switch everything to snake case while we still have a relatively small number of components so that its easier to think about? After that issue where travis is case sensitive, I'm sort of leaning towards snake case so we avoid it entirely.

Otherwise, I'm open to camel casing everything starting with lowercase letters but it should be consistent at least across the front end code.

Thoughts @el-mapache & @brandocalrissian?