### PR TITLE
Proxy objects in S3 bucket that match a prefix

### DIFF
--- a/api/services/S3Proxy.js
+++ b/api/services/S3Proxy.js
@@ -60,7 +60,12 @@ const resolveKey = (path) => {
       if (err) {
         reject(err)
         return
-      } else if (data.Contents.length === 1 && data.Contents[0].Key === path) {
+      }
+
+      const object = data.Contents.find(candidate => {
+        return candidate.Key === path
+      })
+      if (object && object.Size > 0) {
         resolve(path)
       } else {
         resolve(path + "/index.html")


### PR DESCRIPTION
The logic in the S3Proxy service class was assuming that objects where the path prefix matched more than one bucket object were directories. This was not the case.

An example of an exception is a file named `uswds.min.js` and `uswds.min.js.map` in the same directory. They'll both match against `uswds.min.js`. The result of this is the S3Proxy attempting to proxy from `uswds.min.js/index.html`.

This commit solves this problem by doing the following:

1. Finding an object with a key that is an exact match
2. Checking the size of the object and resolve with a directory if the object has a size of 0