### PR TITLE
Remove unauthenticated logic from Header and Nav

### DIFF
--- a/assets/app/components/app.js
+++ b/assets/app/components/app.js
@@ -41,7 +41,6 @@ class App extends React.Component {
     return (
       <div>
         <Header
-          isLoggedIn={ !!storeState.user }
           username={storeState.user.username}
         />
         {children && React.cloneElement(children, {

--- a/assets/app/components/header.js
+++ b/assets/app/components/header.js
@@ -4,22 +4,18 @@ import Disclaimer from './disclaimer';
 import Nav from './nav';
 
 const propTypes = {
-  isLoggedIn: React.PropTypes.bool,
   username: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.object
   ])
 };
 
-const Header = ({ isLoggedIn = false, username = null }) =>
+const Header = ({ username = null }) =>
   <header className="usa-site-header" role="banner">
     <Disclaimer />
-    <Nav isLoggedIn={ isLoggedIn } username={ username } />
+    <Nav username={ username } />
   </header>
 
 Header.propTypes = propTypes;
-Header.defaultProps = {
-  isLoggedIn: false
-};
 
 export default Header;

--- a/assets/app/components/nav.js
+++ b/assets/app/components/nav.js
@@ -2,32 +2,26 @@ import React from 'react';
 import { Link } from 'react-router';
 
 const propTypes = {
-  isLoggedIn: React.PropTypes.bool,
   username: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.object
   ])
 };
 
-const getSecondaryNav = (loggedIn, username) => {
-  const authLinks = [
+const getSecondaryNav = (username) => {
+  const links = [
     <Link to="/sites">{username}</Link>,
     <a href="https://federalist-docs.18f.gov" target="_blank">Documentation</a>,
     <a href="https://github.com/18F/federalist/issues/new" target="_blank">Contact us</a>,
     <a href="/logout">Log out</a>,
   ];
-  const unAuthLinks = [
-    <a href="/auth/github">Log in</a>,
-    <a href="https://federalist-docs.18f.gov" target="_blank">Documentation</a>,
-    <a href="https://github.com/18F/federalist/issues/new" target="_blank">Contact us</a>,
-  ];
 
-  return (loggedIn ? authLinks : unAuthLinks).map((link, index) => {
+  return links.map((link, index) => {
     return <li key={index}>{link}</li>;
   });
 };
 
-const Nav = ({ isLoggedIn, username = null }) =>
+const Nav = ({ username = null }) =>
   <nav className="usa-site-navbar">
     <div className="usa-grid">
       <div className="nav-elements">
@@ -36,7 +30,7 @@ const Nav = ({ isLoggedIn, username = null }) =>
         </div>
         <div className="navbar-links" id="navbar-links">
           <ul className="" id="nav-mobile">
-            {getSecondaryNav(isLoggedIn, username)}
+            {getSecondaryNav(username)}
           </ul>
         </div>
       </div>

--- a/test/client/app/components/app.test.js
+++ b/test/client/app/components/app.test.js
@@ -51,7 +51,6 @@ describe('<App/>', () => {
 
   it('delivers the correct props to the header', () => {
     const expectedProps = {
-      isLoggedIn: true,
       username: username
     };
     const actualProps = wrapper.find(Header).props();

--- a/test/client/app/components/header.test.js
+++ b/test/client/app/components/header.test.js
@@ -13,16 +13,8 @@ describe('<Header/>', () => {
       wrapper = shallow(<Header/>);
     });
 
-    it('has props for isLoggedIn', () => {
-      expect(wrapper.instance().props.isLoggedIn).to.be.defined;
-    });
-
     it('has props for username', () => {
       expect(wrapper.instance().props.username).to.be.defined;
-    });
-
-    it('sets isLoggedIn to false if a value is not provided', () => {
-      expect(wrapper.instance().props.isLoggedIn).to.be.false;
     });
   });
 

--- a/test/client/app/components/nav.test.js
+++ b/test/client/app/components/nav.test.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router';
 import Nav from '../../../../assets/app/components/nav';
 
 const userName = 'el-mapache';
-const helpText = 'Help';
+const helpText = 'Documentation';
 const contactUsText = 'Contact us';
 
 describe('<Nav/>', () => {
@@ -20,42 +20,28 @@ describe('<Nav/>', () => {
     expect(firstAnchor.text()).to.have.equal('Federalist logo');
   });
 
-  it('defaults to a logged out state if isLoggedIn is not supplied', () => {
+  it('displays a `contact us` link', () => {
     wrapper = shallow(<Nav/>);
 
-    expect(wrapper.find('a[href="/auth/github"]')).to.have.length(1);
+    expect(wrapper.find('a').filter(el => el.text() === contactUsText));
   });
 
-  describe('when prop isLoggedIn is false', () => {
-    beforeEach(() => {
-      wrapper = shallow(<Nav isLoggedIn={false}/>);
-    });
+  it('displays a `help` link', () => {
+    wrapper = shallow(<Nav/>);
 
-    it('displays a `contact us` link', () => {
-      expect(wrapper.find('a').filter(el => el.text() === contactUsText));
-    });
-
-    it('displays a `help` link', () => {
-      expect(wrapper.find('a').filter(el => el.text() === helpText));
-    });
-
-    it('displays a `log in` link', () => {
-      expect(wrapper.find('a[href="/auth/github"]')).to.have.length(1);
-    });
+    expect(wrapper.find('a').filter(el => el.text() === helpText));
   });
 
-  describe('when prop isLoggedIn is true', () => {
-    it('displays a link to log out if isLoggedIn prop is true', () => {
-      wrapper = shallow(<Nav isLoggedIn={true}/>);
+  it('displays a link to log out', () => {
+    wrapper = shallow(<Nav/>);
 
-      expect(wrapper.find('a[href="/logout"]')).to.have.length(1);
-    });
+    expect(wrapper.find('a[href="/logout"]')).to.have.length(1);
+  });
 
-    it('displays link with usersname when logged in', () => {
-      wrapper = shallow(<Nav isLoggedIn={true} username={userName}/>);
+  it('displays a link with usersname', () => {
+    wrapper = shallow(<Nav username={userName}/>);
 
-      expect(wrapper.find(Link)).to.have.length(1);
-      expect(wrapper.find(Link).children().text()).to.equal(userName);
-    });
+    expect(wrapper.find(Link)).to.have.length(1);
+    expect(wrapper.find(Link).children().text()).to.equal(userName);
   });
 });


### PR DESCRIPTION
The array `unAuthLinks` is only used if the `Nav`
component's `isLoggedIn` prop is false. That prop is passed through the
`Header` component:

```javascript
const Header = ({ isLoggedIn = false, username = null }) =>
  <header className="usa-site-header" role="banner">
    <Disclaimer />
    <Nav isLoggedIn={ isLoggedIn } username={ username } />
  </header>
```

Which has it's props passed down from the `App` component where the
logic to set `isLoggedIn` lives:

```javascript
render() {
  const storeState = this.state;

  return (
    <div>
      <Header
        isLoggedIn={ !!storeState.user }
        username={storeState.user.username}
      />
      <!-- ... -->
    </div>
  );
}
```

What's interesting about this, it that `main.js`, the entry point for
the frontend has a check for the presence of `storeState.user` and does
not render if that is false:

```javascript
store.subscribe(() => {
  const state = store.getState();

  if (!state.user) return;

  render(/* ... */);
});
```

What this means is this code is in fact never used since `isLoggedIn` is
only false if there is no user in the state, and if there is no user in
the state the frontend will not render.

With the above in mind, this commit removes the logic that renders the
unauthenticated links from the Nav / Header components.