### PR TITLE
Add master to the list of branches that get built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
   only:
     - staging
+    - master
 cache: false
 language: node_js
 sudo: true


### PR DESCRIPTION
Changes merged into master prior to this commit have not been deployed,
because Travis was configured to only build the staging branch. This
commit adds the master branch to the list of branches that get built.