### PR TITLE
Look for build object instead of id for build logs in frontend

### DIFF
--- a/assets/app/components/site/siteBuildLogs.js
+++ b/assets/app/components/site/siteBuildLogs.js
@@ -12,7 +12,7 @@ class SiteBuildLogs extends React.Component {
     }
 
     return this.props.buildLogs.filter(log => {
-      return log.build === parseInt(this.props.params.buildId);
+      return log.build.id === parseInt(this.props.params.buildId);
     }).sort((a, b) => {
       return new Date(a.createdAt) - new Date(b.createdAt);
     });

--- a/test/client/app/components/site/siteBuildLogs.test.js
+++ b/test/client/app/components/site/siteBuildLogs.test.js
@@ -8,8 +8,8 @@ describe("<SiteBuildLogs/>", () => {
     const props = {
       params: { buildId: 1 },
       buildLogs: [
-        { build: 1, output: "output 1", source: "source 1" },
-        { build: 1, output: "output 2", source: "source 2" },
+        { build: { id: 1 }, output: "output 1", source: "source 1" },
+        { build: { id: 1 }, output: "output 2", source: "source 2" },
       ],
     };
 
@@ -25,8 +25,8 @@ describe("<SiteBuildLogs/>", () => {
     const props = {
       params: { buildId: 1 },
       buildLogs: [
-        { build: 1, output: "output 1", source: "source 1" },
-        { build: 2, output: "output 2", source: "source 2" },
+        { build: { id: 1 } , output: "output 1", source: "source 1" },
+        { build: { id: 2 }, output: "output 2", source: "source 2" },
       ],
     };
 


### PR DESCRIPTION
Before f7317cf12ae11eae1f2a05ca958c9a6e2842cbc0, the build log API response object had an integer for the `build` property. After f7317cf12ae11eae1f2a05ca958c9a6e2842cbc0, that property was changed to be a build object, but the SiteBuildLogs component was not updated to be aware of that. This manifested itself in a bug where that component showed there were no build logs even though there should have been.

This commit update the SiteBuildLogs to eliminate that bug.