### PR TITLE
Set build's completedAt on callback

### DIFF
--- a/api/modelss/build.js
+++ b/api/modelss/build.js
@@ -35,11 +35,13 @@ const completeJob = function(err) {
     return this.update({
       state: "error",
       error: completeJobErrorMessage(err),
+      completedAt: new Date(),
     })
   } else {
     return this.update({
       state: "success",
       error: "",
+      completedAt: new Date(),
     })
   }
 }

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -252,6 +252,7 @@ describe("Build API", () => {
         expect(build).to.not.be.undefined
         expect(build.state).to.equal("success")
         expect(build.error).to.equal("")
+        expect(new Date() - build.completedAt).to.be.below(1000)
         done()
       }).catch(done)
     })
@@ -273,6 +274,7 @@ describe("Build API", () => {
         expect(build).to.not.be.undefined
         expect(build.state).to.equal("error")
         expect(build.error).to.equal("The build failed for a reason")
+        expect(new Date() - build.completedAt).to.be.below(1000)
         done()
       }).catch(done)
     })

--- a/test/api/unit/modelss/build.test.js
+++ b/test/api/unit/modelss/build.test.js
@@ -52,6 +52,7 @@ describe("Build model", () => {
       }).then(build => {
         expect(build.state).to.equal("success")
         expect(build.error).to.equal("")
+        expect(new Date() - build.completedAt).to.be.below(1000)
         done()
       }).catch(done)
     })


### PR DESCRIPTION
The completedAt data for builds was not being set by the build status callback which was making it appear as it completed builds were not completed. This commit adds the completedAt attribute to the list of attributes that is updated when a build status callback is hit.