### PR TITLE
Use autopilot to deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+before_deploy:
+  - export PATH=$HOME:$PATH
+  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0"
+  - tar xzvf $HOME/cf.tgz -C $HOME
+  - travis_retry cf install-plugin autopilot -f -r CF-Community
 deploy:
   provider: script
   script: scripts/deploy-travis.sh

--- a/scripts/deploy-travis.sh
+++ b/scripts/deploy-travis.sh
@@ -2,13 +2,10 @@
 
 set -e
 
-wget https://s3.amazonaws.com/go-cli/releases/v6.12.4/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb
-
-rm temp.deb
-
 cf api $CF_API
-cf login --u $CF_USERNAME --p $CF_PASSWORD --o $CF_ORGANIZATION --s $CF_SPACE
+cf auth $CF_USERNAME $CF_PASSWORD && cf target -o $CF_ORGANIZATION -s $CF_SPACE
 
-./scripts/deploy.sh $CF_APP
+# Run autopilot plugin
+cf zero-downtime-push $CF_APP -f manifest.yml -p .
 
 cf logout


### PR DESCRIPTION
Using before_deploy values lifted from the openfec project
and using the autopilot plugin to deploy automatically to
cloud.gov from travis