### PR TITLE
Remove unused routes from policies

### DIFF
--- a/config/policies.js
+++ b/config/policies.js
@@ -68,15 +68,11 @@ module.exports.policies = {
     'find': ['passport', 'sessionAuth', 'filterCurrentUser'],
     'findOne': ['passport', 'sessionAuth', 'filterCurrentUser'],
     'clone': ['passport', 'sessionAuth'],
-    'fork': ['passport', 'sessionAuth'],
-    'lock': ['passport', 'sessionAuth'],
-    'unlock': ['passport', 'sessionAuth'],
     'update': ['passport', 'sessionAuth', 'filterCurrentUser']
   },
 
   UserController: {
     'findOne': ['passport', 'sessionAuth', 'filterSelfOnly'],
-    'populate': ['passport', 'sessionAuth', 'filterSelfOnly'],
     'usernames': ['passport', 'sessionAuth'],
     'add-site': ['passport', 'sessionAuth'],
     'me': ['passport', 'sessionAuth']


### PR DESCRIPTION
This commit removes routes from the policies that aren't used. These include:

- Site.fork
- Site.lock
- Site.unlock
- User.populate

ref #597