### PR TITLE
Refactor GitHub service

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -40,11 +40,13 @@ module.exports = {
     });
 
     function checkPermissions(done) {
-      GitHub.checkPermissions(user, owner, repository, function(err, perms) {
-        if (err) return done(err);
-        if (perms && perms.push) return done();
-        done('You do not have write access to this repository');
-      });
+      GitHub.checkPermissions(user, owner, repository).then(permissions => {
+        if (permissions && permissions.push) {
+          done()
+        } else {
+          done("You do not have write access to this repository")
+        }
+      }).catch(done)
     }
 
     function checkSite(done) {

--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -66,24 +66,9 @@ module.exports = {
 
   registerSite: function(values, done) {
     const webhookUserId = values.users[0].id || values.users[0]
-    async.parallel({
-      // Set up GitHub webhook
-      hook: GitHub.setWebhook.bind(this, values, webhookUserId)
-    }, function(err, res) {
-      // Ignore error if hook already exists; otherwise, return error
-      if (err) {
-        var ghErr,
-            hookMessage = 'Hook already exists on this repository',
-            noAccessMessage = 'Not Found';
-        try { ghErr = JSON.parse(err.message).errors[0].message; } catch(e) {}
-        if (ghErr === hookMessage) return done();
-        try { ghErr = JSON.parse(err.message).message; } catch(e) {}
-        if (ghErr === noAccessMessage) return done('You do not have admin access to this repository');
-        if (err.message) return done(err.message);
-        return done(err);
-      }
-      done();
-    });
+    GitHub.setWebhook(values, webhookUserId).then(() => {
+      done()
+    }).catch(done)
   },
 
   startInitialBuild: function(model, done) {

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -72,7 +72,22 @@ const handleWebhookError = (error) => {
 }
 
 module.exports = {
-  setWebhook: function(site, user) {
+  checkPermissions: (user, owner, repository) => {
+    return githubClient(user.githubAccessToken).then(github => {
+      return getRepository(github, {
+        user: owner,
+        repo: repository,
+      })
+    }).then(repository => {
+      if (!repository) {
+        throw new Error("This repository does not exit")
+      } else {
+        return repository.permissions
+      }
+    })
+  },
+
+  setWebhook: (site, user) => {
     return User.findOne(user).then(model => {
       user = model
       return githubClient(user.githubAccessToken)
@@ -93,7 +108,7 @@ module.exports = {
     })
   },
 
-  validateUser: function(accessToken) {
+  validateUser: (accessToken) => {
     var approvedOrgs = sails.config.passport.github.organizations || []
 
     return githubClient(accessToken).then(github => {
@@ -108,20 +123,5 @@ module.exports = {
         throw new Error("Unauthorized")
       }
     })
-  },
-
-  checkPermissions: function(user, owner, repository, done) {
-    return githubClient(user.githubAccessToken).then(github => {
-      return getRepository(github, {
-        user: owner,
-        repo: repository,
-      })
-    }).then(repository => {
-      if (!repository) {
-        done("This repository does not exit")
-      } else {
-        done(null, repository.permissions)
-      }
-    }).catch(done)
   },
 }

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -1,26 +1,46 @@
-/*
- * Service for interfacing with GitHub
- */
-var url = require('url'),
-    Client = require('github'),
-    github = new Client({ version: '3.0.0' });
+const Github = require("github")
+
+const getOrganizations = (github) => {
+  return new Promise((resolve, reject) => {
+    github.user.getOrgs({}, function(err, organizations) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(organizations)
+      }
+    })
+  })
+}
+
+const getRepository = (github, options) => {
+  return new Promise((resolve, reject) => {
+    github.repos.get(options, function(err, repo) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(repo)
+      }
+    })
+  })
+}
+
+const githubClient = (accessToken) => {
+  return new Promise((resolve, reject) => {
+    let client = new Github({ version: "3.0.0" })
+    client.authenticate({
+      type: 'oauth',
+      token: accessToken
+    })
+    resolve(client)
+  })
+}
 
 module.exports = {
-
-  /*
-   * Set a webhook on a repository
-   * @param {Site} site model to apply the webhook
-   * @param {Function} callback function
-   */
   setWebhook: function(site, user, done) {
-    User.findOne(user).then(user => {
-      // Authenticate request with user's oauth token
-      github.authenticate({
-        type: 'oauth',
-        token: user.githubAccessToken
-      });
-
-      // Create the webhook for the site repository
+    return User.findOne(user).then(model => {
+      user = model
+      return githubClient(user.githubAccessToken)
+    }).then(github => {
       github.repos.createHook({
         user: site.owner,
         repo: site.repository,
@@ -32,64 +52,40 @@ module.exports = {
           content_type: 'json'
         }
       }, done)
-    })
+    }).catch(done)
   },
 
-  /*
-   * Validate that a user is part of an approved Organization
-   * @param {object} values to become a user model
-   * @param {Function} callback function
-   */
   validateUser: function(accessToken) {
-    var approved = sails.config.passport.github.organizations || [];
-    if (process.env.NODE_ENV === 'test' && process.env.FEDERALIST_TEST_ORG) {
-      approved.push(parseInt(process.env.FEDERALIST_TEST_ORG));
-    }
+    var approvedOrgs = sails.config.passport.github.organizations || []
 
-    // Authenticate request with user's oauth token
-    github.authenticate({
-      type: 'oauth',
-      token: accessToken
-    });
+    return githubClient(accessToken).then(github => {
+      return getOrganizations(github)
+    }).then(organizations => {
+      var usersApprovedOrgs = _(organizations)
+        .pluck('id')
+        .intersection(approvedOrgs)
+        .value()
 
-    return new Promise((resolve, reject) => {
-      // Get user's organizations
-      github.user.getOrgs({}, function(err, organizations) {
-        if (err) return reject(new Error(err.message));
-
-        // Do the user's organizations in any on the approved list?
-        var hasApproval = _(organizations)
-              .pluck('id')
-              .intersection(approved)
-              .value().length > 0;
-        if (hasApproval) return resolve();
-        reject(new Error('Unauthorized'));
-      });
+      if (usersApprovedOrgs.length <= 0) {
+        throw new Error("Unauthorized")
+      }
     })
   },
 
-  /*
-   * Check user permissions
-   * @param {object} user model
-   * @param {string} repository owner
-   * @param {string} repository name
-   * @param {Function} callback function
-   */
   checkPermissions: function(user, owner, repository, done) {
-    // Authenticate request with user's oauth token
-    github.authenticate({
-     type: 'oauth',
-     token: user.githubAccessToken,
-    });
-
-    // Retrieve the permissions for the repository
-    github.repos.get({
-     user: owner,
-     repo: repository
-    }, function(err, repo) {
-     if (err) return done('Unable to access the repository');
-     if (!repo) return done('The repository does not exist');
-     return done(null, repo.permissions);
-    });
-  }
-};
+    return githubClient(user.githubAccessToken).then(github => {
+      return getRepository(github, {
+        user: owner,
+        repo: repository,
+      })
+    }).then(repository => {
+      if (!repository) {
+        done("This repository does not exit")
+      } else {
+        done(null, repository.permissions)
+      }
+    }).catch(err => {
+      done(err)
+    })
+  },
+}

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -54,10 +54,10 @@ const handleWebhookError = (error) => {
   let githubError
 
   try {
-    githubError = JSON.parse(err.message).errors[0].message
+    githubError = JSON.parse(error.message).errors[0].message
   } catch(e) {
     try {
-      githubError = JSON.parse(err.message).message
+      githubError = JSON.parse(error.message).message
     } catch(e) {}
   }
 
@@ -79,11 +79,7 @@ module.exports = {
         repo: repository,
       })
     }).then(repository => {
-      if (!repository) {
-        throw new Error("This repository does not exit")
-      } else {
-        return repository.permissions
-      }
+      return repository.permissions
     })
   },
 

