### PR TITLE
Add "Restart" button the build logs

### DIFF
--- a/api/controllers/BuildController.js
+++ b/api/controllers/BuildController.js
@@ -2,8 +2,43 @@ var decodeb64 = (str) => {
   return new Buffer(str, 'base64').toString('utf8');
 }
 
+const verifyUserIsAuthorizedToRestartBuild = (user, build) => {
+  return User.findOne(user.id).populate("sites").then(user => {
+    const index = user.sites.findIndex(site => site.id === build.site)
+
+    if (index < 0) {
+      const error = new Error("Unauthorized")
+      error.statusCode = 403
+      throw error
+    }
+  })
+}
+
 module.exports = {
-  status: function(req, res) {
+  restart: (req, res) => {
+    let build
+
+    Build.findOne(req.param("id")).then(model => {
+      build = model
+      return verifyUserIsAuthorizedToRestartBuild(req.user, build)
+    }).then(() => {
+      return Build.create({
+        branch: build.branch,
+        site: build.site,
+        user: req.user.id,
+      })
+    }).then(build => {
+      res.json(build)
+    }).catch(err => {
+      if (err.statusCode === 403) {
+        res.forbidden()
+      } else {
+        res.badRequest(err)
+      }
+    })
+  },
+
+  status: (req, res) => {
     var message = decodeb64(req.body.message)
 
     Build.findOne(req.param("id")).then(build => {
@@ -24,5 +59,5 @@ module.exports = {
         sails.log.error(err)
       }
     })
-  }
+  },
 }

--- a/assets/app/actions/actionCreators/buildActions.js
+++ b/assets/app/actions/actionCreators/buildActions.js
@@ -1,10 +1,17 @@
 const buildsReceivedType = "BUILDS_RECEIVED";
+const buildRestartedType = "BUILD_RESTARTED";
 
 const buildsReceived = builds => ({
   type: buildsReceivedType,
   builds
 });
 
+const buildRestarted = build => ({
+  type: buildRestartedType,
+  build
+});
+
 export {
-  buildsReceived, buildsReceivedType
+  buildsReceived, buildsReceivedType,
+  buildRestarted, buildRestartedType,
 };

--- a/assets/app/actions/buildActions.js
+++ b/assets/app/actions/buildActions.js
@@ -2,16 +2,26 @@ import api from '../util/federalistApi';
 import { dispatch } from '../store';
 
 import {
-  buildsReceived as createBuildsReceivedAction
+  buildsReceived as createBuildsReceivedAction,
+  buildRestarted as createBuildRestartedAction,
 } from "./actionCreators/buildActions";
 
 const dispatchBuildsReceivedAction = builds => {
   dispatch(createBuildsReceivedAction(builds));
 };
 
+const dispatchBuildRestartedAction = build => {
+  dispatch(createBuildRestartedAction(build))
+};
+
 export default {
   fetchBuilds() {
     return api.fetchBuilds()
       .then(dispatchBuildsReceivedAction);
-  }
+  },
+
+  restartBuild(build) {
+    return api.restartBuild(build)
+      .then(dispatchBuildRestartedAction);
+  },
 };

--- a/assets/app/components/site/siteLogs.js
+++ b/assets/app/components/site/siteLogs.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { duration, timeFrom } from '../../util/datetime';
+import buildActions from '../../actions/buildActions';
 
 const propTypes = {
   site: React.PropTypes.object
@@ -9,6 +10,19 @@ const getUsername = (site, id) => {
   const user = site.users.find(user => user.id === id);
   return user.username;
 };
+
+const restartClicked = (event, build) => {
+  event.preventDefault()
+  buildActions.restartBuild(build);
+}
+
+const restartLink = (build) =>
+  <a
+    href="#" alt="Restart this build"
+    onClick={ (e) => restartClicked(e, build) }
+  >
+    Restart
+  </a>
 
 const sortSiteBuilds = (site) => {
   return site.builds.sort((a, b) => {
@@ -25,6 +39,7 @@ const SiteLogs = ({site}) =>
         <th scope="col">Completed</th>
         <th scope="col">Duration</th>
         <th scope="col">Message</th>
+        <th scope="col">Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -53,6 +68,7 @@ const SiteLogs = ({site}) =>
             <td>{ timeFrom(build.completedAt) }</td>
             <td>{ duration(build.createdAt, build.completedAt) }</td>
             <td>{ message }</td>
+            <td>{ restartLink(build) }</td>
           </tr>
         )
       })}

