### PR TITLE
Rename PREFIX to SITE_PREFIX in build message

### DIFF
--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -14,7 +14,7 @@ var buildContainerEnvironment = (build) => ({
   CONFIG: build.site.config,
   REPOSITORY: build.site.repository,
   OWNER: build.site.owner,
-  PREFIX: pathForBuild(build),
+  SITE_PREFIX: pathForBuild(build),
   GITHUB_TOKEN: build.user.githubAccessToken,
   GENERATOR: build.site.engine,
   SOURCE_REPO: sourceForBuild(build).repository,

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -87,14 +87,14 @@ describe("SQS", () => {
         })
       })
 
-      it("should set PREFIX in the message to 'site/:owner/:repo/'", done => {
+      it("should set SITE_PREFIX in the message to 'site/:owner/:repo/'", done => {
         factory(Site, { domain: "", owner: "owner", repository: "repo", defaultBranch: "master" }).then(site => {
           return factory(Build, { site: site, branch: "master" })
         }).then(build => {
           return Build.findOne({ id: build.id }).populate("site")
         }).then(build => {
           var message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "PREFIX")).to.equal("site/owner/repo")
+          expect(messageEnv(message, "SITE_PREFIX")).to.equal("site/owner/repo")
           done()
         })
       })
@@ -125,14 +125,14 @@ describe("SQS", () => {
         })
       })
 
-      it("should set PREFIX in the message to 'preview/:owner/:repo/:branch'", done => {
+      it("should set SITE_PREFIX in the message to 'preview/:owner/:repo/:branch'", done => {
         factory(Site, { domain: "", owner: "owner", repository: "repo", defaultBranch: "master" }).then(site => {
           return factory(Build, { site: site, branch: "branch" })
         }).then(build => {
           return Build.findOne({ id: build.id }).populate("site")
         }).then(build => {
           var message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "PREFIX")).to.equal("preview/owner/repo/branch")
+          expect(messageEnv(message, "SITE_PREFIX")).to.equal("preview/owner/repo/branch")
           done()
         })
       })


### PR DESCRIPTION
This commit changes the PREFIX variable in the build message to
SITE_PREFIX. This is in response to the change in
18F/federalist-docker-build#23 in which the build container begins
expecting SITE_PREFIX instead of PREFIX.

This change is necessary because using PREFIX in the environment results
in a collision with npm.

ref #584
ref 18f/federalist-docker-build#23