### PR TITLE
Reduce instance memory from 512MB to 256MB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,8 +5,8 @@ buildpack: nodejs_buildpack
 stack: cflinuxfs2
 domain: fr.cloud.gov
 disk_quota: 2G
-memory: 512MB
-instances: 2
+memory: 256MB
+instances: 5
 services:
 - federalist-production-rds
 - federalist-production-redis

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -5,7 +5,7 @@ buildpack: nodejs_buildpack
 stack: cflinuxfs2
 domain: fr.cloud.gov
 disk_quota: 2G
-memory: 512MB
+memory: 256MB
 instances: 2
 services:
 - federalist-staging-rds


### PR DESCRIPTION
The Federalist web application uses about 150MB of RAM. With this in mind, this commit scales the memory the app is allocated in cloud.gov from 512MB to 256MB, which should free up some memory in our space, while leaving overhead for memory spikes.

This commit also bumps the instance count in production to 5.