--- a/assets/app/reducers/builds.js
+++ b/assets/app/reducers/builds.js
@@ -1,9 +1,14 @@
-import { buildsReceivedType as BUILDS_RECEIVED } from "../actions/actionCreators/buildActions";
+import {
+  buildsReceivedType as BUILDS_RECEIVED,
+  buildRestartedType as BUILD_RESTARTED,
+} from "../actions/actionCreators/buildActions";
 
 export default function builds(state = [], action) {
   switch (action.type) {
   case BUILDS_RECEIVED:
     return action.builds;
+  case BUILD_RESTARTED:
+    return [action.build, ...state];
   default:
     return state;
   }

--- a/assets/app/reducers/sites.js
+++ b/assets/app/reducers/sites.js
@@ -13,6 +13,9 @@ import {
   siteLoadingType as SITE_LOADING
 } from '../actions/actionCreators/siteActions';
 
+import {
+  buildRestartedType as BUILD_RESTARTED,
+} from '../actions/actionCreators/buildActions';
 
 const initialState = [];
 
@@ -113,6 +116,17 @@ export default function sites(state = initialState, action) {
     return mapPropertyToMatchingSite(state, action.siteId, {
       files: files.concat(updatedSiteFiles)
     });
+
+  case BUILD_RESTARTED:
+    return state.map(site => {
+      if (site.id === action.build.site) {
+        return Object.assign({}, site, {
+          builds: [action.build, ...site.builds],
+        })
+      } else {
+        return site
+      }
+    })
 
   default:
     return state;

--- a/assets/app/util/federalistApi.js
+++ b/assets/app/util/federalistApi.js
@@ -58,5 +58,11 @@ export default {
     return this.fetch(`site/${siteId}`, {
       method: 'DELETE'
     });
-  }
+  },
+
+  restartBuild(build) {
+    return this.fetch(`build/${build.id}/restart`, {
+      method: 'POST'
+    })
+  },
 }

