### PR TITLE
references path so edit view loads correct file

### DIFF
--- a/assets/app/components/site/Pages/pagesContainer.js
+++ b/assets/app/components/site/Pages/pagesContainer.js
@@ -19,10 +19,10 @@ class Pages extends React.Component {
   }
 
   getLinkFor(page, id, branch) {
-    const pageName = page.name;
+    const path = page.path;
 
     return this.isDir(page) ?
-      `/sites/${id}/tree/${pageName}` : `/sites/${id}/edit/${branch}/${pageName}`;
+      `/sites/${id}/tree/${path}` : `/sites/${id}/edit/${branch}/${path}`;
   }
 
   getButtonCopy(page) {


### PR DESCRIPTION

* References `path` property instead of `name` when generating an edit view link, github file path now resolves correctly