### PR TITLE
Update WebSocket module to patch for DOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "underscore": "^1.8.3",
     "validator": "^3.39.0",
     "whatwg-fetch": "^1.0.0",
+    "ws": "~1.1.1",
     "yamljs": "^0.2.8"
   },
   "scripts": {


### PR DESCRIPTION
A vulnerability existed in the ws module at version 1.1.0.
This commit updates the module to 1.1.1 to get the fix.

ref #609

More info on the vulnerability here: https://snyk.io/vuln/npm:ws:20160624