--- a/config/policies.js
+++ b/config/policies.js
@@ -60,7 +60,8 @@ module.exports.policies = {
   BuildController: {
     'find': ['passport', 'sessionAuth', 'filterCurrentUser'],
     'findOne': ['passport', 'sessionAuth', 'filterCurrentUser'],
-    'status': ['buildCallback']
+    'restart': ['passport', 'sessionAuth'],
+    'status': ['buildCallback'],
   },
 
   SiteController: {

--- a/config/routes.js
+++ b/config/routes.js
@@ -34,6 +34,7 @@ module.exports.routes = {
 
   'post /webhook/github': 'WebhookController.github',
   'post /build/status/:id/:token': 'BuildController.status',
+  'post /v0/build/:id/restart': 'BuildController.restart',
 
   'get /preview/:owner/:repo/:branch': 'PreviewController.proxy',
   'get /preview/:owner/:repo/:branch/*': 'PreviewController.proxy',
@@ -43,7 +44,7 @@ module.exports.routes = {
   'get /logout': 'AuthController.logout',
 
   'get /v0/me': 'UserController.me',
-
+  
   'get /sites(/*)?': {
     controller: 'main',
     action: 'index'

--- a/test/client/app/actions/actionCreators/buildActionsTest.js
+++ b/test/client/app/actions/actionCreators/buildActionsTest.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import {
-  buildsReceived, buildsReceivedType
+  buildsReceived, buildsReceivedType,
+  buildRestarted, buildRestartedType,
 } from "../../../../../assets/app/actions/actionCreators/buildActions";
 
 describe("buildActions actionCreators", () => {
@@ -10,17 +11,37 @@ describe("buildActions actionCreators", () => {
         a: "bee",
         see: "dee"
       };
-      
+
       const actual = buildsReceived(builds);
-      
+
       expect(actual).to.deep.equal({
         type: buildsReceivedType,
         builds
       });
     });
-    
+
     it("exports its type", () => {
       expect(buildsReceivedType).to.equal("BUILDS_RECEIVED");
+    });
+  });
+
+  describe("build restarted", () => {
+    it("constructs properly", () => {
+      const build = {
+        a: "bee",
+        see: "dee"
+      };
+
+      const actual = buildRestarted(build);
+
+      expect(actual).to.deep.equal({
+        type: buildRestartedType,
+        build
+      });
+    });
+
+    it("exports its type", () => {
+      expect(buildRestartedType).to.equal("BUILD_RESTARTED");
     });
   });
 });

--- a/test/client/app/actions/buildActionsTest.js
+++ b/test/client/app/actions/buildActionsTest.js
@@ -8,26 +8,33 @@ describe("buildActions", () => {
   let fixture;
   let dispatch;
   let buildsReceivedActionCreator;
+  let buildRestartedActionCreator;
   let fetchBuilds;
-  
+  let restartBuild;
+
   beforeEach(() => {
     dispatch = spy();
     buildsReceivedActionCreator = stub();
+    buildRestartedActionCreator = stub();
+
     fetchBuilds = stub();
-    
+    restartBuild = stub();
+
     fixture = proxyquire("../../../../assets/app/actions/buildActions", {
       "./actionCreators/buildActions": {
-        buildsReceived: buildsReceivedActionCreator
+        buildsReceived: buildsReceivedActionCreator,
+        buildRestarted: buildRestartedActionCreator,
       },
       "../util/federalistApi": {
-        fetchBuilds: fetchBuilds
+        fetchBuilds: fetchBuilds,
+        restartBuild: restartBuild,
       },
       "../store": {
-        dispatch: dispatch
+        dispatch: dispatch,
       }
     }).default;
   });
-  
+
   it("fetchBuilds", () => {
     const builds = {
       "we": "like to build it's true",
@@ -41,6 +48,26 @@ describe("buildActions", () => {
     buildsReceivedActionCreator.withArgs(builds).returns(action);
 
     const actual = fixture.fetchBuilds();
+
+    actual.then(() => {
+      expect(dispatch.calledOnce).to.be.true;
+      expect(dispatch.calledWith(action)).to.be.true;
+    });
+  });
+
+  it("restartBuild", () => {
+    const build = {
+      "we": "like to build it's true",
+      "how": "about you?"
+    };
+    const buildPromise = Promise.resolve(build);
+    const action = {
+      action: "action"
+    };
+    restartBuild.withArgs().returns(buildPromise);
+    buildRestartedActionCreator.withArgs(build).returns(action);
+
+    const actual = fixture.restartBuild();
 
     actual.then(() => {
       expect(dispatch.calledOnce).to.be.true;

--- a/test/client/app/reducers/buildsTest.js
+++ b/test/client/app/reducers/buildsTest.js
@@ -7,11 +7,13 @@ proxyquire.noCallThru();
 describe("buildsReducer", () => {
   let fixture;
   const BUILDS_RECEIVED = "builds received!";
+  const BUILD_RESTARTED = "build restarted!";
 
   beforeEach(() => {
     fixture = proxyquire("../../../../assets/app/reducers/builds.js", {
       "../actions/actionCreators/buildActions": {
-        buildsReceivedType: BUILDS_RECEIVED
+        buildsReceivedType: BUILDS_RECEIVED,
+        buildRestartedType: BUILD_RESTARTED,
       }
     }).default;
   });
@@ -47,5 +49,17 @@ describe("buildsReducer", () => {
     });
 
     expect(actual).to.deep.equal(BUILDS);
+  });
+
+  it("adds the restarted build in the action", () => {
+    const BUILDS = [ "build b", "build c" ];
+    const BUILD = "build a";
+
+    const actual = fixture(BUILDS, {
+      type: BUILD_RESTARTED,
+      build: BUILD
+    });
+
+    expect(actual).to.deep.equal([BUILD, ...BUILDS])
   });
 });

--- a/test/client/app/reducers/sitesTest.js
+++ b/test/client/app/reducers/sitesTest.js
@@ -14,6 +14,7 @@ describe("sitesReducer", () => {
   const SITE_FILE_CONTENT_RECEIVED = "cool files!";
   const SITE_UPLOAD_RECEIVED = 'uploaded!';
   const SITE_FILES_RECEIVED = "contents? we have contents!";
+  const BUILD_RESTARTED = "build restarted!"
 
   beforeEach(() => {
     fixture = proxyquire("../../../../assets/app/reducers/sites", {
@@ -31,7 +32,10 @@ describe("sitesReducer", () => {
         siteAssetsReceivedType: SITE_ASSETS_RECEIVED,
         siteConfigsReceivedType: SITE_CONFIGS_RECEIVED,
         siteFilesReceivedType: SITE_FILES_RECEIVED
-      }
+      },
+      "../actions/actionCreators/buildActions": {
+        buildRestartedType: BUILD_RESTARTED,
+      },
     }).default;
   });
 
@@ -773,6 +777,29 @@ describe("sitesReducer", () => {
     });
 
     expect(actual.pop().files.pop()).to.deep.equal(file);
+  });
+
+  it("adds the restarted build in the action to its site", () => {
+    const sitePendingRestart = {
+      id: "pick this one",
+      builds: ["finished build"],
+    };
+    const otherSite = {
+      id: "not this one",
+    };
+    const build = {
+      site: "pick this one",
+    };
+    const restartedSite = Object.assign({}, sitePendingRestart, {
+      builds: [build, ...sitePendingRestart.builds],
+    });
+
+    const actual = fixture([sitePendingRestart, otherSite], {
+      type: BUILD_RESTARTED,
+      build: build
+    });
+
+    expect(actual).to.deep.equal([restartedSite, otherSite])
   });
 
 });


### PR DESCRIPTION
This PR adds a restart button to the build logs. This button communicates with the API via a restart endpoint that was also added in the PR. This endpoint creates a new build with the same site, user, and branch as the previous. It then renders this build back to the frontend where it is appended to the build log.