### PR TITLE
Lowercase GitHub owner and repo name before saving a site

### DIFF
--- a/api/models/Site.js
+++ b/api/models/Site.js
@@ -56,6 +56,16 @@ module.exports = {
     this.registerSite(values, done);
   },
 
+  beforeValidate: function(values, done) {
+    if (values.repository) {
+      values.repository = values.repository.toLowerCase()
+    }
+    if (values.owner) {
+      values.owner = values.owner.toLowerCase()
+    }
+    done()
+  },
+
   registerSite: function(values, done) {
     const webhookUserId = values.users[0].id || values.users[0]
     GitHub.setWebhook(values, webhookUserId).then(() => {

--- a/test/api/unit/models/Site.test.js
+++ b/test/api/unit/models/Site.test.js
@@ -1,35 +1,56 @@
-var assert = require('assert'),
-    sinon = require('sinon');
+const expect = require('chai').expect
+const sinon = require('sinon')
 
-describe('Site Model', function() {
+describe('Site Model', () => {
 
-  describe('.beforeCreate', function(){
-    it('should register site', function(done) {
-      var registerSite = Site.registerSite;
-      Site.registerSite = sinon.spy(function() {
-        assert(Site.registerSite.called);
-        Site.registerSite = registerSite;
-        done();
-      });
-      Site.beforeCreate({});
-    });
-  });
+  describe('.beforeCreate', () => {
+    it('should register site', (done) => {
+      var registerSite = Site.registerSite
+      Site.registerSite = sinon.spy(() => {
+        expect(Site.registerSite.called).to.be.true
+        Site.registerSite = registerSite
+        done()
+      })
+      Site.beforeCreate({})
+    })
+  })
 
-  describe('.registerSite', function(){
-    it('should call GitHub.setWebhook', function(done) {
-      var setWebhook = GitHub.setWebhook;
-      GitHub.setWebhook = sinon.spy(function() {
-        assert(GitHub.setWebhook.called);
-        GitHub.setWebhook = setWebhook;
-        done();
-        return Promise.resolve();
-      });
+  describe(".beforeValidate", () => {
+    it("should lowercase the GitHub repository owner and name", done => {
+      const site = {
+        owner: "RepoOwner",
+        repository: "RepoName",
+      }
+      Site.beforeValidate(site, err => {
+        expect(err).to.be.undefined
+        expect(site.owner).to.equal("repoowner")
+        expect(site.repository).to.equal("reponame")
+        done()
+      })
+    })
+
+    it("should not error for an empty hash", done => {
+      Site.beforeValidate({}, err => {
+        expect(err).to.be.undefined
+        done()
+      })
+    })
+  })
+
+  describe('.registerSite', () => {
+    it('should call GitHub.setWebhook', done => {
+      const setWebhook = GitHub.setWebhook
+      GitHub.setWebhook = sinon.spy(() => {
+        expect(GitHub.setWebhook.called).to.be.true
+        GitHub.setWebhook = setWebhook
+        done()
+        return Promise.resolve()
+      })
       Site.registerSite({
         users: [1],
         owner: "someone",
         repository: "something",
-      }, () => {});
-    });
-  });
-
-});
+      }, () => {})
+    })
+  })
+})


### PR DESCRIPTION
This commit lowercases the GitHub owner and repo name in the `beforeValidate` callback in the Site model. This callback is called every time `save` is called on a site. There are a number of advantages to this:

1. Consistent case in URLs (ref #331)
1. Support for `federalist-redirects` which expects a lower case owner name