### PR TITLE
Build container logging

### DIFF
--- a/api/controllers/BuildLogController.js
+++ b/api/controllers/BuildLogController.js
@@ -1,0 +1,72 @@
+const authorizeUserForBuild = ({ user, build }) => {
+  return User.findOne(user.id).populate("sites").then(user => {
+    const siteIndex = user.sites.findIndex(site => {
+      return site.id === build.site
+    })
+    if (siteIndex < 0) {
+      const error = new Error("Unauthorized")
+      error.code = 403
+      throw error
+    }
+  })
+}
+
+module.exports = {
+  create: (req, res) => {
+    Build.findOne(req.param("build_id")).then(build => {
+      if (!build) {
+        const error = new Error("Not found")
+        error.code = 404
+        throw error
+      }
+      return BuildLog.create({
+        build: build,
+        output: req.param("output"),
+        source: req.param("source"),
+      })
+    }).then(build => {
+      res.json(build)
+    }).catch(err => {
+      if (err.code === 404) {
+        res.notFound()
+      } else {
+        res.serverError(err)
+      }
+    })
+  },
+
+  find: (req, res) => {
+    let build
+
+    Build.findOne(req.param("build_id")).populate("buildLogs").then(model => {
+      build = model
+
+      if (!build) {
+        const error = new Error("Not found")
+        error.code = 404
+        throw error
+      }
+
+      return authorizeUserForBuild({
+        build: build,
+        user: req.user,
+      })
+    }).then(() => {
+      res.json(build.buildLogs)
+    }).catch(err => {
+      if (err.code === 404) {
+        res.notFound()
+      } else if (err.code === 403) {
+        res.forbidden()
+      } else {
+        res.serverError(err)
+      }
+    })
+  },
+
+  _config: {
+    actions: false,
+    shortcuts: false,
+    rest: false,
+  },
+}

--- a/api/models/Build.js
+++ b/api/models/Build.js
@@ -71,11 +71,20 @@ module.exports = {
       model: 'user',
       required: true
     },
+    buildLogs: {
+      collection: 'buildLog',
+      via: 'build',
+    },
     source: {
       type: 'json'
     }
   },
 
   afterCreate: afterCreate,
-  completeJob: completeJob
+  completeJob: completeJob,
+  toJSON: () => {
+    let object = this.toObject()
+    object.buildLogs = undefined
+    return object
+  }
 };

--- a/api/models/BuildLog.js
+++ b/api/models/BuildLog.js
@@ -1,0 +1,17 @@
+module.exports = {
+  schema: true,
+  attributes: {
+    source: {
+      type: 'string',
+      required: true,
+    },
+    output: {
+      type: 'string',
+      required: true,
+    },
+    build: {
+      model: 'build',
+      required: true
+    },
+  },
+}

--- a/api/models/BuildLog.js
+++ b/api/models/BuildLog.js
@@ -1,3 +1,18 @@
+const saniztizeBuildSecrets = (values, callback) => {
+  Build.findOne(values.build.id || values.build).populate("user").then(build => {
+    secrets = [
+      sails.config.s3.accessKeyId,
+      sails.config.s3.secretAccessKey,
+      sails.config.build.token,
+      build.user.githubAccessToken,
+    ]
+    secrets.forEach(secret => {
+      values.output = values.output.replace(secret, "[FILTERED]")
+    })
+    callback()
+  })
+}
+
 module.exports = {
   schema: true,
   attributes: {
@@ -13,5 +28,9 @@ module.exports = {
       model: 'build',
       required: true
     },
+  },
+
+  beforeValidate: (values, cb) => {
+    saniztizeBuildSecrets(values, cb)
   },
 }

