### PR TITLE
Fix webhook issue that was preventing site creation

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -28,7 +28,7 @@ module.exports = {
       return res.badRequest('Please specify a repository owner and name.')
     }
 
-    req.body.users = [user]
+    req.body.users = [user.id]
 
     async.series([
       checkPermissions,

--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -94,7 +94,7 @@ module.exports = {
         if (ghErr === hookMessage) return done();
         try { ghErr = JSON.parse(err.message).message; } catch(e) {}
         if (ghErr === noAccessMessage) return done('You do not have admin access to this repository');
-        if (JSON.parse(err.message)) return done(JSON.parse(err.message));
+        if (err.message) return done(err.message);
         return done(err);
       }
       done();


### PR DESCRIPTION
This commit fixes an issue creating webhooks that was occurring when users attempted to add repository based sites. The issues occurred because `GitHub.setWebhook(site, user, done)` was being passed a user object instead of an integer for the user's id.

This commit fixes the issues and adds tests to verify this works as expected in the future.