### PR TITLE
Refactor webhook controller

### DIFF
--- a/api/controllers/WebhookController.js
+++ b/api/controllers/WebhookController.js
@@ -1,78 +1,81 @@
-// Validation from https://github.com/rvagg/github-webhook-handler
-// Copyright (c) 2014 Rod Vagg, MIT License
-
-var crypto = require('crypto');
+var crypto = require('crypto')
 
 module.exports = {
-
   github: function(req, res) {
-    var sig = req.headers['x-hub-signature'],
-        event = req.headers['x-github-event'],
-        id = req.headers['x-github-delivery'],
-        secret = sails.config.webhook.secret,
-        payload = req.body;
-
-    // Ignore non-push events
-    if (event !== 'push') return res.ok();
-
-    // Validate headers
-    if (!sig) return res.badRequest('No X-Hub-Signature found on request');
-    if (!event) return res.badRequest('No X-Github-Event found on request');
-    if (!id) return res.badRequest('No X-Github-Delivery found on request');
-
-    // Validate secret signature
-    if (sig !== signBlob(secret, JSON.stringify(payload))) {
-      return res.badRequest('X-Hub-Signature does not match blob signature');
-    }
-
-    // Send OK status to webhook
-    res.ok();
-
-    // Ignore empty commits and deleted branches
-    if (!payload.commits || !payload.commits.length) return;
-
-    // Log request payload (only if verbose logging is enabled)
-    sails.log.verbose('Received GitHub webhook payload: ', payload);
-
-    // Set up a new build model
-    async.parallel({
-
-      // Find a matching user
-      user: function(next) {
-        sails.log.verbose('Getting user from payload');
-        var record = { username: payload.sender.login };
-        User.findOrCreate(record, record, next);
-      },
-
-      // Find a matching site
-      site: function(next) {
-        sails.log.verbose('getting site for repo: ', payload.repository);
-        Site.findOne({
-          owner: payload.repository.full_name.split('/')[0],
-          repository: payload.repository.full_name.split('/')[1]
-        }, next);
+    signWebhookRequest(req).then(() => {
+      if (req.body.commits && req.body.commits.length > 0) {
+        return createBuildForWebhookRequest(req)
       }
-
-    }, function(err, data) {
-      sails.log.verbose('callback called');
-      // Abort if no matching user or site found
-      if (err) return sails.log.warn('Unable to set up build: ', err);
-
-      // Set branch
-      data.branch = payload.ref.replace('refs/heads/', '');
-      sails.log.verbose('about to create a build using site: ', data.site);
-      // Create a new build
-      Build.create(data, function(err) {
-        sails.log.verbose('creating a build?', err);
-        if (err) return sails.log.warn('Unable to create build: ', err);
-      });
-
-    });
-
+    }).then(build => {
+      if (build) {
+        res.ok(build)
+      } else {
+        res.ok("No new commits found. No build scheduled.")
+      }
+    }).catch(err => {
+      if (err.message) {
+        res.badRequest(err.message)
+      } else {
+        sails.log.error(err)
+        res.badRequest()
+      }
+    })
   }
+}
 
-};
+var signWebhookRequest = (request) => {
+  return new Promise((resolve, reject) => {
+    var webhookSecret = sails.config.webhook.secret
+    var requestBody = JSON.stringify(request.body)
 
-function signBlob (key, blob) {
-  return 'sha1=' + crypto.createHmac('sha1', key).update(blob).digest('hex');
+    var signature = request.headers["x-hub-signature"]
+    var signedRequestBody = signBlob(webhookSecret, requestBody)
+
+    if (!signature) {
+      reject(new Error("No X-Hub-Signature found on request"))
+    } else if (signature !== signedRequestBody) {
+      reject(new Error("X-Hub-Signature does not match blob signature"))
+    } else {
+      resolve(true)
+    }
+  })
+}
+
+var signBlob = (key, blob) => {
+  return 'sha1=' + crypto.createHmac('sha1', key).update(blob).digest('hex')
+}
+
+var createBuildForWebhookRequest = (request) => {
+  var user = findUserForWebhookRequest(request)
+  var site = findSiteForWebhookRequest(request)
+
+  return Promise.props({ user, site }).then(buildParams => {
+    buildParams.branch = request.body.ref.replace('refs/heads/', '')
+    return Build.create(buildParams)
+  })
+}
+
+var findUserForWebhookRequest = (request) => {
+  var username = request.body.sender.login
+
+  return User.findOrCreate({ username }).then(user => {
+    if (!user) {
+      throw new Error(`Unable to find or create Federalist user with username ${username}`)
+    } else {
+      return user
+    }
+  })
+}
+
+var findSiteForWebhookRequest = (request) => {
+  var owner = request.body.repository.full_name.split('/')[0]
+  var repository = request.body.repository.full_name.split('/')[1]
+
+  return Site.findOne({ owner, repository }).then(site => {
+    if (!repository) {
+      throw new Error(`Unable to find Federalist site with ${owner}/${repository}`)
+    } else {
+      return site
+    }
+  })
 }


### PR DESCRIPTION
This commit refactors the code in the WebhookController to make a couple of changes:

- Respond with an error if the user that triggered the webhook does not exist in Federalist
- Respond with an error if the site the webhook was triggered for does not exist in Federalist
- Don't respond with a 200 OK until a build has been created
- Break out some of the logic and refactor the code to make it more readable

ref #627