### PR TITLE
Remove "Hugo" as a build engine option in the frontend

### DIFF
--- a/assets/app/components/AddSite/index.js
+++ b/assets/app/components/AddSite/index.js
@@ -114,7 +114,6 @@ class AddSite extends React.Component {
                   onChange={this.onChange}
                 >
                   <option value="jekyll">Jekyll</option>
-                  <option value="hugo">Hugo</option>
                   <option value="static">Static (just publish the files in the repository)</option>
                 </select>
               </div>


### PR DESCRIPTION
This commit removes the "Hugo" option from the new "Add Site" screen's
drop down for adding sites from an existing repository. This is done
because we currently do not support Hugo and have never supported Hugo
in the past.

ref #756