### PR TITLE
fixes issue where code compiles `this` to undefined

### DIFF
--- a/assets/app/components/site/editor/editorContainer.js
+++ b/assets/app/components/site/editor/editorContainer.js
@@ -30,15 +30,6 @@ const alertAndRedirect = (message, uri) => {
   routeActions.redirect(uri);
 };
 
-const openPRWithHead = (branchName, site) => {
-  return this.submitFile(branchName).then(() => {
-    return siteActions.createPR(site, branchName, site.defaultBranch);
-  }).then(() => {
-    routeActions.redirect(`/sites/${site.id}`);
-  });
-}
-
-
 let insertFn;
 
 class Editor extends React.Component {
@@ -157,6 +148,14 @@ class Editor extends React.Component {
     return { content, path, message };
   }
 
+  openPRWithHead(branchName, site) {
+    return this.submitFile(branchName).then(() => {
+      return siteActions.createPR(site, branchName, site.defaultBranch);
+    }).then(() => {
+      routeActions.redirect(`/sites/${site.id}`);
+    });
+  }
+
   commitOrPR() {
     const { site } = this.props;
     const { path } = this.state;
@@ -168,7 +167,7 @@ class Editor extends React.Component {
     }
 
     // All federalist draft branch PRs are opened against master
-    openPRWithHead(draftBranch.name, site);
+    this.openPRWithHead(draftBranch.name, site);
   }
 
   submitFile(branch = this.props.site.defaultBranch) {


### PR DESCRIPTION

Seems like babel is forcing references to `this` to be undefined if the method doesn't live within a class or fat arrow function. Using `.call` and passing the `this` context the function should execute in was causing the 'save & submit' button to break.

The function in question had to be moved back into the class to work as expected.