### PR TITLE
Upgrade sails, grunt, and socket.io-redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "ejs": "~0.8.4",
     "express-force-ssl": "^0.2.12",
     "github": "^0.2.4",
-    "grunt": "0.4.2",
-    "grunt-cli": "^0.1.13",
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
     "include-all": "~0.1.3",
     "keymirror": "^0.1.1",
     "lodash.isequal": "^4.4.0",
@@ -33,11 +33,11 @@
     "rc": "~0.5.0",
     "request": "^2.61.0",
     "s3": "^4.4.0",
-    "sails": "~0.11.0-rc8",
-    "sails-db-migrate": "^0.7.0",
+    "sails": "~0.12.9",
+    "sails-db-migrate": "^1.4.0",
     "sails-disk": "~0.10.0",
     "sails-postgresql": "^0.10.15",
-    "socket.io-redis": "^0.1.4",
+    "socket.io-redis": "^1.0.0",
     "underscore": "^1.8.3",
     "validator": "^3.39.0",
     "whatwg-fetch": "^1.0.0",
@@ -120,7 +120,7 @@
     "watchify": "^3.2.2"
   },
   "engines": {
-    "node": "4.2.3",
-    "npm": "2.15.9"
+    "node": "6.9.0",
+    "npm": "3.10.8"
   }
 }


### PR DESCRIPTION
This commit updates the following packages to remediate vulneratbilites:

- sails@0.11.0 -> sails@0.12.9
  - [handlebars@3.0.3 -> handlebars@4.0.6](https://snyk.io/vuln/npm:handlebars:20151207)
  - [hawk@1.1.1 -> hawk@3.1.3](https://snyk.io/vuln/npm:hawk:20160119)
  - [minimatch@0.2.14 -> minimatch@3.0.3](https://snyk.io/vuln/npm:minimatch:20160620)
  - [negotiator@0.5.3 -> skipper@0.6.2](https://snyk.io/vuln/npm:negotiator:20160616)
  - [request@2.40.0 -> request@2.68.0](https://snyk.io/vuln/npm:request:20160119)
  - [uglify-js@2.3.6 -> uglify-js@2.6.0](https://snyk.io/vuln/npm:uglify-js:20150824)
- grunt@0.4.2 -> grunt@1.0.1
  - [minimatch@0.2.14 -> minimatch@3.0.3](https://snyk.io/vuln/npm:minimatch:20160620)
- grunt-cli@0.1.13 -> grunt-cli@1.2.0
  - [minimatch@0.3.0 -> minimatch@3.0.2](https://snyk.io/vuln/npm:minimatch:20160620)
- socket.io-redis@0.1.4 -> socket.io-redis@1.0.0
  - [ms@0.6.2 -> ms@0.7.1](https://snyk.io/vuln/npm:ms:20151024)

This commit also bumps the node and npm versions which makes `npm install` run a bit snappier and will let us use some of the more modern features available in node v6.

ref #611
ref #608