### PR TITLE
Handle situation where a build's user is not in site.users array

### DIFF
--- a/assets/app/components/site/siteBuilds.js
+++ b/assets/app/components/site/siteBuilds.js
@@ -9,7 +9,9 @@ const propTypes = {
 
 const getUsername = (site, id) => {
   const user = site.users.find(user => user.id === id);
-  return user.username;
+  if (user) {
+    return user.username;
+  }
 };
 
 const restartClicked = (event, build) => {

--- a/test/client/app/components/site/siteBuilds.test.js
+++ b/test/client/app/components/site/siteBuilds.test.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { expect } from "chai";
+import { shallow } from "enzyme";
+import SiteBuilds from "../../../../../assets/app/components/site/siteBuilds";
+
+let user
+let build
+let props
+
+describe("<SiteBuilds/>", () => {
+  beforeEach(() => {
+    user = {
+      id: 1,
+      username: "user123",
+    }
+    build = {
+      user: user.id,
+      id: 1,
+      branch: "master",
+      createdAt: "2016-12-28T12:00:00",
+      completedAt: "2016-12-28T12:05:00",
+      state: "success",
+    }
+    props = {
+      site: {
+        builds: [
+          build,
+        ],
+        users: [
+          user,
+        ],
+      },
+    }
+  })
+
+  const columnIndex = (wrapper, name) => {
+    let index
+    wrapper.find("th").children().forEach((child, childIndex) => {
+      if (child.contains(name)) {
+        index = childIndex
+      }
+    })
+    return index
+  }
+
+  it("should render the username for a build's user", () => {
+    const wrapper = shallow(<SiteBuilds {...props}/>)
+    const userIndex = columnIndex(wrapper, "User")
+
+    const userCell = wrapper.find("tr").at(1).find("td").at(userIndex)
+    expect(userCell.text()).to.equal(user.username)
+  })
+
+  it("should render an empty string for the username for builds where the user cannot be found", () => {
+    build.user = user.id + 1
+    const wrapper = shallow(<SiteBuilds {...props}/>)
+    const userIndex = columnIndex(wrapper, "User")
+
+    const userCell = wrapper.find("tr").at(1).find("td").at(userIndex)
+    expect(userCell.text()).to.equal("")
+  })
+})


### PR DESCRIPTION
The build logs were crashing in staging because there was a build with a user that was not present in the `users` array on the SiteBuild component's `site` prop. This was causing the following error:

```
Cannot read property "username" of undefined.
```

The source of the error was the `getUsername` method. This commit fixes that method so that it can handle this exception case, but does not fix the root issue, that users building sites are not being rendered in the API response.

ref #695