### PR TITLE
Add minified uswds css to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ assets/js/bundle.js
 # USWDS assets
 assets/images/uswds
 assets/styles/uswds.css
+assets/styles/uswds.min.css
 assets/styles/google-fonts.css
 assets/fonts/merriweather*
 assets/fonts/sourcesanspro*


### PR DESCRIPTION
This code is generated by the `uswds:styles` npm script and does not need to be tracked.