### PR TITLE
Don't stub `GitHub.registerSite` in integration tests

### DIFF
--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -65,9 +65,10 @@ module.exports = {
   },
 
   registerSite: function(values, done) {
+    const webhookUserId = values.users[0].id || values.users[0]
     async.parallel({
       // Set up GitHub webhook
-      hook: GitHub.setWebhook.bind(this, values, values.users[0])
+      hook: GitHub.setWebhook.bind(this, values, webhookUserId)
     }, function(err, res) {
       // Ignore error if hook already exists; otherwise, return error
       if (err) {

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -6,12 +6,10 @@ var session = require("../support/session")
 
 describe("Build API", () => {
   beforeEach(() => {
-    sinon.stub(Site, "registerSite", (_, done) => done())
     sinon.stub(Site, "startInitialBuild", (_, done) => done())
   })
 
   afterEach(() => {
-    Site.registerSite.restore()
     Site.startInitialBuild.restore()
   })
 

--- a/test/api/requests/webhook.test.js
+++ b/test/api/requests/webhook.test.js
@@ -1,18 +1,9 @@
 var crypto = require('crypto')
 var expect = require("chai").expect
 var request = require("supertest-as-promised")
-var sinon = require("sinon")
 var factory = require("../support/factory")
 
 describe("Webhook API", () => {
-  beforeEach(() => {
-    sinon.stub(GitHub, "setWebhook", (_, __, done) => done())
-  })
-
-  afterEach(() => {
-    GitHub.setWebhook.restore()
-  })
-
   var signWebhookPayload = (payload) => {
     var secret = sails.config.webhook.secret
     var blob = JSON.stringify(payload)

--- a/test/api/support/factory.js
+++ b/test/api/support/factory.js
@@ -1,11 +1,22 @@
 var Promise = require("bluebird")
+var githubAPINocks = require("./githubAPINocks")
 
 var factory = (model, overrides) => {
   var attributes = defaultAttributes[model.globalId].call(undefined, overrides)
 
   return Promise.props(attributes).then(attributes => {
+    prepareForCreation(model, attributes)
     return model.create(attributes)
   })
+}
+
+var prepareForCreation = (model, attributes) => {
+  if (model.globalId === "Site") {
+    githubAPINocks.webhook({
+      owner: attributes.owner,
+      repo: attributes.repository,
+    })
+  }
 }
 
 var buildAttributes = (overrides) => {

--- a/test/api/unit/models/Build.test.js
+++ b/test/api/unit/models/Build.test.js
@@ -1,16 +1,7 @@
 var expect = require("chai").expect
-var sinon = require('sinon')
 var factory = require("../../support/factory")
 
 describe('Build Model', () => {
-  beforeEach(() => {
-    sinon.stub(GitHub, "setWebhook", (_, __, done) => done())
-  })
-
-  afterEach(() => {
-    GitHub.setWebhook.restore()
-  })
-
   describe(".afterCreate(model)", () => {
     it("should send a new build message", done => {
       var oldSendMessage = SQS.sqsClient.sendMessage

--- a/test/api/unit/models/Site.test.js
+++ b/test/api/unit/models/Site.test.js
@@ -23,7 +23,7 @@ describe('Site Model', function() {
         GitHub.setWebhook = setWebhook;
         done();
       });
-      Site.registerSite({ users: [] });
+      Site.registerSite({ users: [1] });
     });
   });
 

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -1,17 +1,7 @@
-//var AWS = require('aws-sdk-mock')
 var expect = require("chai").expect
-var sinon = require("sinon")
 var factory = require("../../support/factory")
 
 describe("SQS", () => {
-  beforeEach(() => {
-    sinon.stub(GitHub, "setWebhook", (_, __, done) => done())
-  })
-
-  afterEach(() => {
-    GitHub.setWebhook.restore()
-  })
-
   describe(".sendBuildMessage(build)", () => {
     it("should send a formatted build message", done => {
       var oldSendMessage = SQS.sqsClient.sendMessage


### PR DESCRIPTION
One of the weaknesses of our integration tests was the fact that they did not cover the GitHub service.
In the integration tests we stubbed the GitHub service's API to prevent it from sending HTTP requests to GitHub which would 404.

This commit fixes that by adding a request mock for the Webhook API endpoint and using that in the specs.

This needs to be used in the factories when one-off sites are created, and in tests where we want to verify that a webhook is created successfully.
It also needs to be used in requests that create Sites.