### PR TITLE
Load session secret from env in staging/production

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,16 +1,18 @@
 var AWS = require('aws-sdk'),
+    env = require("../services/environment")
     cfenv = require('cfenv'),
     appEnv = cfenv.getAppEnv(),
     dbURL = appEnv.getServiceURL('federalist-database'),
     AWSCreds = appEnv.getServiceCreds('federalist-aws-user'),
     redisCreds = appEnv.getServiceCreds('federalist-redis');
-console.log('OK I GUESS I AM RUNNING\n\n\n');
+
 var _ = require('underscore');
 var session = {
   cookie: {
     secure: true
   },
-  proxy: true
+  proxy: true,
+  secret: env.FEDERALIST_SESSION_SECRET
 };
 
 /**

--- a/config/env/staging.js
+++ b/config/env/staging.js
@@ -1,4 +1,5 @@
 var AWS = require('aws-sdk'),
+    env = require("../services/environment")
     cfenv = require('cfenv'),
     appEnv = cfenv.getAppEnv(),
     dbURL = appEnv.getServiceURL('federalist-staging-rds'),
@@ -11,7 +12,8 @@ var session = {
   cookie: {
     secure: true
   },
-  proxy: true
+  proxy: true,
+  secret: env.FEDERALIST_SESSION_SECRET
 };
 
 /**


### PR DESCRIPTION
This commit adds code to the environment files that loads the session secret from the cloud foundry environment instead of using the hardcoded secret in `session.js`.

In development, the hardcoded secret will still be used.

I've already updated the user provided service in govcloud staging so there shouldn't be any configuration necessary in cloud foundry before this can be merged.