--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -44,20 +44,22 @@ const repo = ({ accessToken, owner, repo, response } = {}) => {
     webhookNock = webhookNock.query(true)
   }
 
-  response = response || 201
-  if (typeof response === "number") {
-    response = [response, {}]
-  } else if (!response[1]) {
-    response[1] = {}
-  }
-
-  return webhookNock.reply(response[0], Object.assign({
+  const typicalResponse = {
     permissions: {
       admin: false,
       push: true,
       pull: true,
-    },
-  }, response[1]))
+    }
+  }
+
+  response = response || 201
+  if (typeof response === "number") {
+    response = [response, typicalResponse]
+  } else if (response[1] === undefined) {
+    response[1] = typicalResponse
+  }
+
+  return webhookNock.reply(...response)
 }
 
 const user = ({ accessToken, githubUserID, username, email } = {}) => {
@@ -76,13 +78,13 @@ const user = ({ accessToken, githubUserID, username, email } = {}) => {
     })
 }
 
-const userOrganizations = ({ accessToken, organizations } = {}) => {
+const userOrganizations = ({ accessToken, organizations, response } = {}) => {
   accessToken = accessToken || "access-token-123abc"
   organizations = organizations || [{ id: 123456 }]
 
   return nock("https://api.github.com")
     .get(`/user/orgs?access_token=${accessToken}`)
-    .reply(200, organizations)
+    .reply(response || 200, organizations)
 }
 
 const webhook = ({ accessToken, owner, repo, response } = {}) => {

--- a/test/api/unit/models/Site.test.js
+++ b/test/api/unit/models/Site.test.js
@@ -22,8 +22,13 @@ describe('Site Model', function() {
         assert(GitHub.setWebhook.called);
         GitHub.setWebhook = setWebhook;
         done();
+        return Promise.resolve();
       });
-      Site.registerSite({ users: [1] });
+      Site.registerSite({
+        users: [1],
+        owner: "someone",
+        repository: "something",
+      }, () => {});
     });
   });
 

