### PR TITLE
Stop redirects on edit page if page is new, put page in pages

### DIFF
--- a/assets/app/components/app.js
+++ b/assets/app/components/app.js
@@ -1,10 +1,6 @@
-
 import React from 'react';
-import { routeTypes } from '../constants';
 import store from '../store';
-
 import alertActions from '../actions/alertActions';
-
 import Header from './header';
 
 class App extends React.Component {

--- a/assets/app/components/site/editor/editorContainer.js
+++ b/assets/app/components/site/editor/editorContainer.js
@@ -62,6 +62,11 @@ class Editor extends React.Component {
   }
 
   componentDidMount() {
+    // Bail if we are on a new page; there wont be any drafts
+    if (this.props.route.isNewPage) {
+      return;
+    }
+
     // trigger the fetch file content action for the case
     // when a user first loads this view. That could be
     // a changing of the route to a site for the first time
@@ -151,7 +156,7 @@ class Editor extends React.Component {
     }
 
     if (this.props.route.isNewPage) {
-      path = `${path}.md`;
+      path = `pages/${path}.md`;
     }
 
     return { content, path, message };

--- a/assets/app/util/branchFormatter.js
+++ b/assets/app/util/branchFormatter.js
@@ -5,7 +5,7 @@ export const formatDraftBranchName = (path) => {
 }
 
 export const pathHasDraft = (path, branches) => {
-  return !!getDraft(path, branches);
+  return Boolean(getDraft(path, branches));
 }
 
 export const getDraft = (path = '', branches = []) => {


### PR DESCRIPTION
* Don't attempt to redirect when user is creating a new page
* Put newly created pages in the `pages` directory
* Call `Boolean` to make code less obtuse