### PR TITLE
Show preview links

### DIFF
--- a/assets/app/components/site/sitePreviewLinksTable.js
+++ b/assets/app/components/site/sitePreviewLinksTable.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+const branchRow = ({ branch, site }) => (
+  <tr key={branch.name}>
+    <td>{branch.name}</td>
+    <td>
+      <a href={previewURL({ branch, site })}>View</a>
+    </td>
+  </tr>
+)
+
+const previewURL = ({ branch, site }) => {
+  if (branch.name === site.defaultBranch) {
+    return site.viewLink
+  } else {
+    return `/preview/${site.owner}/${site.repository}/${branch.name}/`
+  }
+}
+
+const tableBody = (site) => {
+  if (site.branches && site.branches.length) {
+    return (
+      <tbody>
+        {site.branches.map(branch => {
+          return branchRow({ site, branch })
+        })}
+      </tbody>
+    )
+  } else {
+    return <tbody><tr><td>No branch data</td></tr></tbody>
+  }
+}
+
+const tableHeader = () => (
+  <thead>
+    <tr>
+      <th>Branch</th>
+      <th></th>
+    </tr>
+  </thead>
+)
+
+const SitePreviewLinksTable = ({ site }) => (
+  <table className="usa-table-borderless">
+    {tableHeader()}
+    {tableBody(site)}
+  </table>
+)
+
+SitePreviewLinksTable.propTypes = {
+  site: React.PropTypes.object.isRequired,
+};
+
+export default SitePreviewLinksTable;

--- a/assets/app/components/site/siteSettings.js
+++ b/assets/app/components/site/siteSettings.js
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import SitePreviewLinksTable from "./sitePreviewLinksTable";
 import RadioInput from '../radioInput';
 import LinkButton from '../linkButton';
 import siteActions from '../../actions/siteActions';
@@ -61,7 +62,7 @@ class SiteSettings extends React.Component {
       <form id="site-edit" onSubmit={this.onSubmit}>
         <div className="usa-grid">
           <div className="usa-width-one-whole">
-            <label for="defaultBranch" className={ defaultBranchClass }>
+            <label htmlFor="defaultBranch" className={ defaultBranchClass }>
               Default branch</label>
             <input
               name="defaultBranch"
@@ -90,8 +91,13 @@ class SiteSettings extends React.Component {
         </div>
         <div className="usa-grid">
           <div className="usa-width-one-whole">
+            <SitePreviewLinksTable site={this.props.site}/>
+          </div>
+        </div>
+        <div className="usa-grid">
+          <div className="usa-width-one-whole">
             <div className="form-group">
-              <label className="active" for="domain">Custom domain</label>
+              <label className="active" htmlFor="domain">Custom domain</label>
               <input
                 name="domain"
                 className="form-control"
@@ -112,7 +118,7 @@ class SiteSettings extends React.Component {
         <div className="usa-grid">
           <div className="usa-width-one-whole">
             <div className="form-group">
-               <label for="config" className="">Custom configuration</label>
+               <label htmlFor="config" className="">Custom configuration</label>
               <textarea
                 name="config"
                 className="form-control"

--- a/test/client/app/components/site/sitePreviewLinksTable.test.js
+++ b/test/client/app/components/site/sitePreviewLinksTable.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import SitePreviewLinksTable from '../../../../../assets/app/components/site/sitePreviewLinksTable';
+
+let site;
+
+describe("<SitePreviewLinksTable/>", () => {
+  beforeEach(() => {
+    site = {
+      branches: [
+        { name: "branch-name" },
+        { name: "default=branch" },
+      ],
+      owner: "owner-name",
+      repository: "repo-name",
+      defaultBranch: "default-ranch",
+      viewLink: "www.example.com/owner-name/repo-name",
+    };
+  });
+
+  it("render a table with a list of branches", () => {
+    site.branches = [
+      { name: "branch-a" },
+      { name: "branch-b" },
+    ];
+
+    const wrapper = shallow(<SitePreviewLinksTable site={site}/>);
+    const rows = wrapper.find("tbody").find("tr");
+
+    expect(rows).to.have.length(2)
+    expect(rows.at(0).contains("branch-a")).to.be.true;
+    expect(rows.at(1).contains("branch-b")).to.be.true;
+  });
+
+  it("renders the view URL for the default branch", () => {
+    site = {
+      branches: [
+        { name: "master" },
+      ],
+      defaultBranch: "master",
+      viewLink: "www.example.com",
+    };
+
+    const wrapper = shallow(<SitePreviewLinksTable site={site}/>);
+    const link = wrapper.find("a");
+
+    expect(link.contains("View")).to.be.true;
+    expect(link.prop("href")).to.equal(site.viewLink);
+  });
+
+  it("renders the the preview URL for preview branches", () => {
+    site = {
+      branches: [
+        { name: "preview-branch" },
+      ],
+      owner: "owner-name",
+      repository: "repo-name",
+      defaultBranch: "master",
+    };
+    const previewURL = "/preview/owner-name/repo-name/preview-branch/"
+
+    const wrapper = shallow(<SitePreviewLinksTable site={site}/>);
+    const link = wrapper.find("a");
+
+    expect(link.contains("View")).to.be.true;
+    expect(link.prop("href")).to.equal(previewURL);
+  });
+
+  it("renders a placeholder if a site has not branch data", () => {
+    site.branches = []
+
+    const wrapper = shallow(<SitePreviewLinksTable site={site}/>);
+    const rows = wrapper.find("tbody").find("tr");
+
+    expect(rows).to.have.length(1)
+    expect(rows.first().contains("No branch data")).to.be.true
+  });
+});


### PR DESCRIPTION
This PR adds a table to the settings view which lists the branches in a site's repo and provides a link to view the site preview for the given branch. It does so by adding a new component named `SitePreviewLinksTable`.

This PR can be review at this point, but should not be merged as I have yet to add tests.