### PR TITLE
Site API request specs

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -28,7 +28,7 @@ module.exports = {
 
       Site.findOne({
         id: site.id
-      }).populate('builds').exec(function(err, site) {
+      }).populate('builds').populate("users").exec(function(err, site) {
         if (err) return res.serverError(err);
 
         // Delete the build that runs automatically when the site is created

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -141,6 +141,7 @@ describe("Build API", () => {
           .set("Cookie", cookie)
           .expect(200)
       }).then(response => {
+        expect(response.body).to.be.a("array")
         expect(response.body).to.be.empty
         done()
       })

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -1,0 +1,32 @@
+describe("Site API", () => {
+  describe("GET /v0/site", () => {
+    it("should require authentication")
+    it("should render a list of sites associated with the user")
+    it("should not render any sites not associated with the user")
+  })
+
+  describe("GET /v0/site/:id", () => {
+    it("should require authentication")
+    it("should redner a JSON representation of the site")
+    it("should respond with a 401 if the user is not associated with the site")
+  })
+
+  describe("DELETE /v0/site/:id", () => {
+    it("should require authentication")
+    it("should allow a user to delete a site associated with their account")
+    it("should not allow a user to delete a site not associated with their account")
+  })
+
+  describe("PUT /v0/site/:id", () => {
+    it("should require authentication")
+    it("should allow a user to update a site associated with their account")
+    it("should not allow a user to update a site not associated with their account")
+    it("should trigger a rebuild of the site")
+  })
+
+  describe("POST /v0/site/clone", () => {
+    it("should require authentication")
+    it("should create a new site record for the given repository")
+    it("should trigger a build that pushes the source repo to the destiantion repo")
+  })
+})

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -1,31 +1,103 @@
+var expect = require("chai").expect
+var request = require("supertest-as-promised")
+var sinon = require("sinon")
+var factory = require("../support/factory")
+
 describe("Site API", () => {
+  beforeEach(() => {
+    sinon.stub(GitHub, "setWebhook", (_, __, done) => done())
+  })
+
+  afterEach(() => {
+    GitHub.setWebhook.restore()
+  })
+
   describe("GET /v0/site", () => {
-    it("should require authentication")
+    it("should require authentication", done => {
+      factory(Build).then(build => {
+        return request("http://localhost:1337")
+          .get("/v0/site")
+          .expect(403)
+      }).then(response => {
+        expect(response.body).to.be.empty
+        done()
+      })
+    })
+
     it("should render a list of sites associated with the user")
     it("should not render any sites not associated with the user")
   })
 
   describe("GET /v0/site/:id", () => {
-    it("should require authentication")
+    it("should require authentication", done => {
+      factory(Build).then(build => {
+        return request("http://localhost:1337")
+          .get(`/v0/site/${build.id}`)
+          .expect(403)
+      }).then(response => {
+        expect(response.body).to.be.empty
+        done()
+      })
+    })
+
     it("should redner a JSON representation of the site")
     it("should respond with a 401 if the user is not associated with the site")
   })
 
   describe("DELETE /v0/site/:id", () => {
-    it("should require authentication")
+    it("should require authentication", done => {
+      factory(Build).then(build => {
+        return request("http://localhost:1337")
+          .delete(`/v0/site/${build.id}`)
+          .expect(403)
+      }).then(response => {
+        expect(response.body).to.be.empty
+        done()
+      })
+    })
+
     it("should allow a user to delete a site associated with their account")
     it("should not allow a user to delete a site not associated with their account")
   })
 
   describe("PUT /v0/site/:id", () => {
-    it("should require authentication")
+    it("should require authentication", done => {
+      factory(Build).then(build => {
+        return request("http://localhost:1337")
+          .put(`/v0/site/${build.id}`, {
+            defaultBranch: "master"
+          })
+          .expect(403)
+      }).then(response => {
+        expect(response.body).to.be.empty
+        done()
+      })
+    })
+
     it("should allow a user to update a site associated with their account")
     it("should not allow a user to update a site not associated with their account")
     it("should trigger a rebuild of the site")
   })
 
   describe("POST /v0/site/clone", () => {
-    it("should require authentication")
+    it("should require authentication", done => {
+      factory(Build).then(build => {
+        return request("http://localhost:1337")
+          .post(`/v0/site/clone`, {
+            sourceOwner: "18f",
+            sourceRepo: "example-template",
+            destinationOrg: "partner-org",
+            destinationRepo: "partner-site",
+            destinationBranch: "master",
+            engine: "jekyll"
+          })
+          .expect(403)
+      }).then(response => {
+        expect(response.body).to.be.empty
+        done()
+      })
+    })
+
     it("should create a new site record for the given repository")
     it("should trigger a build that pushes the source repo to the destiantion repo")
   })

--- a/test/api/support/factory.js
+++ b/test/api/support/factory.js
@@ -28,12 +28,21 @@ var buildAttributes = (overrides) => {
   }, overrides)
 }
 
-var siteAttributes = (overrides) => Object.assign({
-  owner: "user",
-  repository: "site",
-  engine: "jekyll",
-  users: []
-}, overrides)
+var siteAttributes = (overrides) => {
+  overrides = overrides || {}
+  var users = overrides["users"]
+
+  if (users === undefined) {
+    users = Promise.all([factory(User)])
+  }
+
+  return Object.assign({
+    owner: "user",
+    repository: "site",
+    engine: "jekyll",
+    users: users
+  }, overrides)
+}
 
 var userAttributes = (overrides) => {
   var username = generateUniqueUserName()


### PR DESCRIPTION
This commit adds request specs for the Site API's action

The actions that are tests are:

- find
- findOne
- update
- destroy
- clone

We are electing not to test the `fork` action since it does not seem to be implemented anywhere outside of the policies. We also aren't testing the `lock` and `unlock` actions since they are buggy and therefore not used for anything.