### PR TITLE
Prevent site container from redirecting if site data is not present

### DIFF
--- a/assets/app/components/siteContainer.js
+++ b/assets/app/components/siteContainer.js
@@ -21,7 +21,23 @@ class SiteContainer extends React.Component {
   }
 
   componentDidMount() {
-    const { storeState, params, routeParams } = this.props;
+    const { storeState } = this.props;
+    if (storeState.sites.length) {
+      this.downloadCurrentSiteData();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { storeState } = this.props;
+    const prevStoreState = prevProps.storeState;
+
+    if (storeState.sites.length && !prevStoreState.sites.length) {
+      this.downloadCurrentSiteData();
+    }
+  }
+
+  downloadCurrentSiteData() {
+    const { storeState, params } = this.props;
     const currentSite = this.getCurrentSite(storeState.sites, params.id);
 
     if (currentSite) {


### PR DESCRIPTION
The SiteContainer component would redirect to the SiteList if a user
refreshed while viewing it. This was because the container was mounted
without any site data, causing the container to think a user was
attempting to look at a site which was not in their site list.

This commit fixes that by checking that site data exists before
attempting to set a current site. This means that the container will
wait until data is present before redirecting.

The downside of this solution is that a user without any sites will not
see a redirect since they do not have site data to begin with.

In the future, I think a better solution would be to change the state
such that it is aware of whether or not site data has been fetched. That
way instead of checking the `storeState.sites` array, the SiteContainer
could check that sites have been downloaded directly and then know
whether to proceed with rendering site content. That change will require
some big architectual change though.