### PR TITLE
Give GitHub OAuth token write:repo_hooks scope

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -6,7 +6,7 @@ module.exports.passport = {
       clientID: env.GITHUB_CLIENT_ID || 'not_set',
       clientSecret: env.GITHUB_CLIENT_SECRET || 'not_set',
       callbackURL: env.GITHUB_CLIENT_CALLBACK_URL || 'not_set',
-      scope: ['user', 'repo']
+      scope: ['user', 'repo', 'write:repo_hooks']
     },
     organizations: [
       6233994,  // 18f


### PR DESCRIPTION
This commit adds a scope to the GitHub OAuth token so that it can create webhooks on repositories.