--- a/api/policies/buildCallback.js
+++ b/api/policies/buildCallback.js
@@ -3,7 +3,7 @@
  * Requests must have a `token` param that matches config and an `id`
  */
 module.exports = function (req, res, next) {
-  if (req.param('token') !== sails.config.build.token || !req.param('id')) {
+  if (req.param('token') !== sails.config.build.token) {
     return res.badRequest();
   }
   next();

--- a/api/policies/buildCallback.js
+++ b/api/policies/buildCallback.js
@@ -1,7 +1,3 @@
-/**
- * Build Callback Policy
- * Requests must have a `token` param that matches config and an `id`
- */
 module.exports = function (req, res, next) {
   if (req.param('token') !== sails.config.build.token) {
     return res.badRequest();

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -6,7 +6,8 @@ var buildContainerEnvironment = (build) => ({
   AWS_DEFAULT_REGION: s3Config.region,
   AWS_ACCESS_KEY_ID: s3Config.accessKeyId,
   AWS_SECRET_ACCESS_KEY: s3Config.secretAccessKey,
-  CALLBACK: `${buildConfig.callback}${build.id}/${buildConfig.token}`,
+  STATUS_CALLBACK: buildConfig.statusCallback.replace(":build_id", build.id).replace(":token", buildConfig.token),
+  LOG_CALLBACK: buildConfig.logCallback.replace(":build_id", build.id).replace(":token", buildConfig.token),
   BUCKET: s3Config.bucket,
   BASEURL: baseURLForBuild(build),
   CACHE_CONTROL: buildConfig.cacheControl,
@@ -18,7 +19,7 @@ var buildContainerEnvironment = (build) => ({
   GITHUB_TOKEN: build.user.githubAccessToken,
   GENERATOR: build.site.engine,
   SOURCE_REPO: sourceForBuild(build).repository,
-  SOURCE_OWNER: sourceForBuild(build).owner
+  SOURCE_OWNER: sourceForBuild(build).owner,
 })
 
 var defaultBranch = (build) => {

--- a/assets/app/actions/actionCreators/buildLogActions.js
+++ b/assets/app/actions/actionCreators/buildLogActions.js
@@ -1,0 +1,10 @@
+const buildLogsReceivedType = "BUILD_LOGS_RECEIVED";
+
+const buildLogsReceived = logs => ({
+  type: buildLogsReceivedType,
+  logs,
+});
+
+export {
+  buildLogsReceivedType, buildLogsReceived,
+}

--- a/assets/app/actions/buildLogActions.js
+++ b/assets/app/actions/buildLogActions.js
@@ -1,0 +1,17 @@
+import api from '../util/federalistApi';
+import { dispatch } from '../store';
+
+import {
+  buildLogsReceived as createBuildLogsReceivedAction,
+} from "./actionCreators/buildLogActions";
+
+const dispatchBuildLogsReceivedAction = logs => {
+  dispatch(createBuildLogsReceivedAction(logs));
+}
+
+export default {
+  fetchBuildLogs(build) {
+    return api.fetchBuildLogs(build)
+      .then(dispatchBuildLogsReceivedAction);
+  },
+};

--- a/assets/app/components/site/SideNav/sideNav.js
+++ b/assets/app/components/site/SideNav/sideNav.js
@@ -34,9 +34,9 @@ class SideNav extends React.Component {
             linkText={sideNavPaths.SETTINGS}
           />
           <SideNavItem
-            href={this.getUrl(siteId, sideNavPaths.LOGS)}
+            href={this.getUrl(siteId, sideNavPaths.BUILDS)}
             icon='logs'
-            linkText={sideNavPaths.LOGS}
+            linkText={sideNavPaths.BUILDS}
           />
         </ul>
       </div>

--- a/assets/app/components/site/siteBuildLogs.js
+++ b/assets/app/components/site/siteBuildLogs.js
@@ -1,0 +1,65 @@
+import React from "react";
+import buildLogActions from "../../actions/buildLogActions";
+
+class SiteBuildLogs extends React.Component {
+  componentDidMount() {
+    buildLogActions.fetchBuildLogs({ id: this.props.params.buildId });
+  }
+
+  buildLogs() {
+    if (!this.props.buildLogs) {
+      return [];
+    }
+
+    return this.props.buildLogs.filter(log => {
+      return log.build === parseInt(this.props.params.buildId);
+    }).sort((a, b) => {
+      return new Date(a.createdAt) - new Date(b.createdAt);
+    });
+  }
+
+  render() {
+    if (this.buildLogs().length > 0) {
+      return this.renderBuildLogsTable()
+    } else {
+      return this.renderEmptyState()
+    }
+  }
+
+  renderBuildLogsTable() {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Source</th>
+            <th>Output</th>
+            <th>Timestamp</th>
+          </tr>
+        </thead>
+        <tbody>
+          { this.buildLogs().map(log => this.renderBuildLogRow(log)) }
+        </tbody>
+      </table>
+    )
+  }
+
+  renderBuildLogRow(log) {
+    return (
+      <tr key={log.id}>
+        <td>{ log.source }</td>
+        <td>
+          <output><pre
+            style={{ whiteSpace: "pre-wrap" }}
+          >{ log.output }</pre></output>
+        </td>
+        <td>{ log.createdAt }</td>
+      </tr>
+    )
+  }
+
+  renderEmptyState() {
+    return <p>This build does not have any build logs</p>;
+  }
+}
+
+export default SiteBuildLogs;

--- a/assets/app/components/site/siteBuilds.js
+++ b/assets/app/components/site/siteBuilds.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 import { duration, timeFrom } from '../../util/datetime';
 import buildActions from '../../actions/buildActions';
 
@@ -16,13 +17,18 @@ const restartClicked = (event, build) => {
   buildActions.restartBuild(build);
 }
 
-const restartLink = (build) =>
+const restartLink = (build) => (
   <a
     href="#" alt="Restart this build"
     onClick={ (e) => restartClicked(e, build) }
   >
     Restart
   </a>
+)
+
+const buildLogsLink = ({ site, build }) => (
+  <Link to={`/sites/${site.id}/builds/${build.id}/logs`}>Logs</Link>
+)
 
 const sortSiteBuilds = (site) => {
   return site.builds.sort((a, b) => {
@@ -30,7 +36,7 @@ const sortSiteBuilds = (site) => {
   })
 }
 
-const SiteLogs = ({site}) =>
+const SiteBuilds = ({site}) =>
   <table className="usa-table-borderless build-log-table">
     <thead>
       <tr>
@@ -68,17 +74,20 @@ const SiteLogs = ({site}) =>
             <td>{ timeFrom(build.completedAt) }</td>
             <td>{ duration(build.createdAt, build.completedAt) }</td>
             <td>{ message }</td>
-            <td>{ restartLink(build) }</td>
+            <td>
+              { restartLink(build) }<br/>
+              { buildLogsLink({ site, build }) }
+            </td>
           </tr>
         )
       })}
     </tbody>
   </table>
 
-SiteLogs.defaultProps = {
+SiteBuilds.defaultProps = {
   builds: []
 };
 
-SiteLogs.propTypes = propTypes;
+SiteBuilds.propTypes = propTypes;
 
-export default SiteLogs;
+export default SiteBuilds;

--- a/assets/app/components/siteContainer.js
+++ b/assets/app/components/siteContainer.js
@@ -82,9 +82,14 @@ class SiteContainer extends React.Component {
           site
         };
         break;
+      case 'logs':
+        childConfigs = {
+          buildLogs: storeState.buildLogs,
+        };
+        break;
       case 'settings':
       case 'pages':
-      case 'logs':
+      case 'builds':
       default:
         childConfigs = { site };
     }

--- a/assets/app/constants.js
+++ b/assets/app/constants.js
@@ -16,8 +16,8 @@ export const routeTypes = keymirror({
   SITE_CONTENT: null,
   // Represents a site media page
   SITE_MEDIA: null,
-  // Represents a site log page
-  SITE_LOGS: null,
+  // Represents a site builds page
+  SITE_BUILDS: null,
   // Represents a site setting page
   SITE_SETTINGS: null,
   // Represents an edit page
@@ -39,5 +39,5 @@ export const sideNavPaths = {
   MEDIA: 'media',
   PAGES: 'pages',
   SETTINGS: 'settings',
-  LOGS: 'logs'
+  BUILDS: 'builds'
 };

--- a/assets/app/reducers.js
+++ b/assets/app/reducers.js
@@ -1,5 +1,6 @@
 import assets from './reducers/assets';
 import builds from './reducers/builds';
+import buildLogs from './reducers/buildLogs';
 import alert from './reducers/alert';
 import sites from './reducers/sites';
 import user from './reducers/user';
@@ -7,6 +8,7 @@ import user from './reducers/user';
 export default {
   assets,
   builds,
+  buildLogs,
   alert,
   sites,
   user

--- a/assets/app/reducers/buildLogs.js
+++ b/assets/app/reducers/buildLogs.js
@@ -1,0 +1,12 @@
+import {
+  buildLogsReceivedType as BUILD_LOGS_RECEIVED,
+} from "../actions/actionCreators/buildLogActions";
+
+export default function buildLogs(state = [], action) {
+  switch (action.type) {
+  case BUILD_LOGS_RECEIVED:
+    return action.logs;
+  default:
+    return state;
+  }
+}

--- a/assets/app/routes.js
+++ b/assets/app/routes.js
@@ -6,7 +6,8 @@ import SiteList from './components/siteList/siteList';
 import SiteContainer from './components/siteContainer';
 import SitePagesContainer from './bundles/pagesContainerBundle';
 import SiteEditorContainer from './components/site/editor/editorContainer';
-import SiteLogs from './components/site/siteLogs';
+import SiteBuilds from './components/site/siteBuilds';
+import SiteBuildLogs from './components/site/siteBuildLogs';
 import SiteMediaContainer from './components/site/siteMediaContainer';
 import SiteSettings from './components/site/siteSettings';
 import NewSite from './components/AddSite';
@@ -27,7 +28,10 @@ export default (
         <Route path="edit/:branch/(**/):fileName" component={SiteEditorContainer}/>
         <Route path="media" component={SiteMediaContainer}/>
         <Route path="settings" component={SiteSettings}/>
-        <Route path="logs" component={SiteLogs}/>
+        <Route path="builds">
+          <IndexRoute component={SiteBuilds}/>
+          <Route path=":buildId/logs" component={SiteBuildLogs}/>
+        </Route>
       </Route>
       <Redirect from="*" to="/not-found"/>
     </Route>

--- a/assets/app/util/federalistApi.js
+++ b/assets/app/util/federalistApi.js
@@ -18,6 +18,10 @@ export default {
     return this.fetch('build');
   },
 
+  fetchBuildLogs(build) {
+    return this.fetch(`build/${build.id}/log`);
+  },
+
   fetchSites() {
     return this.fetch('site');
   },

--- a/config/build.js
+++ b/config/build.js
@@ -6,6 +6,7 @@ var env = envFn();
 
 module.exports.build = {
   cacheControl: env.FEDERALIST_CACHE_CONTROL || 'max-age=60',
-  callback: env.FEDERALIST_BUILD_CALLBACK || 'http://localhost:1337/build/status/',
+  statusCallback: env.FEDERALIST_BUILD_STATUS_CALLBACK || 'http://localhost:1337/v0/build/:build_id/status/:token',
+  logCallback: env.FEDERALIST_BUILD_LOG_CALLBACK || 'http://localhost:1337/v0/build/:build_id/log/:token',
   token: env.FEDERALIST_BUILD_TOKEN,
 }

--- a/config/policies.js
+++ b/config/policies.js
@@ -64,6 +64,11 @@ module.exports.policies = {
     'status': ['buildCallback'],
   },
 
+  BuildLogController: {
+    'find': ['passport', 'sessionAuth'],
+    'create': ['buildCallback'],
+  },
+
   SiteController: {
     'destroy': ['passport', 'sessionAuth', 'filterCurrentUser'],
     'find': ['passport', 'sessionAuth', 'filterCurrentUser'],

--- a/config/routes.js
+++ b/config/routes.js
@@ -44,7 +44,10 @@ module.exports.routes = {
   'get /logout': 'AuthController.logout',
 
   'get /v0/me': 'UserController.me',
-  
+
+  'post /v0/build/:build_id/log/:token': 'BuildLogController.create',
+  'get  /v0/build/:build_id/log': 'BuildLogController.find',
+
   'get /sites(/*)?': {
     controller: 'main',
     action: 'index'

--- a/config/routes.js
+++ b/config/routes.js
@@ -33,7 +33,8 @@ module.exports.routes = {
   ***************************************************************************/
 
   'post /webhook/github': 'WebhookController.github',
-  'post /build/status/:id/:token': 'BuildController.status',
+
+  'post /v0/build/:id/status/:token': 'BuildController.status',
   'post /v0/build/:id/restart': 'BuildController.restart',
 
   'get /preview/:owner/:repo/:branch': 'PreviewController.proxy',

--- a/migrations/20161219163300-create-build-logs.js
+++ b/migrations/20161219163300-create-build-logs.js
@@ -1,0 +1,14 @@
+exports.up = (db, callback) => {
+  return db.createTable("buildlog", {
+    id: { type: "int", primaryKey: true, autoIncrement: true },
+    output: "string",
+    source: "string",
+    build: "int",
+    createdAt: "timestamp",
+    updatedAt: "timestamp",
+  }, callback)
+}
+
+exports.down = (db, callback) => {
+  return db.dropTable("buildlog", callback)
+}

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -20,3 +20,5 @@ env:
   NODE_MODULES_CACHE: false
   APP_NAME: federalist-staging
   APP_DOMAIN: fr.cloud.gov
+  FEDERALIST_BUILD_STATUS_CALLBACK: https://federalist-staging.fr.cloud.gov/v0/build/:build_id/status/:token
+  FEDERALIST_BUILD_LOG_CALLBACK: https://federalist-staging.fr.cloud.gov/v0/build/:build_id/log/:token

--- a/test/api/requests/build-logs.test.js
+++ b/test/api/requests/build-logs.test.js
@@ -1,0 +1,137 @@
+var expect = require("chai").expect
+var request = require("supertest-as-promised")
+var factory = require("../support/factory")
+var session = require("../support/session")
+
+describe("Build Log API", () => {
+  describe("POST /v0/build/:build_id/log/:token", () => {
+    it("should create a build log with the given params", done => {
+      let build
+
+      factory(Build).then(model => {
+        build = model
+
+        return request("localhost:1337")
+          .post(`/v0/build/${build.id}/log/${sails.config.build.token}`)
+          .type("json")
+          .send({
+            source: "build.sh",
+            output: "This is the output for build.sh",
+          })
+          .expect(200)
+      }).then(response => {
+        expect(response.body).to.have.property("source", "build.sh")
+        expect(response.body).to.have.property("output", "This is the output for build.sh")
+
+        return BuildLog.find({ build: build.id })
+      }).then(logs => {
+        expect(logs).to.have.length(1)
+        expect(logs[0]).to.have.property("source", "build.sh")
+        expect(logs[0]).to.have.property("output", "This is the output for build.sh")
+        done()
+      })
+    })
+
+    it("should respond with a 400 and not create a build log for an invalid build token", done => {
+      let build
+
+      factory(Build).then(model => {
+        build = model
+
+        return request("localhost:1337")
+          .post(`/v0/build/${build.id}/log/invalid-token`)
+          .type("json")
+          .send({
+            source: "build.sh",
+            body: "This is the output for build.sh",
+          })
+          .expect(400)
+      }).then(response => {
+        expect(response.body).to.be.empty
+
+        return BuildLog.find({ build: build.id })
+      }).then(logs => {
+        expect(logs).to.be.empty
+        done()
+      })
+    })
+
+    it("should respond with a 404 if no build is found for the given id", done => {
+      request("localhost:1337")
+        .post(`/v0/build/fake-id/log/${sails.config.build.token}`)
+        .type("json")
+        .send({
+          source: "build.sh",
+          body: "This is the output for build.sh",
+        })
+        .expect(404, done)
+    })
+  })
+
+  describe("GET /v0/build/:build_id/log", () => {
+    it("should require authentication", done => {
+      factory(BuildLog).then(buildLog => {
+        return request("http://localhost:1337")
+          .get(`/v0/build/${buildLog.build}/log`)
+          .expect(403)
+      }).then(response => {
+        expect(response.body).to.be.empty
+        done()
+      })
+    })
+
+    it("should render builds logs for the given build", done => {
+      let build
+
+      factory(Build).then(model => {
+        build = model
+
+        return Promise.all(Array(3).fill(0).map(() => {
+          factory(BuildLog, {
+            build: build,
+          })
+        }))
+      }).then(models => {
+        return Site.findOne({ id: build.site }).populate("users")
+      }).then(site => {
+        let user = site.users[0]
+        return session(user)
+      }).then(cookie => {
+        return request("localhost:1337")
+          .get(`/v0/build/${build.id}/log`)
+          .set("Cookie", cookie)
+          .expect(200)
+      }).then(response => {
+        expect(response.body).to.be.a("array")
+        expect(response.body).to.have.length(3)
+        response.body.forEach(log => {
+          expect(log).to.have.property("source")
+          expect(log).to.have.property("output")
+        })
+        done()
+      })
+    })
+
+    it("should respond with a 403 if the given build is not associated with one of the user's sites", done => {
+      let build
+
+      factory(Build).then(model => {
+        build = model
+
+        return Promise.all(Array(3).fill(0).map(() => factory(BuildLog)))
+      }).then(models => {
+        return factory(User)
+      }).then(user => {
+        return session(user)
+      }).then(cookie => {
+        return request("localhost:1337")
+          .get(`/v0/build/${build.id}/log`)
+          .set("Cookie", cookie)
+          .expect(403)
+      }).then(response => {
+        expect(response.body).to.be.empty
+        done()
+      })
+    })
+  })
+})

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -15,6 +15,8 @@ describe("Build API", () => {
 
   var buildResponseExpectations = (response, build) => {
     Object.keys(build).forEach(key => {
+      if (key === "buildLogs") return;
+
       expect(response[key]).to.not.be.undefined
       if (typeof build[key] === "number" && typeof response[key] === "object") {
         expect(response[key].id).to.equal(build[key])

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -273,12 +273,12 @@ describe("Build API", () => {
     })
   })
 
-  describe("POST /build/status/:id/:token", () => {
+  describe("POST /v0/build/:id/status/:token", () => {
     var postBuildStatus = (options) => {
       buildToken = options["buildToken"] || sails.config.build.token
 
       return request("http://localhost:1337")
-        .post(`/build/status/${options["buildID"]}/${buildToken}`)
+        .post(`/v0/build/${options["buildID"]}/status/${buildToken}`)
         .type("json")
         .send({
           status: options["status"],

--- a/test/api/support/factory.js
+++ b/test/api/support/factory.js
@@ -39,6 +39,12 @@ var buildAttributes = (overrides) => {
   }, overrides)
 }
 
+const buildLogAttributes = ({ build, source, output } = {}) => ({
+  build: build || factory(Build),
+  source: source || "clone.sh",
+  output: output || "This is output from the build container",
+})
+
 var siteAttributes = (overrides) => {
   overrides = overrides || {}
   var users = overrides["users"]
@@ -83,6 +89,7 @@ var generateUniqueUserName = () => {
 
 var defaultAttributes = {
   Build: buildAttributes,
+  BuildLog: buildLogAttributes,
   Site: siteAttributes,
   User: userAttributes
 }

--- a/test/api/unit/models/BuildLog.test.js
+++ b/test/api/unit/models/BuildLog.test.js
@@ -1,0 +1,26 @@
+var expect = require("chai").expect
+var factory = require("../../support/factory")
+
+describe("BuildLog", () => {
+  describe(".afterValidate", () => {
+    it("should filter secrets that appear in the output", done => {
+      let build, unfilteredOutput
+
+      factory(Build).then(model => {
+        build = model
+        return Site.findOne(build.site).populate("users")
+      }).then(site => {
+        user = site.users[0]
+        unfilteredOutput = `${sails.config.s3.accessKeyId} ${sails.config.s3.secretAccessKey} ${sails.config.build.token} ${user.githubAccessToken}`
+        return BuildLog.create({
+          build: build,
+          output: unfilteredOutput,
+          source: "publish.sh",
+        })
+      }).then(build => {
+        expect(build.output).to.equal(Array(4).fill("[FILTERED]").join(" "))
+        done()
+      })
+    })
+  })
+})

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -52,12 +52,22 @@ describe("SQS", () => {
       })
     })
 
-    it("should set CALLBACK in the message", done => {
+    it("should set STATUS_CALLBACK in the message", done => {
       factory(Build).then(build => {
         return Build.findOne({ id: build.id }).populate("site")
       }).then(build => {
         var message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "CALLBACK")).to.equal("http://localhost:1337/build/status/" + build.id + "/" + sails.config.build.token)
+        expect(messageEnv(message, "STATUS_CALLBACK")).to.equal("http://localhost:1337/v0/build/" + build.id + "/status/" + sails.config.build.token)
+        done()
+      })
+    })
+
+    it("should set LOG_CALLBACK in the message", done => {
+      factory(Build).then(build => {
+        return Build.findOne({ id: build.id }).populate("site")
+      }).then(build => {
+        var message = SQS.messageBodyForBuild(build)
+        expect(messageEnv(message, "LOG_CALLBACK")).to.equal("http://localhost:1337/v0/build/" + build.id + "/log/" + sails.config.build.token)
         done()
       })
     })

--- a/test/client/app/actions/actionCreators/buildLogActionsTest.js
+++ b/test/client/app/actions/actionCreators/buildLogActionsTest.js
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+import {
+  buildLogsReceived, buildLogsReceivedType,
+} from "../../../../../assets/app/actions/actionCreators/buildLogActions";
+
+describe("buildLogActions actionCreators", () => {
+  describe("build logs received", () => {
+    it("constructs properly", () => {
+      const logs = ["Log 1", "Log2 "];
+
+      const actual = buildLogsReceived(logs);
+
+      expect(actual).to.deep.equal({
+        type: buildLogsReceivedType,
+        logs: logs,
+      });
+    });
+
+    it("exports its type", () => {
+      expect(buildLogsReceivedType).to.equal("BUILD_LOGS_RECEIVED");
+    });
+  });
+});

--- a/test/client/app/actions/buildLogActionsTest.js
+++ b/test/client/app/actions/buildLogActionsTest.js
@@ -1,0 +1,48 @@
+import { expect } from "chai";
+import { spy, stub } from "sinon";
+import proxyquire from "proxyquire";
+
+proxyquire.noCallThru();
+
+describe("buildActions", () => {
+  let fixture;
+  let dispatch;
+  let buildLogsReceivedActionCreator;
+  let fetchBuildLogs;
+
+  beforeEach(() => {
+    dispatch = spy();
+    buildLogsReceivedActionCreator = stub();
+
+    fetchBuildLogs = stub();
+
+    fixture = proxyquire("../../../../assets/app/actions/buildLogActions", {
+      "./actionCreators/buildActions": {
+        buildLogsReceived: buildLogsReceivedActionCreator,
+      },
+      "../util/federalistApi": {
+        fetchBuildLogs: fetchBuildLogs,
+      },
+      "../store": {
+        dispatch: dispatch,
+      }
+    }).default;
+  });
+
+  it("fetchBuildLogs", () => {
+    const logs = ["Log 1", "Log 2"];
+    const buildLogsPromise = Promise.resolve(logs);
+    const action = {
+      action: "action"
+    };
+    fetchBuildLogs.withArgs().returns(buildLogsPromise);
+    buildLogsReceivedActionCreator.withArgs(logs).returns(action);
+
+    const actual = fixture.fetchBuildLogs();
+
+    actual.then(() => {
+      expect(dispatch.calledOnce).to.be.true;
+      expect(dispatch.calledWith(action)).to.be.true;
+    });
+  });
+});

--- a/test/client/app/components/site/siteBuildLogs.test.js
+++ b/test/client/app/components/site/siteBuildLogs.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import SiteBuildLogs from '../../../../../assets/app/components/site/siteBuildLogs';
+
+describe("<SiteBuildLogs/>", () => {
+  it("should render a table with build logs for the given build", () => {
+    const props = {
+      params: { buildId: 1 },
+      buildLogs: [
+        { build: 1, output: "output 1", source: "source 1" },
+        { build: 1, output: "output 2", source: "source 2" },
+      ],
+    };
+
+    const wrapper = shallow(<SiteBuildLogs {...props} />);
+    expect(wrapper.find("table")).to.have.length(1)
+    expect(wrapper.find("table").contains("output 1")).to.be.true;
+    expect(wrapper.find("table").contains("output 2")).to.be.true;
+    expect(wrapper.find("table").contains("source 1")).to.be.true;
+    expect(wrapper.find("table").contains("source 2")).to.be.true;
+  });
+
+  it("should not render logs for another build", () => {
+    const props = {
+      params: { buildId: 1 },
+      buildLogs: [
+        { build: 1, output: "output 1", source: "source 1" },
+        { build: 2, output: "output 2", source: "source 2" },
+      ],
+    };
+
+    const wrapper = shallow(<SiteBuildLogs {...props} />);
+    expect(wrapper.find("table")).to.have.length(1);
+    expect(wrapper.find("table").contains("output 1")).to.be.true;
+    expect(wrapper.find("table").contains("output 2")).to.be.false;
+    expect(wrapper.find("table").contains("source 1")).to.be.true;
+    expect(wrapper.find("table").contains("source 2")).to.be.false;
+  });
+
+  it("should render an empty state if there are no builds", () => {
+    const props = {
+      params: { buildId: 1 },
+      buildLogs: [],
+    };
+
+    const wrapper = shallow(<SiteBuildLogs {...props} />);
+    expect(wrapper.find("table")).to.have.length(0);
+    expect(wrapper.find("p")).to.have.length(1);
+    expect(wrapper.find("p").contains("This build does not have any build logs")).to.be.true;
+  });
+});

--- a/test/client/app/reducers/buildLogsTest.js
+++ b/test/client/app/reducers/buildLogsTest.js
@@ -1,0 +1,50 @@
+import { expect } from "chai";
+import proxyquire from "proxyquire";
+
+proxyquire.noCallThru();
+
+describe("buildLogsReducer", () => {
+  let fixture;
+  const BUILD_LOGS_RECEIVED = "build logs received!";
+
+  beforeEach(() => {
+    fixture = proxyquire("../../../../assets/app/reducers/buildLogs.js", {
+      "../actions/actionCreators/buildLogActions": {
+        buildLogsReceivedType: BUILD_LOGS_RECEIVED,
+      }
+    }).default;
+  });
+
+  it("ignores other actions and returns and empty array", () => {
+    const LOGS = ["Log 1", "Log 2"]
+
+    const actual = fixture(undefined, {
+      type: "Not the right action type",
+      logs: LOGS
+    });
+
+    expect(actual).to.deep.equal([]);
+  });
+
+  it("records the build logs received in the action", () => {
+    const LOGS = ["Log 1", "Log 2"]
+
+    const actual = fixture([], {
+      type: BUILD_LOGS_RECEIVED,
+      logs: LOGS
+    });
+
+    expect(actual).to.deep.equal(LOGS);
+  });
+
+  it("overrides the build logs with the ones received in the action", () => {
+    const LOGS = ["Log 1", "Log 2"]
+
+    const actual = fixture(["Log 3"], {
+      type: BUILD_LOGS_RECEIVED,
+      logs: LOGS
+    });
+
+    expect(actual).to.deep.equal(LOGS);
+  });
+});


### PR DESCRIPTION
This PR prepares the web application to receive updates about the build from the build container and display them to the user.

This PR is WIP. At the moment, it extends the API such that build containers can communicate output to the the backend, and the frontend can fetch the build logs from the backend. This PR will be ready when the frontend is able to display these records to the user.