### PR TITLE
Sort site builds array in build log

### DIFF
--- a/assets/app/components/site/siteLogs.js
+++ b/assets/app/components/site/siteLogs.js
@@ -10,6 +10,12 @@ const getUsername = (site, id) => {
   return user.username;
 };
 
+const sortSiteBuilds = (site) => {
+  return site.builds.sort((a, b) => {
+    return new Date(b.createdAt) - new Date(a.createdAt)
+  })
+}
+
 const SiteLogs = ({site}) =>
   <table className="usa-table-borderless build-log-table">
     <thead>
@@ -22,7 +28,7 @@ const SiteLogs = ({site}) =>
       </tr>
     </thead>
     <tbody>
-      {site.builds.reverse().map((build) => {
+      {sortSiteBuilds(site).map((build) => {
         const rowClass = `usa-alert-${build.state}`;
         const username = getUsername(site, build.user);
 


### PR DESCRIPTION
The build log was reversing the site's array of builds in place. This meant every time `render` was called on the component it would reverse the order of the list of builds.

This commit fixes the issue by using the `sort` method to make sure that:

1. A copy of the build array is modified
2. The build array is always sorted correctly regardless of how the API renders it (since Sails does not promise to render a sorted array)

ref #644