### PR TITLE
Fix route declaration for preview URLS

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -34,7 +34,8 @@ module.exports.routes = {
   "get /sites(/*)?": "MainController.index",
 
   // Previews
-  "get /preview/:owner/:repo/:branch(/*)?": "PreviewController.proxy",
+  "get /preview/:owner/:repo/:branch": "PreviewController.proxy",
+  "get /preview/:owner/:repo/:branch/*": "PreviewController.proxy",
 
   /**
     Webhooks


### PR DESCRIPTION
This commit fixes the route declaration for preview URLs. Prior to this commit it combined a regex with a url param which apparently confused Sails's router. This commit splits it up into 2 declarations.

This reverts part of the changeset in 0f2876b986c1af9e688e24c12bb59274e688773b, but not in a way that is particularly concerning.

Ref #736