### PR TITLE
Fix download-sites-export script

### DIFF
--- a/scripts/download-sites-export.sh
+++ b/scripts/download-sites-export.sh
@@ -13,21 +13,19 @@ elif cf target | grep "Space: \s*production"; then
   APP_NAME="federalist"
 fi
 
+# Cleanup any old data
+if [[ -f current-sites.csv ]]; then
+  rm current-sites.csv
+fi
+
 # Run the export script on the instance
 cf ssh $APP_NAME <<EOD
 cd app
 PORT=4000 timeout 5s .heroku/node/bin/node scripts/exportSitesAsCsv.js
 EOD
 
-# Get the necessary values to scp to the instance
-APP_GUID=$(cf app $APP_NAME --guid)
-SSH_PASS=$(cf ssh-code)
-CF_USERNAME="cf:$APP_GUID/0"
+# Download current-sites.csv
+cf ssh $APP_NAME -c "cat /home/vcap/app/current-sites.csv" >> ./current-sites.csv
 
-# Use scp to download the file
-expect <<EOD
-spawn scp -P 2222 -o "User $CF_USERNAME" ssh.fr.cloud.gov:/home/vcap/app/current-sites.csv ./current-sites.csv
-expect "assword: "
-send "$SSH_PASS\r"
-sleep 2
-EOD
+# Instructions
+echo "Sites exported to $(pwd)/current-sites.csv"


### PR DESCRIPTION
This commit fixes the `download-sites-export.sh` script by removing `expect` and `scp` entirely and instead accessing the resulting CSV file the intended way with `cf ssh`.

Ref #678