### PR TITLE
Jk edit tree fix

### DIFF
--- a/assets/app/actions/siteActions.js
+++ b/assets/app/actions/siteActions.js
@@ -140,9 +140,8 @@ export default {
   fetchContent(site, path) {
     function dispatchChildContent(site, path, files) {
       store.dispatch({
-        type: siteActionTypes.SITE_CHILD_CONTENT_RECEIVED,
-        siteId: 1,
-        path,
+        type: siteActionTypes.SITE_CONTENTS_RECEIVED,
+        siteId: site.id,
         files
       });
     }

--- a/assets/app/actions/siteActions.js
+++ b/assets/app/actions/siteActions.js
@@ -119,7 +119,7 @@ export default {
       return this.fetchSiteAssets(site).then((site) => {
         return github.fetchRepositoryContent(site).then((files) => {
           store.dispatch({
-            type: siteActionTypes.SITE_CONTENTS_RECEIVED,
+            type: siteActionTypes.SITE_FILES_RECEIVED,
             siteId: site.id,
             files
           });
@@ -137,10 +137,10 @@ export default {
   },
 
   // todo rename to something like fetchTree
-  fetchContent(site, path) {
+  fetchFiles(site, path) {
     function dispatchChildContent(site, path, files) {
       store.dispatch({
-        type: siteActionTypes.SITE_CONTENTS_RECEIVED,
+        type: siteActionTypes.SITE_FILES_RECEIVED,
         siteId: site.id,
         files
       });

--- a/assets/app/components/site/Pages/pagesContainer.js
+++ b/assets/app/components/site/Pages/pagesContainer.js
@@ -19,10 +19,10 @@ class Pages extends React.Component {
   }
 
   getLinkFor(page, id, branch) {
-    const pageName = page.name;
+    const path = page.path;
 
     return this.isDir(page) ?
-      `/sites/${id}/tree/${pageName}` : `/sites/${id}/edit/${branch}/${pageName}`;
+      `/sites/${id}/tree/${path}` : `/sites/${id}/edit/${branch}/${path}`;
   }
 
   getButtonCopy(page) {

--- a/assets/app/components/site/Pages/pagesContainer.js
+++ b/assets/app/components/site/Pages/pagesContainer.js
@@ -8,8 +8,8 @@ const propTypes = {
   site: React.PropTypes.object
 };
 
-const filterByPath = (files = [], startingPath = '/') => {
-  const isRoot = (startingPath === '/');
+const filterByPath = (files = [], startingPath = '') => {
+  const isRoot = (startingPath === '');
   const path = (!isRoot) ? `${startingPath}/` : '((?!/).)*$';
   const startsWithPath = new RegExp(`^${path}`);
   const f = files.filter((file) => startsWithPath.test(file.path));
@@ -19,7 +19,7 @@ const filterByPath = (files = [], startingPath = '/') => {
 
 const getPath = (routeParams) => {
   const { splat, fileName } = routeParams;
-  let path = '/';
+  let path = '';
 
   if (splat) {
     path = `${splat}/${fileName}`;
@@ -36,13 +36,17 @@ class Pages extends React.Component {
     super(props);
   }
 
+  componentDidMount() {
+    siteActions.fetchFiles(this.props.site, getPath(this.props.params));
+  }
+
   componentWillReceiveProps(nextProps) {
     const { params, site } = nextProps;
     const nextFiles = filterByPath(site.files, params.fileName);
     const files = filterByPath(this.props.site.files, this.props.params.fileName);
     if (nextFiles.length === files.length) return;
 
-    siteActions.fetchFiles(site, params.fileName);
+    siteActions.fetchFiles(site, getPath(params));
   }
 
   getLinkFor(page, id, branch) {

--- a/assets/app/components/site/Pages/pagesContainer.js
+++ b/assets/app/components/site/Pages/pagesContainer.js
@@ -42,7 +42,7 @@ class Pages extends React.Component {
     const files = filterByPath(this.props.site.files, this.props.params.fileName);
     if (nextFiles.length === files.length) return;
 
-    siteActions.fetchContent(site, params.fileName);
+    siteActions.fetchFiles(site, params.fileName);
   }
 
   getLinkFor(page, id, branch) {

--- a/assets/app/components/site/Pages/pagesContainer.js
+++ b/assets/app/components/site/Pages/pagesContainer.js
@@ -8,14 +8,45 @@ const propTypes = {
   site: React.PropTypes.object
 };
 
+const filterByPath = (files, startingPath = '/') => {
+  const isRoot = (startingPath === '/');
+  const path = (!isRoot) ? `${startingPath}/` : '((?!/).)*$';
+  const startsWithPath = new RegExp(`^${path}`);
+  const f = files.filter((file) => file.path.match(startsWithPath));
+  return f;
+};
+
 class Pages extends React.Component {
+  constructor(props) {
+    super(props);
+    let path = '/';
+
+    if (props.params.splat) {
+      path = `${props.params.splat}/${props.params.fileName}`;
+    }
+    else if (props.params.fileName) {
+      path = props.params.fileName;
+    }
+
+    this.state = {
+      path,
+      files: []
+    }
+  }
   componentDidMount() {
-    const currentDirectory = this.props.params.fileName;
-    siteActions.fetchContent(this.props.site, currentDirectory);
+    siteActions.fetchContent(this.props.site, this.state.path);
   }
 
-  getClasses() {
-    return 'usa-button-outline file-list-item-button';
+  componentWillReceiveProps(nextProps) {
+    const { params, site } = nextProps;
+    const files = filterByPath(site.files, params.fileName);
+    if (files.length === this.state.files.length) return;
+
+    this.setState({
+      files
+    });
+
+    siteActions.fetchContent(site, params.fileName);
   }
 
   getLinkFor(page, id, branch) {
@@ -25,56 +56,30 @@ class Pages extends React.Component {
       `/sites/${id}/tree/${path}` : `/sites/${id}/edit/${branch}/${path}`;
   }
 
-  getButtonCopy(page) {
-    return this.isDir(page) ? 'Open' : 'Edit';
+  getButtonCopy(file) {
+    return this.isDir(file) ? 'Open' : 'Edit';
   }
 
-  isDir(page) {
-    return page.type === 'dir';
-  }
-
-  getPagesFor(site) {
-    const currentDirectory = this.props.params.fileName;
-    const { files, childDirectoriesMap = {} } = site;
-
-    let directoryContents;
-
-    // User is on the pages index, return all files at the top level
-    if (!currentDirectory) {
-      return childDirectoriesMap['/'] || files;
-    }
-
-    directoryContents = childDirectoriesMap[currentDirectory];
-
-    // There is no entry in the child directories map for the supplied folder
-    // so fetch its content
-    if (!directoryContents) {
-      siteActions.fetchContent(site, currentDirectory);
-      return [];
-    }
-
-    return directoryContents;
+  isDir(file) {
+    return file.type === 'dir';
   }
 
   render() {
-    const { site } = this.props;
-    let pages;
+    const { fileName } = this.props.params;
 
-    if (!site) {
+    if (!this.props.site) {
       return null;
     }
 
-    pages = this.getPagesFor(site) || [];
-
     return (
       <ul className="list-group">
-        {pages.map((page, index) => {
-          const { id, branch, defaultBranch } = site;
+        {this.state.files.map((page, index) => {
+          const { id, branch, defaultBranch } = this.props.site;
 
           return (
             <PageListItem key={index} pageName={page.name}>
               <LinkButton href={this.getLinkFor(page, id, branch || defaultBranch)}
-                className={this.getClasses()}
+                className="usa-button-outline file-list-item-button"
                 text={this.getButtonCopy(page)} />
             </PageListItem>
           );

--- a/assets/app/constants.js
+++ b/assets/app/constants.js
@@ -59,8 +59,7 @@ export const siteActionTypes = keymirror({
   // Asset files retrieved from github
   SITE_ASSETS_RECEIVED: null,
   // All files that aren't config or assets retrieved from github
-  SITE_CONTENTS_RECEIVED: null,
-  SITE_CHILD_CONTENT_RECEIVED: null, // is this the tree?
+  SITE_FILES_RECEIVED: null,
   SITE_FILE_ADDED: null,
   // When an individual file/path is received
   SITE_FILE_CONTENT_RECEIVED: null

--- a/assets/app/reducers/sites.js
+++ b/assets/app/reducers/sites.js
@@ -21,16 +21,19 @@ export default function sites(state = initialState, action) {
   case siteActionTypes.SITE_ASSETS_RECEIVED:
     return mapPropertyToMatchingSite(state, action.siteId, { assets: action.assets });
 
-  case siteActionTypes.SITE_CONTENTS_RECEIVED:
+  case siteActionTypes.SITE_FILES_RECEIVED:
+    const nextFiles = action.files || [];
     const site = state.find((site) => site.id === action.siteId);
+
     if (!site) return state;
+
     if (!site.files) {
       return mapPropertyToMatchingSite(state, action.siteId, {
-        files: action.files
+        files: nextFiles
       });
     }
 
-    let newFiles = action.files.map((file) => {
+    let newFiles = nextFiles.map((file) => {
       const exists = site.files.find((f) => f.path === file.path);
       if (!exists) return file;
 
@@ -48,20 +51,6 @@ export default function sites(state = initialState, action) {
 
   case siteActionTypes.SITE_DELETED:
     return state.filter((site) => site.id != action.siteId);
-
-  case siteActionTypes.SITE_CHILD_CONTENT_RECEIVED:
-    const nextMap = {};
-    nextMap[action.path || '/'] = action.files || [];
-
-    return state.map((site) => {
-      if (site.id !== action.siteId) return site;
-
-      const currentMap = site.childDirectoriesMap || {};
-
-      return Object.assign({}, site, {
-        childDirectoriesMap: Object.assign({}, currentMap, nextMap)
-      });
-    });
 
   case siteActionTypes.SITE_FILE_CONTENT_RECEIVED:
     const currentSite = state.find((site) => site.id === action.siteId);

--- a/assets/app/reducers/sites.js
+++ b/assets/app/reducers/sites.js
@@ -33,6 +33,7 @@ export default function sites(state = initialState, action) {
     let newFiles = action.files.map((file) => {
       const exists = site.files.find((f) => f.path === file.path);
       if (!exists) return file;
+
       return Object.assign({}, exists, file);
     });
 

--- a/assets/app/routes.js
+++ b/assets/app/routes.js
@@ -23,7 +23,7 @@ export default (
       <Route path=":id" component={SiteContainer}>
         <IndexRedirect to="tree" />
         <Route path="tree" component={SitePagesContainer}>
-          <Route path=":fileName" component={SitePagesContainer} />
+          <Route path="(**/):fileName" component={SitePagesContainer} />
         </Route>
         <Route path="new/:branch(/:fileName)" component={SiteEditorContainer} isNewPage={true} />
         <Route path="edit/:branch/(**/):fileName" component={SiteEditorContainer}/>

--- a/test/client/app/reducers/sitesTest.js
+++ b/test/client/app/reducers/sitesTest.js
@@ -7,9 +7,8 @@ describe("sitesReducer", () => {
   let fixture;
   const SITE_ADDED = "hey, new site!";
   const SITE_ASSETS_RECEIVED = "Whoa. Assets.";
-  const SITE_CHILD_CONTENT_RECEIVED = "kids have contents.";
   const SITE_CONFIGS_RECEIVED = "Tasty configs!";
-  const SITE_CONTENTS_RECEIVED = "contents? we have contents!";
+  const SITE_FILES_RECEIVED = "contents? we have contents!";
   const SITE_DELETED = "bye, site.";
   const SITE_UPDATED = "change the site, please";
   const SITES_RECEIVED = "hey, sites!";
@@ -21,9 +20,8 @@ describe("sitesReducer", () => {
         siteActionTypes: {
           SITE_ADDED: SITE_ADDED,
           SITE_ASSETS_RECEIVED: SITE_ASSETS_RECEIVED,
-          SITE_CHILD_CONTENT_RECEIVED: SITE_CHILD_CONTENT_RECEIVED,
           SITE_CONFIGS_RECEIVED: SITE_CONFIGS_RECEIVED,
-          SITE_CONTENTS_RECEIVED: SITE_CONTENTS_RECEIVED,
+          SITE_FILES_RECEIVED: SITE_FILES_RECEIVED,
           SITE_DELETED: SITE_DELETED,
           SITE_UPDATED: SITE_UPDATED,
           SITES_RECEIVED: SITES_RECEIVED,
@@ -313,7 +311,7 @@ describe("sitesReducer", () => {
     ];
 
     const actual = fixture(existingSites, {
-      type: SITE_CONTENTS_RECEIVED,
+      type: SITE_FILES_RECEIVED,
       siteId: "siteToKeepCEOWIOIIJV",
       files: files
     });
@@ -344,7 +342,7 @@ describe("sitesReducer", () => {
     ];
 
     const actual = fixture(existingSites, {
-      type: SITE_CONTENTS_RECEIVED,
+      type: SITE_FILES_RECEIVED,
       siteId: "siteToKeep",
       files: files
     });
@@ -386,7 +384,7 @@ describe("sitesReducer", () => {
     ];
 
     const actual = fixture(existingSites, {
-      type: SITE_CONTENTS_RECEIVED,
+      type: SITE_FILES_RECEIVED,
       siteId: "siteToKeep",
       files: files
     });
@@ -431,7 +429,7 @@ describe("sitesReducer", () => {
     ];
 
     const actual = fixture(existingSites, {
-      type: SITE_CONTENTS_RECEIVED,
+      type: SITE_FILES_RECEIVED,
       siteId: "siteToKeep",
       files: files
     });
@@ -447,8 +445,8 @@ describe("sitesReducer", () => {
     expect(actual.length).to.equal(2);
     expect(site.files.length).to.equal(updatedSiteOne.files.length);
   });
-  
-  it("does nothing when given a child contents received action and the new site's id is not found", () => {
+
+  it("does nothing when given a files_received action and the new site's id is not found", () => {
     const siteOne = {
       id: "siteToKeep",
       oldData: true
@@ -461,164 +459,131 @@ describe("sitesReducer", () => {
 
     const existingSites = [ siteOne, siteTwo ];
 
-    const files = {
-      whatever: "punk",
-      what: "huh?"
-    };
+    const files = [
+      {path: "punk"},
+      {path: "huh?"}
+    ];
 
     const actual = fixture(existingSites, {
-      type: SITE_CHILD_CONTENT_RECEIVED,
+      type: SITE_FILES_RECEIVED,
       siteId: "siteToKeepCEOWIOIIJV"
     });
 
     expect(actual).to.deep.equal(existingSites);
   });
 
-  it("sets a site's 'childDirectoriesMap' property to map the action's path to the action's files when given a child content received action and the new site's id is found, without an existing childDirectoriesMap", () => {
+  it("returns files from action if no files are set on site", () => {
     const siteOne = {
-      id: "siteToKeep",
-      oldData: true
+      id: "siteToKeep"
     };
 
     const siteTwo = {
-      id: "anotherSiteToKeep",
-      oldData: true
+      id: "anotherSiteToKeep"
     };
 
     const existingSites = [ siteOne, siteTwo ];
 
-    const files = {
-      whatever: "punk",
-      what: "huh?"
-    };
-
-    const path = "/go/here/or/not";
+    const files = [
+      {path: "punk"},
+      {path: "huh?"}
+    ];
 
     const actual = fixture(existingSites, {
-      type: SITE_CHILD_CONTENT_RECEIVED,
+      type: SITE_FILES_RECEIVED,
       siteId: "siteToKeep",
-      files: files,
-      path: path
+      files: files
     });
 
     const updatedSiteOne = {
       id: "siteToKeep",
-      oldData: true,
-      childDirectoriesMap: {
-        "/go/here/or/not": files
-      }
+      files: files
     };
 
     expect(actual).to.deep.equal([ updatedSiteOne, siteTwo ]);
   });
 
-  it("sets a site's 'childDirectoriesMap' property to map the action's path to the action's files when given a child content received action and the new site's id is found, with an existing childDirectoriesMap", () => {
-    const path = "/go/here/or/not";
-    const existingPath = "/already/home";
-    const existingFiles = [ "previously on something something", "format TBD" ];
-    const existingChildDirectoriesMap = { };
-    existingChildDirectoriesMap[existingPath] = existingFiles;
+  it("returns a new files array with the union of the new and existing files", () => {
+    const existingFiles = [
+      { path: "previously on something something" },
+      { path: "format TBD" }
+    ];
 
     const siteOne = {
       id: "siteToKeep",
-      oldData: true,
-      childDirectoriesMap: existingChildDirectoriesMap
+      files: existingFiles
     };
 
     const siteTwo = {
-      id: "anotherSiteToKeep",
-      oldData: true
+      id: "anotherSiteToKeep"
     };
 
     const existingSites = [ siteOne, siteTwo ];
 
-    const files = [ "whatever", "punk",  "huh?" ];
+    const newFiles = [
+      {path: "punk"},
+      {path: "huh?"}
+    ];
 
     const actual = fixture(existingSites, {
-      type: SITE_CHILD_CONTENT_RECEIVED,
+      type: SITE_FILES_RECEIVED,
       siteId: "siteToKeep",
-      files: files,
-      path: path
+      files: newFiles
     });
 
     const updatedSiteOne = {
       id: "siteToKeep",
-      oldData: true,
-      childDirectoriesMap: {
-        "/already/home": existingFiles,
-        "/go/here/or/not": files
-      }
+      files: existingFiles.concat(newFiles)
+    };
+
+    const actualSiteOne = actual.find((site) => site.id === siteOne.id);
+
+    expect(actualSiteOne.files.length).to.equal(updatedSiteOne.files.length);
+  });
+
+  it("returns an empty array if action.files is missing and site has no files", () => {
+    const siteOne = {
+      id: "siteToKeep"
+    };
+
+    const siteTwo = {
+      id: "anotherSiteToKeep"
+    };
+
+    const existingSites = [ siteOne, siteTwo ];
+
+    const actual = fixture(existingSites, {
+      type: SITE_FILES_RECEIVED,
+      siteId: "siteToKeep"
+    });
+
+    const updatedSiteOne = {
+      id: "siteToKeep",
+      files: []
     };
 
     expect(actual).to.deep.equal([ updatedSiteOne, siteTwo ]);
   });
 
-  it("updates a site's 'childDirectoriesMap' property to map the action's path to the action's files when given a child content received action and the new site's id is found, with an existing childDirectoriesMap containing the path", () => {
-    const path = "/go/here/or/not";
-    const existingFiles = [ "previously on something something", "format TBD" ];
-    const existingChildDirectoriesMap = { };
-    existingChildDirectoriesMap[path] = existingFiles;
-
+  it("returns site's exisiting files if action.files is missing and site has files", () => {
     const siteOne = {
       id: "siteToKeep",
-      oldData: true,
-      childDirectoriesMap: existingChildDirectoriesMap
+      files: [{path: 'test'}]
     };
 
     const siteTwo = {
-      id: "anotherSiteToKeep",
-      oldData: true
+      id: "anotherSiteToKeep"
     };
 
     const existingSites = [ siteOne, siteTwo ];
 
-    const files = [ "whatever", "punk",  "huh?" ];
-
     const actual = fixture(existingSites, {
-      type: SITE_CHILD_CONTENT_RECEIVED,
-      siteId: "siteToKeep",
-      files: files,
-      path: path
+      type: SITE_FILES_RECEIVED,
+      siteId: "siteToKeep"
     });
 
     const updatedSiteOne = {
       id: "siteToKeep",
-      oldData: true,
-      childDirectoriesMap: {
-        "/go/here/or/not": files
-      }
-    };
-
-    expect(actual).to.deep.equal([ updatedSiteOne, siteTwo ]);
-  });
-
-  it("sets a site's 'childDirectoriesMap' property to map the action's path to an empty array when given a child content received action and the new site's id is found... and the action doesn't have a files attribute", () => {
-    const siteOne = {
-      id: "siteToKeep",
-      oldData: true
-    };
-
-    const siteTwo = {
-      id: "anotherSiteToKeep",
-      oldData: true
-    };
-
-    const existingSites = [ siteOne, siteTwo ];
-
-    const path = "/go/here/or/not";
-
-    const actual = fixture(existingSites, {
-      type: SITE_CHILD_CONTENT_RECEIVED,
-      siteId: "siteToKeep",
-      path: path
-    });
-
-    const updatedSiteOne = {
-      id: "siteToKeep",
-      oldData: true,
-      childDirectoriesMap: {
-        "/go/here/or/not": []
-      }
+      files: [{path: 'test'}]
     };
 
     expect(actual).to.deep.equal([ updatedSiteOne, siteTwo ]);
@@ -689,7 +654,7 @@ describe("sitesReducer", () => {
     const fileContent = "yo dude, here's some content";
     const pathOne = "/here/is/path/one";
     const pathTwo = "/here/is/path/two";
-    
+
     const fileOne = {
       sha: fileSha,
       path: pathOne,


### PR DESCRIPTION

* Nested file paths resolve correctly
* Refactored SITE_CHILD_CONTENTS_RECEIVED and the directory map to SITE_FILES_RECEIVED and flat array
* Fixed tests
* First attempt at standard data fetching pattern -- calls actions from both componentDidMount and ComponentWillReceiveProps to handle cases where component is loaded directly and navigated to.