### PR TITLE
Set X-Frame-Options: SAMEORIGIN for previews

### DIFF
--- a/api/controllers/PreviewController.js
+++ b/api/controllers/PreviewController.js
@@ -22,6 +22,7 @@ module.exports = {
           var redirect = headers['x-amz-website-redirect-location'] ||
             headers['X-Amz-Website-Redirect-Location'];
           if (redirect) return res.redirect(redirect);
+          headers['x-frame-options'] = 'SAMEORIGIN';
           res.set(headers);
         }),
         stream = object.createReadStream().on('error', function(error) {


### PR DESCRIPTION
This is a potential fix for #706 that sets the `X-Frame-Options` [header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) to `SAMEORIGIN` so that hosted sites can display legitimate `<iframe>` elements referencing pages in the same domain. 

From a compliance perspective this may be a no-no because this _technically_ allows different Federalist sites to load one another's previews, but I think the risk of click-jacking is pretty low if we assume that most (all?) Federalist sites are entirely static. (Sites that authenticate with other services via AJAX would still, theoretically, be vulnerable.)

cc @jmhooper @NoahKunin 