### PR TITLE
Use jekyll as the build engine for template sites

### DIFF
--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -81,6 +81,7 @@ const createSiteFromExistingRepo = ({ siteParams, user }) => {
 
 const createSiteFromTemplate = ({ siteParams, user, template }) => {
   let site = Site.build(siteParams)
+  site.engine = "jekyll"
   const { owner, repository } = siteParams
 
   return site.validate().then(error => {

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -281,6 +281,23 @@ describe("SiteCreator", () => {
         }).catch(done)
       })
 
+      it("should use jekyll as the build engine", done => {
+        const siteParams = {
+          owner: crypto.randomBytes(3).toString("hex"),
+          repository: crypto.randomBytes(3).toString("hex"),
+          template: "microsite",
+        }
+
+        factory.user().then(user => {
+          githubAPINocks.createRepoForOrg()
+          githubAPINocks.webhook()
+          return SiteCreator.createSite({ siteParams, user })
+        }).then(site => {
+          expect(site.engine).to.equal("jekyll")
+          done()
+        }).catch(done)
+      })
+
       it("should trigger a build that pushes the source repo to the destiantion repo", done => {
         let user
         const siteParams = {


### PR DESCRIPTION
The template sites are all jekyll sites, but default build engine for sites is the "static" build engine. Because of this, the "jekyll" option needs to be set explicitly in the SiteCreator. This commit does that.

ref #722