### PR TITLE
Add label and text box to choose custom site org (WIP)

### DIFF
--- a/assets/app/components/AddSite/TemplateSiteList/templateSite.js
+++ b/assets/app/components/AddSite/TemplateSiteList/templateSite.js
@@ -100,6 +100,12 @@ class TemplateSite extends React.Component {
                 type="text"
                 value={this.state.siteName}
                 onChange={this.handleChange} />
+              <label for="site-org">Repository Location</label>
+              <input
+                name="site-org"
+                type="text"
+                value={this.state.orgName}
+                onChange={this.handleChange} />
               <input type="submit" value="Create site" />
             </form>
           </div>


### PR DESCRIPTION
May need to edit 
* https://github.com/18F/federalist/blob/wslack-custom-org/assets/app/components/AddSite/TemplateSiteList/templateSite.js#L35
* https://github.com/18F/federalist/blob/wslack-custom-org/assets/app/util/githubApi.js#L153
* https://github.com/18F/federalist/blob/wslack-custom-org/assets/app/util/federalistApi.js#L38

And referencing: 
* https://developer.github.com/v3/repos/#create
* https://github.com/18F/federalist/pull/454/files#diff-c4a074e69be9b8d80a8f3d7215ae842aR39

(not to public: I'm not a dev, but am using this feature to learn about how Federalist works and API calls so I can be a better product owner)