--- a/test/api/unit/services/GitHub.test.js
+++ b/test/api/unit/services/GitHub.test.js
@@ -1,0 +1,146 @@
+const expect = require("chai").expect
+const factory = require("../../support/factory")
+const githubAPINocks = require("../../support/githubAPINocks")
+
+describe("GitHub", () => {
+  describe(".checkPermissions(user, owner, repository)", () => {
+    it("should resolve with the users permissions", done => {
+      factory(User).then(user => {
+        githubAPINocks.repo({
+          accessToken: user.accessToken,
+          owner: "repo-owner",
+          repo: "repo-name",
+          response: [200, { permissions: "Repo permissions" }],
+        })
+
+        return GitHub.checkPermissions(user, "repo-owner", "repo-name")
+      }).then(permissions => {
+        expect(permissions).to.equal("Repo permissions")
+        done()
+      })
+    })
+
+    it("should reject if the repository does not exist", done => {
+      factory(User).then(user => {
+        githubAPINocks.repo({
+          accessToken: user.accessToken,
+          owner: "repo-owner",
+          repo: "repo-name",
+          response: [404, { message: "Not Found" }],
+        })
+
+        return GitHub.checkPermissions(user, "repo-owner", "repo-name")
+      }).catch(error => {
+        expect(error).to.not.be.undefined
+        done()
+      })
+    })
+  })
+
+  describe(".setWebhook(site, user)", () => {
+    it("should set a webhook on the repository", done => {
+      let site, user
+
+      factory(User).then(model => {
+        user = model
+        return factory(Site)
+      }).then(model => {
+        site = model
+        githubAPINocks.webhook({
+          accessToken: user.accessToken,
+          owner: site.owner,
+          repo: site.repository,
+          response: 201
+        })
+        return GitHub.setWebhook(site, user.id)
+      }).then(() => {
+        done()
+      })
+    })
+
+    it("should resolve if the webhook already exists", done => {
+      let site, user
+
+      factory(User).then(model => {
+        user = model
+        return factory(Site)
+      }).then(model => {
+        site = model
+        githubAPINocks.webhook({
+          accessToken: user.accessToken,
+          owner: site.owner,
+          repo: site.repository,
+          response: [400, {
+            errors: [{ message: "Hook already exists on this repository" }]
+          }]
+        })
+        return GitHub.setWebhook(site, user.id)
+      }).then(() => {
+        done()
+      })
+    })
+
+    it("should reject if the user does not have admin access to the repository", done => {
+      let site, user
+
+      factory(User).then(model => {
+        user = model
+        return factory(Site)
+      }).then(model => {
+        site = model
+        githubAPINocks.webhook({
+          accessToken: user.accessToken,
+          owner: site.owner,
+          repo: site.repository,
+          response: [404, {
+            message: "Not Found"
+          }]
+        })
+        return GitHub.setWebhook(site, user.id)
+      }).catch(err => {
+        expect(err.message).to.equal("You do not have admin access to this repository")
+        done()
+      })
+    })
+  })
+
+  describe(".validateUser(accessToken)", () => {
+    it("should resolve if the user is on a whitelisted team", done => {
+      githubAPINocks.userOrganizations({
+        accessToken: "123abc",
+        organizations: [{ id: sails.config.passport.github.organizations[0] }],
+      })
+
+      GitHub.validateUser("123abc").then(() => {
+        done()
+      })
+    })
+
+    it("should reject if the user is not on a whitelisted team", done => {
+      const FAKE_INVALID_ORG_ID = 4598345
+
+      githubAPINocks.userOrganizations({
+        accessToken: "123abc",
+        organizations: [{ id: FAKE_INVALID_ORG_ID }],
+      })
+
+      GitHub.validateUser("123abc").catch(err => {
+        expect(err.message).to.equal("Unauthorized")
+        done()
+      })
+    })
+
+    it("should reject if access token is not a valid GitHub access token", done => {
+      const FAKE_INVALID_ORG_ID = 4598345
+
+      githubAPINocks.userOrganizations({
+        accessToken: "123abc",
+        response: 403,
+      })
+
+      GitHub.validateUser("123abc").catch(err => {
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This commit refactors the GitHub service to return Promises instead of using callbacks. This makes the asynchronous logic easier to follow.

This commit also updates the places where the GitHub service is used, in some cases pulling logic that is a concern of the service out of other parts of the app and into the service, and also removing the callback logic.