### PR TITLE
Fetch database username from "user" prop in postgres config

### DIFF
--- a/api/modelss/index.js
+++ b/api/modelss/index.js
@@ -2,7 +2,7 @@ const Sequelize = require('sequelize');
 
 const postgresConfig = sails.config.connections.postgres
 const database = postgresConfig.database
-const username = postgresConfig.username
+const username = postgresConfig.user
 const password = postgresConfig.password
 
 const sequelize = new Sequelize(database, username, password, {


### PR DESCRIPTION
Prior to this commit, the app was looking for the username for the
database user in the config under "username". Sails does not use
"username" and instead uses "user" which meant the database adapter was
not finding a database username causing issues authenticationing with
the db.