### PR TITLE
skips creating a pr if one is already open for the draft in question

### DIFF
--- a/assets/app/actions/siteActions.js
+++ b/assets/app/actions/siteActions.js
@@ -143,7 +143,17 @@ export default {
   },
 
   createPR(site, head, base) {
-    return github.createPullRequest(site, head, base).then((pr) => {
+    return github.fetchPullRequests(site).then((openPrs) => {
+      const existingPr = openPrs.find((pr) => {
+        return pr.head.ref === head;
+      });
+
+      if (!existingPr) {
+        return github.createPullRequest(site, head, base);
+      }
+
+      return existingPr;
+    }).then((pr) => {
       return github.mergePullRequest(site, pr);
     }).then(() => {
       return github.deleteBranch(site, head);


### PR DESCRIPTION

* In the case of an existing PR, return and use it instead of attempting to create a new one