### PR TITLE
Replace build restart with generic create action

### DIFF
--- a/api/authorizers/build.js
+++ b/api/authorizers/build.js
@@ -13,8 +13,11 @@ const findOne = (user, build) => {
   return authorize(user, build)
 }
 
-const restart = (user, build) => {
-  return authorize(user, build)
+const create = (user, params) => {
+  if (user.id != params.user) {
+    throw 403
+  }
+  return authorize(user, params)
 }
 
-module.exports = { findOne, restart }
+module.exports = { findOne, create }

--- a/api/controllers/BuildController.js
+++ b/api/controllers/BuildController.js
@@ -11,6 +11,23 @@ module.exports = {
     })
   },
 
+  create: (req, res) => {
+    const params = {
+      branch: req.param("branch"),
+      site: req.param("site"),
+      user: req.user.id,
+    }
+    authorizer.create(req.user, params).then(() => {
+      return Build.create(params)
+    }).then(build => {
+      return Build.findOne(build.id).populate("user").populate("site")
+    }).then(build => {
+      res.json(build)
+    }).catch(err => {
+      res.error(err)
+    })
+  },
+
   findOne: (req, res) => {
     let build
 
@@ -22,27 +39,6 @@ module.exports = {
       }
       return authorizer.findOne(req.user, build)
     }).then(() => {
-      res.json(build)
-    }).catch(err => {
-      res.error(err)
-    })
-  },
-
-  restart: (req, res) => {
-    let build
-
-    Build.findOne(req.param("id")).then(model => {
-      build = model
-      return authorizer.restart(req.user, build)
-    }).then(() => {
-      return Build.create({
-        branch: build.branch,
-        site: build.site,
-        user: req.user.id,
-      })
-    }).then(build => {
-      return Build.findOne(build.id).populate("user").populate("site")
-    }).then(build => {
       res.json(build)
     }).catch(err => {
       res.error(err)

--- a/assets/app/reducers/sites.js
+++ b/assets/app/reducers/sites.js
@@ -119,7 +119,7 @@ export default function sites(state = initialState, action) {
 
   case BUILD_RESTARTED:
     return state.map(site => {
-      if (site.id === action.build.site) {
+      if (site.id === action.build.site.id) {
         return Object.assign({}, site, {
           builds: [action.build, ...site.builds],
         })

--- a/assets/app/util/federalistApi.js
+++ b/assets/app/util/federalistApi.js
@@ -51,8 +51,12 @@ export default {
   },
 
   restartBuild(build) {
-    return this.fetch(`build/${build.id}/restart`, {
-      method: 'POST'
-    })
+    return this.fetch(`build/`, {
+      method: 'POST',
+      data: {
+        site: build.site.id || build.site,
+        branch: build.branch,
+      },
+    });
   },
 }

--- a/assets/swagger/index.yml
+++ b/assets/swagger/index.yml
@@ -24,6 +24,35 @@ paths:
           description: Not authorized
           schema:
             $ref: "Error.json"
+    post:
+      summary: Create a build
+      parameters:
+        - name: build
+          in: body
+          schema:
+            type: object
+            properties:
+              site:
+                type: integer
+                description: The ID of the site to build.
+              branch:
+                type: string
+                description: |
+                  The branch that should be built. If no branch is provided, the
+                  site's default branch will be built.
+      responses:
+        200:
+          description: The newly created build
+          schema:
+            $ref: "Build.json"
+        400:
+          description: Bad request
+          schema:
+            $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
   /build/{id}:
     parameters:
     - name: id
@@ -80,32 +109,6 @@ paths:
       responses:
         200:
           description: Acknowledgement that the build has been updated
-        400:
-          description: Bad request
-          schema:
-            $ref: "Error.json"
-        403:
-          description: Not authorized
-          schema:
-            $ref: "Error.json"
-        404:
-          description: Not found
-          schema:
-            $ref: "Error.json"
-  /build/{id}/restart:
-    parameters:
-      - name: id
-        in: path
-        description: The id of the build
-        type: integer
-        required: true
-    post:
-      summary: Create a new build mirrored after the given build.
-      responses:
-        200:
-          description: Acknowledgement that the build has been restarted
-          schema:
-            $ref: "Build.json"
         400:
           description: Bad request
           schema:

--- a/config/policies.js
+++ b/config/policies.js
@@ -56,9 +56,9 @@ module.exports.policies = {
   },
 
   BuildController: {
+    'create': ['passport', 'sessionAuth'],
     'find': ['passport', 'sessionAuth'],
     'findOne': ['passport', 'sessionAuth'],
-    'restart': ['passport', 'sessionAuth'],
     'status': ['buildCallback'],
   },
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -3,9 +3,9 @@ module.exports.routes = {
     API
   */
   // Builds
+  "post /v0/build": "BuildController.create",
   "get /v0/build": "BuildController.find",
   "get /v0/build/:id": "BuildController.findOne",
-  "post /v0/build/:id/restart": "BuildController.restart",
 
   // Build logs
   "get /v0/build/:build_id/log": "BuildLogController.find",

--- a/test/api/unit/authorizers/build.test.js
+++ b/test/api/unit/authorizers/build.test.js
@@ -4,7 +4,7 @@ const factory = require("../../support/factory")
 const authorizer = require("../../../../api/authorizers/build.js")
 
 describe("Build authorizer", () => {
-  describe("findOne", () => {
+  describe("findOne(user, build)", () => {
     it("should resolve if the build is associated with one of the user's site", done => {
       factory(User).then(user => {
         const site = factory(Site, { users: [user] })
@@ -43,16 +43,12 @@ describe("Build authorizer", () => {
     })
   })
 
-  describe("restart", () => {
+  describe("create(user, params)", () => {
     it("should resolve if the build is associated with one of the user's site", done => {
-      factory(User).then(user => {
-        const site = factory(Site, { users: [user] })
-        return Promise.props({
-          user: user,
-          build: factory(Build, { site: site }),
-        })
-      }).then(({ user, build }) => {
-        return authorizer.restart(user, build)
+      const user = factory(User)
+      const site = factory(Site, { users: Promise.all([user]) })
+      Promise.props({ user, site }).then(({ user, site }) => {
+        return authorizer.create(user, { user: user.id, site: site.id })
       }).then(() => {
         done()
       })
@@ -61,20 +57,21 @@ describe("Build authorizer", () => {
     it("should reject if the build is not associated with one of the user's sites", done => {
       Promise.props({
         user: factory(User),
-        build: factory(Build),
+        site: factory(Site),
       }).then(({ user, build }) => {
-        return authorizer.restart(user, build)
+        return authorizer.create(user, { user: user.id, site: site.id })
       }).catch(err => {
         expect(err).to.equal(403)
         done()
       })
     })
 
-    it("should reject if the build is not associated with one of the user's site even if the user started the build", done => {
+    it("should reject if the build is not associated with the current user", done => {
       const user = factory(User)
-      const build = factory(Build, { user: user, site: factory(Site) })
-      Promise.props({ user, build }).then(({ user, build }) => {
-        return authorizer.restart(user, build)
+      const otherUser = factory(User)
+      const site = factory(Site, { users: Promise.all([user, otherUser]) })
+      Promise.props({ user, otherUser, site }).then(({ user, otherUser, site }) => {
+        return authorizer.create(user, { user: otherUser.id, site: site.id })
       }).catch(err => {
         expect(err).to.equal(403)
         done()

--- a/test/client/app/reducers/sitesTest.js
+++ b/test/client/app/reducers/sitesTest.js
@@ -788,7 +788,7 @@ describe("sitesReducer", () => {
       id: "not this one",
     };
     const build = {
-      site: "pick this one",
+      site: sitePendingRestart,
     };
     const restartedSite = Object.assign({}, sitePendingRestart, {
       builds: [build, ...sitePendingRestart.builds],


### PR DESCRIPTION
These commits replace the build restart API action, which was previously `POST /v0/build/:id/restart`, with a generic create action for builds. Besides being more RESTful, this also has the advantage of being more extensible down the line.

Ref #648 