### PR TITLE
Add AlertBanner to SiteList

### DIFF
--- a/assets/app/components/siteList/siteList.js
+++ b/assets/app/components/siteList/siteList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import AlertBanner from '../alertBanner';
 import SiteListItem from './siteListItem';
 import LinkButton from '../linkButton';
 
@@ -46,6 +47,7 @@ const SiteList = ({ storeState }) =>
           text="Add Website" />
       </div>
     </div>
+    <AlertBanner {...storeState.alert} />
     { getSites(storeState.sites) }
     <div className="usa-grid">
       <div className="usa-width-one-whole">


### PR DESCRIPTION
This commit changes the SiteList component so that it renders an alert banner when there is an error. This was not the case before which meant errors were not being displayed to users.

This issue was most obvious when there was an error adding a site, since the SiteList component is where a user lands after such an error occurs. Prior to this commit, no error message was visible.

Ref #205