### PR TITLE
Lowercase owner/repo before looking up site for webhook

### DIFF
--- a/api/controllers/WebhookController.js
+++ b/api/controllers/WebhookController.js
@@ -19,7 +19,7 @@ module.exports = {
       }
     }).catch(err => {
       if (err.message) {
-        res.badRequest(err.message)
+        res.badRequest(err)
       } else {
         sails.log.error(err)
         res.badRequest()
@@ -84,8 +84,8 @@ const findUserForWebhookRequest = (request) => {
 }
 
 const findSiteForWebhookRequest = (request) => {
-  const owner = request.body.repository.full_name.split('/')[0]
-  const repository = request.body.repository.full_name.split('/')[1]
+  const owner = request.body.repository.full_name.split('/')[0].toLowerCase()
+  const repository = request.body.repository.full_name.split('/')[1].toLowerCase()
 
   return Site.findOne({ where: { owner, repository } }).then(site => {
     if (!site) {


### PR DESCRIPTION
Webhook requests were 400ing because the webhook payload included owner and repo names that had uppercase letters. All of our sites have lowercase names, so they were not being found in response to the webhook.

This commit adds a test and fixes the issue in the controller.