### PR TITLE
Mock SQS in test environment

### DIFF
--- a/config/env/test.js
+++ b/config/env/test.js
@@ -1,5 +1,22 @@
+var AWS = require('aws-sdk')
+
 module.exports = {
   build: {
-    token: "123abc"
-  }
+    token: "123abc",
+    awsBuildKey: "123abc",
+    awsBuildSecret: "456def",
+    s3Bucket: "s3-bucket",
+    awsRegion: "us-gov-west-1",
+    sqsQueue: "https://sqs.us-east-1.amazonaws.com/123abc/456def"
+  },
+  SQS: new AWS.SQS({
+    accessKeyId: "123abc",
+    secretAccessKey: "456def",
+    region: 'us-east-1'
+  }),
+  S3: new AWS.S3({
+    accessKeyId: "123abc",
+    secretAccessKey: "456def",
+    region: "us-gov-west-1"
+  })
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "license": "Public Domain",
   "devDependencies": {
     "autoprefixer": "^6.5.1",
+    "aws-sdk-mock": "^1.5.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",

--- a/test/api/bootstrap.test.js
+++ b/test/api/bootstrap.test.js
@@ -1,9 +1,13 @@
-process.env.TEST_AUTH = 1; // Use alternative auth to avoid interactive user auth
+var AWS = require('aws-sdk-mock')
+var Sails = require('sails')
 
-var Sails = require('sails'),
-  sails;
+var sails
 
 before(function(done) {
+  AWS.mock('SQS', 'sendMessage', function (params, callback) {
+    callback(null, {})
+  })
+
   Sails.lift({
     // configuration for testing purposes
     // Use memory for data store
@@ -20,4 +24,5 @@ before(function(done) {
 after(function(done) {
   // here you can clear fixtures, etc.
   sails.lower(done);
+  AWS.restore('SQS')
 });


### PR DESCRIPTION
This commit mocks the SQS sendMessage function during testing.
This prevents messages from being sent to SQS if the local environment is configured to build on a live deployment of SQS.

This commit also configures the test env so that it will use the SQS queue instead of the local queue which mirrors staging and productions.