### PR TITLE
Compare paths, not number of files contained, to decide when to reload files for a site's path

### DIFF
--- a/assets/app/components/site/Pages/pagesContainer.js
+++ b/assets/app/components/site/Pages/pagesContainer.js
@@ -1,8 +1,8 @@
 import React from 'react';
-
-import PageList from "./pageList";
+import isEqual from 'lodash.isequal';
+import PageList from './pageList';
 import PageListItem from './pageListItem';
-import NavigationJsonPageList from "./navigationJsonPageList";
+import NavigationJsonPageList from './navigationJsonPageList';
 
 import siteActions from '../../../actions/siteActions';
 
@@ -21,10 +21,12 @@ class Pages extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const { params, site } = nextProps;
+    const { params: oldParams, site: oldSite } = this.props;
     const nextFiles = getFilesByPath(site.files, getPath(params));
-    const files = getFilesByPath(site.files, getPath(params));
+    const files = getFilesByPath(oldSite.files, getPath(oldParams));
+    const filesAreTheSame = isEqual(files, nextFiles);
 
-    if (files.length && nextFiles.length === files.length) return;
+    if (filesAreTheSame) return;
 
     fetchFiles(site, params);
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "html2markdown": "^1.1.0",
     "include-all": "~0.1.3",
     "localtunnel": "^1.7.0",
+    "lodash.isequal": "^4.4.0",
     "markdown": "^0.5.0",
     "markdown-it": "^4.4.0",
     "mime": "^1.3.4",


### PR DESCRIPTION
Deep-compare all of the files listed in the old and new properties to decide if we should trigger a fetch instead of using the count of files as an equality proxy.