### PR TITLE
Use consistent API error response format

### DIFF
--- a/api/controllers/BuildController.js
+++ b/api/controllers/BuildController.js
@@ -7,9 +7,7 @@ const verifyUserIsAuthorizedToRestartBuild = (user, build) => {
     const index = user.sites.findIndex(site => site.id === build.site)
 
     if (index < 0) {
-      const error = new Error("Unauthorized")
-      error.statusCode = 403
-      throw error
+      throw 403
     }
   })
 }
@@ -32,11 +30,7 @@ module.exports = {
     }).then(build => {
       res.json(build)
     }).catch(err => {
-      if (err.statusCode === 403) {
-        res.forbidden()
-      } else {
-        res.badRequest(err)
-      }
+      res.error(err)
     })
   },
 
@@ -45,21 +39,14 @@ module.exports = {
 
     Build.findOne(req.param("id")).then(build => {
       if (!build) {
-        var error = new Error(`Unable to find build with id: ${req.param("id")}`)
-        error.statusCode = 404
-        throw error
+        throw 404
       } else {
         return Build.completeJob(message, build)
       }
     }).then(build => {
       res.ok()
     }).catch(err => {
-      if (err.statusCode == 404) {
-        res.notFound()
-      } else {
-        res.serverError()
-        sails.log.error(err)
-      }
+      res.error(err)
     })
   },
 }

--- a/api/controllers/BuildLogController.js
+++ b/api/controllers/BuildLogController.js
@@ -4,9 +4,7 @@ const authorizeUserForBuild = ({ user, build }) => {
       return site.id === build.site
     })
     if (siteIndex < 0) {
-      const error = new Error("Unauthorized")
-      error.code = 403
-      throw error
+      throw 403
     }
   })
 }
