### PR TITLE
Content in prosemirror/codemirror

### DIFF
--- a/assets/app/actions/siteActions.js
+++ b/assets/app/actions/siteActions.js
@@ -113,18 +113,21 @@ export default {
 
   fetchSiteConfigsAndAssets(site) {
     return this.fetchSiteConfigs(site).then((site) => {
-      return this.fetchSiteAssets(site);
-    }).then((site) => {
-      return github.fetchRepositoryContent(site);
-    }).then((files) => {
-      store.dispatch({
-        type: siteActionTypes.SITE_CONTENTS_RECEIVED,
-        siteId: site.id,
-        files
+      return this.fetchSiteAssets(site).then((site) => {
+        return github.fetchRepositoryContent(site).then((files) => {
+          store.dispatch({
+            type: siteActionTypes.SITE_CONTENTS_RECEIVED,
+            siteId: site.id,
+            files
+          });
+
+          return files;
+        });
       });
     }).catch((error) => alertActions.httpError(error.message));
   },
 
+  // todo rename to something like fetchTree
   fetchContent(site, path) {
     function dispatchChildContent(site, path, files) {
       store.dispatch({
@@ -139,6 +142,17 @@ export default {
       .then(
         dispatchChildContent.bind(null, site, path)
       ).catch(error => alertActions.httpError(error.message));
+  },
+
+  fetchFileContent(site, path) {
+    return github.fetchRepositoryContent(site, path)
+      .then((file) => {
+        store.dispatch({
+          type: siteActionTypes.SITE_FILE_CONTENT_RECEIVED,
+          siteId: site.id,
+          file
+        });
+      });
   },
 
   cloneRepo(destination, source) {

--- a/assets/app/components/site/editor/codemirror.js
+++ b/assets/app/components/site/editor/codemirror.js
@@ -3,11 +3,11 @@ import React from 'react';
 import codemirror from 'codemirror';
 
 const propTypes = {
-  initialYmlContent: React.PropTypes.string
+  initialFrontmatterContent: React.PropTypes.string
 };
 
 const defaultProps = {
-  initialYmlContent: ''
+  initialFrontmatterContent: ''
 };
 
 class Codemirror extends React.Component {
@@ -16,12 +16,16 @@ class Codemirror extends React.Component {
     this.editor = codemirror(target, {
       lineNumbers: true,
       mode: 'yaml',
-      value: this.props.initialYmlContent
+      value: this.props.initialFrontmatterContent
     });
 
     this.editor.on('change', (event) => {
       console.log('change event from codemirror', event);
     });
+  }
+
+  componentDidUpdate() {
+    this.editor.setValue(this.props.initialFrontmatterContent);
   }
 
   componentWillUnmount() {

--- a/assets/app/components/site/editor/prosemirror.js
+++ b/assets/app/components/site/editor/prosemirror.js
@@ -33,6 +33,11 @@ class Prosemirror extends React.Component {
     });
   }
 
+  componentDidUpdate() {
+    const doc = defaultMarkdownParser.parse(this.props.initialMarkdownContent);
+    this.editor.setDoc(doc);
+  }
+
   componentWillUnmount() {
     const changeHandlers = this.editor.on.change.handlers;
     changeHandlers.forEach((handler) => {

--- a/assets/app/components/siteContainer.js
+++ b/assets/app/components/siteContainer.js
@@ -17,13 +17,18 @@ class SiteContainer extends React.Component {
   }
 
   componentDidMount() {
-    const { storeState, params } = this.props;
+    const { storeState, params, routeParams } = this.props;
     const currentSite = this.getCurrentSite(storeState.sites, params.id);
 
     if (!currentSite) {
       this.props.router.push('/sites');
     } else {
-      siteActions.fetchSiteConfigsAndAssets(currentSite);
+      siteActions.fetchSiteConfigsAndAssets(currentSite).then(() => {
+        const path = params.fileName;
+        const splat = params.splat;
+        const file = (splat) ? `${splat}/${path}` : path;
+        siteActions.fetchFileContent(currentSite, file);
+      });
     }
   }
 

--- a/assets/app/constants.js
+++ b/assets/app/constants.js
@@ -60,8 +60,10 @@ export const siteActionTypes = keymirror({
   SITE_ASSETS_RECEIVED: null,
   // All files that aren't config or assets retrieved from github
   SITE_CONTENTS_RECEIVED: null,
-  SITE_CHILD_CONTENT_RECEIVED: null,
-  SITE_FILE_ADDED: null
+  SITE_CHILD_CONTENT_RECEIVED: null, // is this the tree?
+  SITE_FILE_ADDED: null,
+  // When an individual file/path is received
+  SITE_FILE_CONTENT_RECEIVED: null
 });
 
 export const userActionTypes = keymirror({

--- a/assets/app/reducers/sites.js
+++ b/assets/app/reducers/sites.js
@@ -33,6 +33,17 @@ export default function sites(state = initialState, action) {
         childDirectoriesMap: Object.assign({}, currentMap, nextMap)
       });
     });
+  case siteActionTypes.SITE_FILE_CONTENT_RECEIVED:
+    const currentSite = state.filter((site) => site.id === action.siteId).pop();
+    const siteFiles = currentSite.files || [];
+    const files = siteFiles.map((file) => {
+      if (file.sha !== action.file.sha) return file;
+      return Object.assign({}, file, action.file);
+    });
+    const alreadyHaveFile = files.find((file) => file.sha === action.file.sha);
+
+    if (!alreadyHaveFile) files.push(action.file);
+    return mapPropertyToMatchingSite(state, action.siteId, {files})
   default:
     return state;
   }

--- a/assets/app/routes.js
+++ b/assets/app/routes.js
@@ -26,7 +26,7 @@ export default (
           <Route path=":fileName" component={SitePagesContainer} />
         </Route>
         <Route path="new/:branch(/:fileName)" component={SiteEditorContainer} isNewPage={true} />
-        <Route path="edit/:branch/:fileName" component={SiteEditorContainer}/>
+        <Route path="edit/:branch/(**/):fileName" component={SiteEditorContainer}/>
         <Route path="media" component={SiteMediaContainer}/>
         <Route path="settings" component={SiteSettings}/>
         <Route path="logs" component={SiteLogs}/>

--- a/test/client/app/reducers/sitesTest.js
+++ b/test/client/app/reducers/sitesTest.js
@@ -13,6 +13,7 @@ describe("sitesReducer", () => {
   const SITE_DELETED = "bye, site.";
   const SITE_UPDATED = "change the site, please";
   const SITES_RECEIVED = "hey, sites!";
+  const SITE_FILE_CONTENT_RECEIVED = "cool, files!";
 
   beforeEach(() => {
     fixture = proxyquire("../../../../assets/app/reducers/sites", {
@@ -25,7 +26,8 @@ describe("sitesReducer", () => {
           SITE_CONTENTS_RECEIVED: SITE_CONTENTS_RECEIVED,
           SITE_DELETED: SITE_DELETED,
           SITE_UPDATED: SITE_UPDATED,
-          SITES_RECEIVED: SITES_RECEIVED
+          SITES_RECEIVED: SITES_RECEIVED,
+          SITE_FILE_CONTENT_RECEIVED: SITE_FILE_CONTENT_RECEIVED
         }
       }
     }).default;
@@ -522,6 +524,58 @@ describe("sitesReducer", () => {
     };
 
     expect(actual).to.deep.equal([ updatedSiteOne, siteTwo ]);
+  });
+
+  it("updates a site's file with a content attribute if it is found", function() {
+    const fileSha = "this is a cool sha";
+    const fileContent = "yo dude, here's some content";
+    const siteOne = {
+      id: "siteToKeep",
+      files: [
+        {
+          sha: fileSha,
+          oldData: "this should make it all the way through"
+        }
+      ]
+    };
+
+    const existingSites = [ siteOne ];
+
+    const actual = fixture(existingSites, {
+      type: SITE_FILE_CONTENT_RECEIVED,
+      siteId: "siteToKeep",
+      file: {
+        sha: fileSha,
+        content: fileContent
+      }
+    });
+
+    const expectedFile = Object.assign({}, siteOne.files.pop(), {
+      content: fileContent
+    });
+
+    expect(actual.pop().files.pop()).to.deep.equal(expectedFile);
+  });
+
+  it("adds a file to a site if it is not found in the state when the request for content comes back from the github api", function() {
+    const file = {
+      sha: "this is a cool sha",
+      content: "yo dude, here's some content"
+    }
+    const siteOne = {
+      id: "siteToKeep",
+      files: []
+    };
+
+    const existingSites = [ siteOne ];
+
+    const actual = fixture(existingSites, {
+      type: SITE_FILE_CONTENT_RECEIVED,
+      siteId: "siteToKeep",
+      file
+    });
+
+    expect(actual.pop().files.pop()).to.deep.equal(file);
   });
 
 });


### PR DESCRIPTION
**Note**: #468 should be merged first

Enhances the functionality of the `<Prosemirror />` and `<Codemirror />` components by fetching the file contents from the Github API and using that data to populate the editors. This does _not_ have functionality for making changes to a document. I will follow up in another PR for that.

Refs #450 and #451 