### PR TITLE
Correct spelling of repo:write_hook scope

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -6,7 +6,7 @@ module.exports.passport = {
       clientID: env.GITHUB_CLIENT_ID || 'not_set',
       clientSecret: env.GITHUB_CLIENT_SECRET || 'not_set',
       callbackURL: env.GITHUB_CLIENT_CALLBACK_URL || 'not_set',
-      scope: ['user', 'repo', 'write:repo_hooks']
+      scope: ['user', 'repo', 'write:repo_hook']
     },
     organizations: [
       6233994,  // 18f


### PR DESCRIPTION
The `repo:write_hook` scope was misspelled in the previous commit.
This commit fixes the typo.