### PR TITLE
Fix SiteContainer so that build logs and branches appear correctly

### DIFF
--- a/assets/app/components/siteContainer.js
+++ b/assets/app/components/siteContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 
-import { replaceRouterHistory } from '../actions/actionCreators/navigationActions';
+import { replaceHistory } from '../actions/routeActions';
 import siteActions from '../actions/siteActions';
 
 import SideNav from './site/SideNav/sideNav';
@@ -27,7 +27,7 @@ class SiteContainer extends React.Component {
     if (currentSite) {
       siteActions.fetchSiteConfigsAndAssets(currentSite);
     } else {
-      replaceRouterHistory('/sites');
+      replaceHistory('/sites');
     }
   }
 

--- a/assets/app/components/siteList/publishedState.js
+++ b/assets/app/components/siteList/publishedState.js
@@ -12,7 +12,7 @@ const getLastBuildTime = (builds) => {
       let bCompletedAt = new Date(b.completedAt);
       return aCompletedAt > bCompletedAt;
     });
-    let last = sorted.pop();
+    let last = sorted.slice().pop();
     return last.completedAt
   }
 };

--- a/test/client/app/components/siteList/publishedState.test.js
+++ b/test/client/app/components/siteList/publishedState.test.js
@@ -9,19 +9,22 @@ const PUBLISHED_BASE = 'Please wait for build to complete or check logs for erro
 const MOST_RECENT_BUILD_TIME = "2015-09-04T15:11:23.000Z"
 const FORMATTED_MOST_RECENT_BUILD_TIME =  moment(MOST_RECENT_BUILD_TIME).format('MMMM Do YYYY, h:mm:ss a')
 const MOST_RECENT_BUILD = `This site was last published at ${FORMATTED_MOST_RECENT_BUILD_TIME}.`;
-const builds = [
-  {
-    completedAt: "2015-09-02T21:43:35.000Z"
-  },
 
-  {
-    completedAt: MOST_RECENT_BUILD_TIME
-  }
-];
-
+let builds;
+let wrapper;
 
 describe('<PublishedState />', () => {
-  let wrapper;
+  beforeEach(() => {
+    builds = [
+      {
+        completedAt: "2015-09-02T21:43:35.000Z"
+      },
+
+      {
+        completedAt: MOST_RECENT_BUILD_TIME
+      }
+    ];
+  })
 
   it('displays a fallback message if the site has no builds', () => {
     wrapper = shallow(<PublishedState />);
@@ -40,4 +43,10 @@ describe('<PublishedState />', () => {
 
     expect(wrapper.find('p').text()).to.equal(MOST_RECENT_BUILD);
   });
+
+  it('does not mutate builds prop', () => {
+    const buildsCopy = builds.concat()
+    wrapper = shallow(<PublishedState builds={builds} />);
+    expect(buildsCopy).to.deep.equal(builds)
+  })
 });


### PR DESCRIPTION
This commit fixes 2 problems involving the site container. These
problems worked together to make the site data as it was displayed in
the container look incorrect.

The first issue was in the site container's code itself. The container
was importing an action creator and not an action to replace the router
history. This meant that if the container loaded without site data
instead of re-directing to the site list as it was intended, it rendered
its children without data fetched from GitHub.

The second issue was deep in the PublishedDate component which was
calling `pop()` on the build array for each site. This was removing the
most recent build from each site so the build logs were rendering
without that build.