### PR TITLE
Fix error message for non-existant repo

### DIFF
--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -10,14 +10,14 @@ const createSite = ({ user, siteParams }) => {
 }
 
 checkExistingGithubRepository = ({ user, owner, repository }) => {
-  return GitHub.getRepository(user, owner, repository).then(repository => {
-    if (!repository) {
+  return GitHub.getRepository(user, owner, repository).then(repo => {
+    if (!repo) {
       throw {
         message: `The repository ${owner}/${repository} does not exist.`,
         status: 400,
       }
     }
-    if (!repository.permissions.push) {
+    if (!repo.permissions.push) {
       throw {
         message: "You do not have write access to this repository",
         status: 400,


### PR DESCRIPTION
When a repo didn't exist, the API would render an error message saying `The repo <org name>/null does not exist`. This was because the null repo object and the repo passed into the function checking the repos existence had a name collision. Because of this, the null repo object was being put in the error message.

This commit fixes the issue by using a different name for the repo object fetched from GitHub.

Ref #765