### PR TITLE
Show correct error message when a user does not have GitHub admin access

### DIFF
--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -68,7 +68,9 @@ const handleWebhookError = (error) => {
     // noop
     return
   } else if (githubError === NO_ACCESS_MESSAGE) {
-    throw new Error(NO_ADMIN_ACCESS_ERROR_MESSAGE)
+    const error = new Error(NO_ADMIN_ACCESS_ERROR_MESSAGE)
+    error.status = 400
+    throw error
   } else {
     throw error
   }

--- a/test/api/unit/services/GitHub.test.js
+++ b/test/api/unit/services/GitHub.test.js
@@ -100,6 +100,7 @@ describe("GitHub", () => {
       }).then(() => {
         throw new Error("Expected admin access error")
       }).catch(err => {
+        expect(err.status).to.equal(400)
         expect(err.message).to.equal("You do not have admin access to this repository")
         done()
       }).catch(done)


### PR DESCRIPTION
Prior to this commit, when a user did not have admin access to a repository, the user would see an error with the message "Internal Server Error". The reason for this was two-fold:

1. Waterline wrapped errors that occurred in lifecycle callbacks in a WL_ERROR, which are interpreted as a 500.
2. The error was not setting its status code so it was interpreted as a 500.

With Waterline gone, 1 is no longer a problem. This commit fixes 2.

Additionally, this commit adds a test for this case.

ref #743