@@ -15,9 +13,7 @@ module.exports = {
   create: (req, res) => {
     Build.findOne(req.param("build_id")).then(build => {
       if (!build) {
-        const error = new Error("Not found")
-        error.code = 404
-        throw error
+        throw 404
       }
       return BuildLog.create({
         build: build,
@@ -29,11 +25,7 @@ module.exports = {
     }).then(buildLog => {
       res.json(buildLog)
     }).catch(err => {
-      if (err.code === 404) {
-        res.notFound()
-      } else {
-        res.serverError(err)
-      }
+      res.error(err)
     })
   },
 
@@ -44,9 +36,7 @@ module.exports = {
       build = model
 
       if (!build) {
-        const error = new Error("Not found")
-        error.code = 404
-        throw error
+        throw 404
       }
 
       return authorizeUserForBuild({
@@ -58,13 +48,7 @@ module.exports = {
     }).then(buildLogs => {
       res.json(buildLogs)
     }).catch(err => {
-      if (err.code === 404) {
-        res.notFound()
-      } else if (err.code === 403) {
-        res.forbidden()
-      } else {
-        res.serverError(err)
-      }
+      res.error(err)
     })
   },
 

--- a/api/models/BuildLog.js
+++ b/api/models/BuildLog.js
@@ -1,4 +1,6 @@
 const saniztizeBuildSecrets = (values, callback) => {
+  values.output = values.output || ""
+
   Build.findOne(values.build.id || values.build).populate("user").then(build => {
     secrets = [
       sails.config.s3.accessKeyId,

--- a/api/responses/badRequest.js
+++ b/api/responses/badRequest.js
@@ -1,63 +1,11 @@
-/**
- * 400 (Bad Request) Handler
- *
- * Usage:
- * return res.badRequest();
- * return res.badRequest(data);
- * return res.badRequest(data, 'some/specific/badRequest/view');
- *
- * e.g.:
- * ```
- * return res.badRequest(
- *   'Please choose a valid `password` (6-12 characters)',
- *   'trial/signup'
- * );
- * ```
- */
+module.exports = function badRequest(error = {}, options) {
+  const res = this.res;
 
-module.exports = function badRequest(data, options) {
+  sails.log.verbose('Sending 400 ("Bad Request") response: \n', error)
 
-  // Get access to `req`, `res`, & `sails`
-  var req = this.req;
-  var res = this.res;
-  var sails = req._sails;
-
-  // Set status code
-  res.status(400);
-
-  // Log error to console
-  if (data !== undefined) {
-    sails.log.verbose('Sending 400 ("Bad Request") response: \n',data);
-  }
-  else sails.log.verbose('Sending 400 ("Bad Request") response');
-
-  // Only include errors in response if application environment
-  // is not set to 'production'.  In production, we shouldn't
-  // send back any identifying information about errors.
-  // if (sails.config.environment === 'production') {
-  //   data = undefined;
-  // }
-
-  // If the user-agent wants JSON, always respond with JSON
-  if (req.wantsJSON) {
-    return res.jsonx(data);
-  }
-
-  // If second argument is a string, we take that to mean it refers to a view.
-  // If it was omitted, use an empty object (`{}`)
-  options = (typeof options === 'string') ? { view: options } : options || {};
-
-  // If a view was provided in options, serve it.
-  // Otherwise try to guess an appropriate view, or if that doesn't
-  // work, just send JSON.
-  if (options.view) {
-    return res.view(options.view, { data: data });
-  }
-
-  // If no second argument provided, try to serve the implied view,
-  // but fall back to sending JSON(P) if no view can be inferred.
-  else return res.guessView({ data: data }, function couldNotGuessView () {
-    return res.jsonx(data);
-  });
-
-};
+  res.status(400)
+  return res.json({
+    message: error.message || "Bad Request",
+    status: 400,
+  })
+}

--- a/api/responses/error.js
+++ b/api/responses/error.js
@@ -1,0 +1,32 @@
+module.exports = function badRequest(error = {}, options) {
+  const res = this.res;
+
+
+  if (typeof error === "number") {
+    error = {
+      status: error,
+    }
+  } else if (error.code && error.code === "E_VALIDATION") {
+    error = {
+      status: 400,
+      message: "The request parameters were invalid."
+    }
+  }
+
+  const status = parseInt(error.status) || 500
+
+  switch(status) {
+    case 400:
+      res.badRequest(error)
+      break
+    case 403:
+      res.forbidden(error)
+      break
+    case 404:
+      res.notFound(error)
+      break
+    case 500:
+    default:
+      res.serverError(error)
+  }
+}

--- a/api/responses/forbidden.js
+++ b/api/responses/forbidden.js
@@ -1,77 +1,11 @@
-/**
- * 403 (Forbidden) Handler
- *
- * Usage:
- * return res.forbidden();
- * return res.forbidden(err);
- * return res.forbidden(err, 'some/specific/forbidden/view');
- *
- * e.g.:
- * ```
- * return res.forbidden('Access denied.');
- * ```
- */
+module.exports = function badRequest(error = {}, options) {
+  const res = this.res;
 
-module.exports = function forbidden (data, options) {
+  sails.log.verbose('Sending 403 ("Forbidden") response: \n', error)
 
-  // Get access to `req`, `res`, & `sails`
-  var req = this.req;
-  var res = this.res;
-  var sails = req._sails;
-
-  // Set status code
-  res.status(403);
-
-  // Log error to console
-  if (data !== undefined) {
-    sails.log.verbose('Sending 403 ("Forbidden") response: \n',data);
-  }
-  else sails.log.verbose('Sending 403 ("Forbidden") response');
-
-  // Only include errors in response if application environment
-  // is not set to 'production'.  In production, we shouldn't
-  // send back any identifying information about errors.
-  if (sails.config.environment === 'production') {
-    data = undefined;
-  }
-
-  // If the user-agent wants JSON, always respond with JSON
-  if (req.wantsJSON) {
-    return res.jsonx(data);
-  }
-
-  // If second argument is a string, we take that to mean it refers to a view.
-  // If it was omitted, use an empty object (`{}`)
-  options = (typeof options === 'string') ? { view: options } : options || {};
-
-  // If a view was provided in options, serve it.
-  // Otherwise try to guess an appropriate view, or if that doesn't
-  // work, just send JSON.
-  if (options.view) {
-    return res.view(options.view, { data: data });
-  }
-
-  // If no second argument provided, try to serve the default view,
-  // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('403', { data: data }, function (err, html) {
-
-    // If a view error occured, fall back to JSON(P).
-    if (err) {
-      //
-      // Additionally:
-      // • If the view was missing, ignore the error but provide a verbose log.
-      if (err.code === 'E_VIEW_FAILED') {
-        sails.log.verbose('res.forbidden() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
-      }
-      // Otherwise, if this was a more serious error, log to the console with the details.
-      else {
-        sails.log.warn('res.forbidden() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
-      }
-      return res.jsonx(data);
-    }
-
-    return res.send(html);
-  });
-
-};
-
+  res.status(403)
+  return res.json({
+    message: error.message || "You are not authorized to perform that action",
+    status: 403,
+  })
+}

--- a/api/responses/notFound.js
+++ b/api/responses/notFound.js
@@ -1,82 +1,11 @@
-/**
- * 404 (Not Found) Handler
- *
- * Usage:
- * return res.notFound();
- * return res.notFound(err);
- * return res.notFound(err, 'some/specific/notfound/view');
- *
- * e.g.:
- * ```
- * return res.notFound();
- * ```
- *
- * NOTE:
- * If a request doesn't match any explicit routes (i.e. `config/routes.js`)
- * or route blueprints (i.e. "shadow routes", Sails will call `res.notFound()`
- * automatically.
- */
+module.exports = function badRequest(error = {}, options) {
+  const res = this.res;
 
-module.exports = function notFound (data, options) {
+  sails.log.verbose('Sending 404 ("Not found") response: \n', error)
 
-  // Get access to `req`, `res`, & `sails`
-  var req = this.req;
-  var res = this.res;
-  var sails = req._sails;
-
-  // Set status code
-  res.status(404);
-
-  // Log error to console
-  if (data !== undefined) {
-    sails.log.verbose('Sending 404 ("Not Found") response: \n',data);
-  }
-  else sails.log.verbose('Sending 404 ("Not Found") response');
-
-  // Only include errors in response if application environment
-  // is not set to 'production'.  In production, we shouldn't
-  // send back any identifying information about errors.
-  if (sails.config.environment === 'production') {
-    data = undefined;
-  }
-
-  // If the user-agent wants JSON, always respond with JSON
-  if (req.wantsJSON) {
-    return res.jsonx(data);
-  }
-
-  // If second argument is a string, we take that to mean it refers to a view.
-  // If it was omitted, use an empty object (`{}`)
-  options = (typeof options === 'string') ? { view: options } : options || {};
-
-  // If a view was provided in options, serve it.
-  // Otherwise try to guess an appropriate view, or if that doesn't
-  // work, just send JSON.
-  if (options.view) {
-    return res.view(options.view, { data: data });
-  }
-
-  // If no second argument provided, try to serve the default view,
-  // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('404', { data: data }, function (err, html) {
-
-    // If a view error occured, fall back to JSON(P).
-    if (err) {
-      //
-      // Additionally:
-      // • If the view was missing, ignore the error but provide a verbose log.
-      if (err.code === 'E_VIEW_FAILED') {
-        sails.log.verbose('res.notFound() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
-      }
-      // Otherwise, if this was a more serious error, log to the console with the details.
-      else {
-        sails.log.warn('res.notFound() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
-      }
-      return res.jsonx(data);
-    }
-
-    return res.send(html);
-  });
-
-};
-
+  res.status(404)
+  return res.json({
+    message: error.message || "Not found",
+    status: 404,
+  })
+}

--- a/api/responses/serverError.js
+++ b/api/responses/serverError.js
@@ -1,77 +1,11 @@
-/**
- * 500 (Server Error) Response
- *
- * Usage:
- * return res.serverError();
- * return res.serverError(err);
- * return res.serverError(err, 'some/specific/error/view');
- *
- * NOTE:
- * If something throws in a policy or controller, or an internal
- * error is encountered, Sails will call `res.serverError()`
- * automatically.
- */
+module.exports = function badRequest(error = {}, options) {
+  const res = this.res;
 
-module.exports = function serverError (data, options) {
+  sails.log.error('Sending 500 ("Server Error") response: \n', error)
 
-  // Get access to `req`, `res`, & `sails`
-  var req = this.req;
-  var res = this.res;
-  var sails = req._sails;
-
-  // Set status code
-  res.status(500);
-
-  // Log error to console
-  if (data !== undefined) {
-    sails.log.error('Sending 500 ("Server Error") response: \n',data);
-  }
-  else sails.log.error('Sending empty 500 ("Server Error") response');
-
-  // Only include errors in response if application environment
-  // is not set to 'production'.  In production, we shouldn't
-  // send back any identifying information about errors.
-  // if (sails.config.environment === 'production') {
-  //   data = undefined;
-  // }
-
-  // If the user-agent wants JSON, always respond with JSON
-  if (req.wantsJSON) {
-    return res.jsonx(data);
-  }
-
-  // If second argument is a string, we take that to mean it refers to a view.
-  // If it was omitted, use an empty object (`{}`)
-  options = (typeof options === 'string') ? { view: options } : options || {};
-
-  // If a view was provided in options, serve it.
-  // Otherwise try to guess an appropriate view, or if that doesn't
-  // work, just send JSON.
-  if (options.view) {
-    return res.view(options.view, { data: data });
-  }
-
-  // If no second argument provided, try to serve the default view,
-  // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('500', { data: data }, function (err, html) {
-
-    // If a view error occured, fall back to JSON(P).
-    if (err) {
-      //
-      // Additionally:
-      // • If the view was missing, ignore the error but provide a verbose log.
-      if (err.code === 'E_VIEW_FAILED') {
-        sails.log.verbose('res.serverError() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
-      }
-      // Otherwise, if this was a more serious error, log to the console with the details.
-      else {
-        sails.log.warn('res.serverError() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
-      }
-      return res.jsonx(data);
-    }
-
-    return res.send(html);
-  });
-
-};
-
+  res.status(500)
+  return res.json({
+    message: "Internal server error",
+    status: 500,
+  })
+}

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -4,6 +4,7 @@ const createWebhook = (github, options) => {
   return new Promise((resolve, reject) => {
     github.repos.createHook(options, (err, res) => {
       if (err) {
+        err.status = err.code
         reject(err)
       } else {
         resolve(res)
@@ -16,6 +17,7 @@ const getOrganizations = (github) => {
   return new Promise((resolve, reject) => {
     github.user.getOrgs({}, (err, organizations) => {
       if (err) {
+        err.status = err.code
         reject(err)
       } else {
         resolve(organizations)
@@ -28,6 +30,7 @@ const getRepository = (github, options) => {
   return new Promise((resolve, reject) => {
     github.repos.get(options, (err, repo) => {
       if (err) {
+        err.status = err.code
         reject(err)
       } else {
         resolve(repo)

--- a/assets/swagger/Error.json
+++ b/assets/swagger/Error.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "required": [
+    "status",
+    "message"
+  ],
+  "properties": {
+    "status": {
+      "type": "number"
+    },
+    "message": {
+      "type": "string"
+    }
+  }
+}

--- a/assets/swagger/index.yml
+++ b/assets/swagger/index.yml
@@ -20,6 +20,10 @@ paths:
             type: array
             items:
               $ref: "Build.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
   /build/{id}:
     parameters:
     - name: id
@@ -34,6 +38,14 @@ paths:
           description: The build object specified by the ID
           schema:
             $ref: "Build.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
   /build/{id}/status/{token}:
     parameters:
     - name: id
@@ -47,7 +59,10 @@ paths:
       type: string
       required: true
     post:
-      summary: Update a build's status. This endpoint is designed to be used by the build container to update the build's status when the build is done with its work.
+      summary: |
+        Update a build's status. This endpoint is designed to be used by the
+        build container to update the build's status when the build is done with
+        its work.
       parameters:
       - name: status
         in: body
@@ -65,6 +80,18 @@ paths:
       responses:
         200:
           description: Acknowledgement that the build has been updated
+        400:
+          description: Bad request
+          schema:
+            $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
   /build/{id}/restart:
     parameters:
       - name: id
@@ -79,6 +106,18 @@ paths:
           description: Acknowledgement that the build has been restarted
           schema:
             $ref: "Build.json"
+        400:
+          description: Bad request
+          schema:
+            $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
   /build/{build_id}/log/{token}:
     parameters:
     - name: build_id
@@ -98,6 +137,18 @@ paths:
           description: Acknowledgement that the build log was created
           schema:
             $ref: "BuildLog.json"
+        400:
+          description: Bad request
+          schema:
+            $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
   /build/{build_id}/log:
     parameters:
     - name: build_id
@@ -114,6 +165,14 @@ paths:
             type: array
             items:
               $ref: "BuildLog.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
   /site:
     get:
       summary: Fetch all of the current user's sites
@@ -124,6 +183,10 @@ paths:
             type: array
             items:
               $ref: "Site.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
     post:
       summary: Create a site
       parameters:
@@ -152,12 +215,25 @@ paths:
                 description: The name of the GitHub repository for the site
               template:
                 type: string
-                description: The name of a Federalist site template. If provided, the a new repo will be created from the repo for the given template. If a template is not provided, Federalist will not create a new repo and will instead expect to build a site from an existing repo.
+                description: |
+                  The name of a Federalist site template. If provided, the a new
+                  repo will be created from the repo for the given template. If
+                  a template is not provided, Federalist will not create a new
+                  repo and will instead expect to build a site from an existing
+                  repo.
       responses:
         200:
           description: The newly created site
           schema:
             $ref: "Site.json"
+        400:
+          description: Bad request
+          schema:
+            $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
   /site/{id}:
     parameters:
     - name: id
@@ -172,6 +248,14 @@ paths:
           description: The site object for the given ID
           schema:
             $ref: "Site.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
     put:
       summary: Update the data for a Federalist site. This action will trigger a rebuild of the site.
       parameters:
@@ -203,6 +287,18 @@ paths:
           description: The updated site object
           schema:
             $ref: "Site.json"
+        400:
+          description: Bad request
+          schema:
+            $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
     delete:
       summary: Delete a site from Federalist
       responses:
@@ -210,6 +306,14 @@ paths:
           description: Acknowledgement that the site was deleted
           schema:
             $ref: "Site.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
   /me:
     get:
       summary: Fetch data for the current user
@@ -218,6 +322,10 @@ paths:
           description: A user object representing the current Federalist user
           schema:
             $ref: "CurrentUser.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
   /user/{id}:
     parameters:
     - name: id
@@ -232,6 +340,14 @@ paths:
           description: A user object for the given ID
           schema:
             $ref: "User.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
   /user/usernames:
     get:
       summary: Fetch the usernames for every user in federalist
@@ -242,3 +358,7 @@ paths:
             type: array
             items:
               type: string
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -28,7 +28,7 @@ describe("Build API", () => {
           .get(`/v0/build/${build.id}`)
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/build/{id}", 403, response.body)
         done()
       })
     })
@@ -71,7 +71,7 @@ describe("Build API", () => {
           .set("Cookie", cookie)
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/build/{id}", 403, response.body)
         done()
       })
     })
@@ -84,7 +84,7 @@ describe("Build API", () => {
           .get("/v0/build")
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/build", 403, response.body)
         done()
       })
     })

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -32,7 +32,7 @@ describe("Site API", () => {
           .get("/v0/site")
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/site", 403, response.body)
         done()
       })
     })
@@ -102,7 +102,7 @@ describe("Site API", () => {
           .get(`/v0/site/${site.id}`)
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/site/{id}", 403, response.body)
         done()
       })
     })
@@ -139,7 +139,7 @@ describe("Site API", () => {
           .set("Cookie", cookie)
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/site/{id}", 403, response.body)
         done()
       })
     })
@@ -167,7 +167,7 @@ describe("Site API", () => {
         .expect(403)
 
       cloneRequest.then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("POST", "/site", 403, response.body)
         done()
       })
     })
@@ -760,7 +760,7 @@ describe("Site API", () => {
           .delete(`/v0/site/${site.id}`)
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("DELETE", "/site/{id}", 403, response.body)
         done()
       })
     })
@@ -802,7 +802,7 @@ describe("Site API", () => {
           .set("Cookie", cookie)
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("DELETE", "/site/{id}", 403, response.body)
         return Site.find({ id: site.id })
       }).then(sites => {
         expect(sites).not.to.be.empty
@@ -821,7 +821,7 @@ describe("Site API", () => {
           })
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("PUT", "/site/{id}", 403, response.body)
         done()
       })
     })
@@ -872,7 +872,7 @@ describe("Site API", () => {
           .expect(403)
       }).then(resp => {
         response = resp
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("PUT", "/site/{id}", 403, response.body)
         return Site.findOne({ id: site.id }).populate("users")
       }).then(site => {
         expect(site).to.have.property("repository", "old-repo-name")

--- a/test/api/requests/user.test.js
+++ b/test/api/requests/user.test.js
@@ -24,7 +24,7 @@ describe("User API", () => {
           .get("/v0/me")
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/me", 403, response.body)
         done()
       })
     })
@@ -59,7 +59,7 @@ describe("User API", () => {
           .get(`/v0/user/${user.id}`)
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/user/{id}", 403, response.body)
         done()
       })
     })
@@ -110,7 +110,7 @@ describe("User API", () => {
           .set("Cookie", cookie)
           .expect(403)
       }).then(response => {
-        expect(response.body).to.be.empty
+        validateAgainstJSONSchema("GET", "/user/{id}", 403, response.body)
         done()
       })
     })


### PR DESCRIPTION
This commit uses the following response structure for every API error response:

```json
{
  "status": 403,
  "message": "You are not authorized to do that thing"
}
```

### Error response handlers

This change heavily modifies the response helpers for errors. For generic errors, an error response handler was added which attempts to determine what type of error has occurred and pipe it to the correct response helper. This done by:

1. *Checking the status:* If the error has a status code that matches a supported HTTP error status code, then the error will be piped to the error handler for that status code. Additionally, if the error is simply a number, (e.g. `throw 404`) a generic error for the corresponding status code will be used.
1. *Checking if the error is a Waterline validation error:* Validation errors from Waterline result in a 400.
1. *Creating a generic 500:* If the error response handler cannot make a determination, it renders a 500 with a generic message.

```javascript
// Render a 404
res.error(404)

// Render a 403
res.error({
  status: 403,
  message: "You need admin privileges to do that."
})

// Render a 500
Promise.resolve().then(() => {
  undefined.property
}).catch(err => {
  res.error(err)
})
```

### Controllers

This commit modifies the way errors are handled in controllers to use the new error response handlers.

### Tests

This commit adds the error responses to the Swagger file, which adds a JSON schema for errors. This commit uses that JSON schema in the tests to verify that errors match the expected format.