### PR TITLE
Hide site editor components

### DIFF
--- a/assets/app/components/site/SideNav/sideNav.js
+++ b/assets/app/components/site/SideNav/sideNav.js
@@ -19,16 +19,6 @@ class SideNav extends React.Component {
       <div className="usa-width-one-sixth" id="fool">
         <ul className="site-actions">
           <SideNavItem
-            href={this.getUrl(siteId)}
-            icon='pages'
-            linkText={sideNavPaths.PAGES}
-          />
-          <SideNavItem
-            href={this.getUrl(siteId, sideNavPaths.MEDIA)}
-            icon='media'
-            linkText={sideNavPaths.MEDIA}
-          />
-          <SideNavItem
             href={this.getUrl(siteId, sideNavPaths.SETTINGS)}
             icon='settings'
             linkText={sideNavPaths.SETTINGS}

--- a/assets/app/routes.js
+++ b/assets/app/routes.js
@@ -20,13 +20,7 @@ export default (
       <IndexRoute component={SiteList}/>
       <Route path="new" component={NewSite} />
       <Route path=":id" component={SiteContainer}>
-        <IndexRedirect to="tree" />
-        <Route path="tree" component={SitePagesContainer}>
-          <Route path="(**/):fileName" component={SitePagesContainer} />
-        </Route>
-        <Route path="new/:branch(/:fileName)" component={SiteEditorContainer} isNewPage={true} />
-        <Route path="edit/:branch/(**/):fileName" component={SiteEditorContainer}/>
-        <Route path="media" component={SiteMediaContainer}/>
+        <IndexRedirect to="settings" />
         <Route path="settings" component={SiteSettings}/>
         <Route path="builds">
           <IndexRoute component={SiteBuilds}/>


### PR DESCRIPTION
This commit hides the site editor components by removing their routes from the route definitions and removing the links from the site side bar nav.

This commit does not remove the code associated with them that is now dead code.