### PR TITLE
Send build log props to SiteBuildLogs component

### DIFF
--- a/assets/app/components/siteContainer.js
+++ b/assets/app/components/siteContainer.js
@@ -48,7 +48,7 @@ class SiteContainer extends React.Component {
   }
 
   getPageTitle(pathname) {
-    const currentPath = pathname.split('/').pop();
+    return pathname.split('/').pop();
   }
 
   getCurrentSite(sites, siteId) {


### PR DESCRIPTION
The build logs where not being set in the props of the SiteBuildLogs container. This happened b/c the SiteContainer was not able to determine which component it was rendering because the `getPageTitle` function was not returning.

This commit fixes the above by adding a `return` to the `getPageTitle` function.