### PR TITLE
Stop exposing global objects

### DIFF
--- a/api/authorizers/build.js
+++ b/api/authorizers/build.js
@@ -1,3 +1,5 @@
+const { User, Site } = require("../models")
+
 const authorize = (user, build) => {
   return User.findById(user.id, { include: [Site] }).then(user => {
     for (site of user.Sites) {

--- a/api/authorizers/site.js
+++ b/api/authorizers/site.js
@@ -1,3 +1,5 @@
+const { User, Site } = require("../models")
+
 const authorize = (user, site) => {
   return User.findById(user.id, { include: [ Site ] }).then(user => {
     for (candidateSite of user.Sites) {

--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -1,5 +1,6 @@
 const buildAuthorizer = require("../authorizers/build")
 const buildLogSerializer = require("../serializers/build-log")
+const { Build, BuildLog } = require("../models")
 
 module.exports = {
   create: (req, res) => {

--- a/api/controllers/build.js
+++ b/api/controllers/build.js
@@ -1,5 +1,6 @@
 const authorizer = require("../authorizers/build")
 const buildSerializer = require("../serializers/build")
+const { Build } = require("../models")
 
 var decodeb64 = (str) => {
   return new Buffer(str, 'base64').toString('utf8');

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -1,6 +1,7 @@
 const authorizer = require("../authorizers/site")
 const SiteCreator = require("../services/SiteCreator")
 const siteSerializer = require("../serializers/site")
+const { User, Site, Build } = require("../models")
 
 module.exports = {
   find: (req, res) => {

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -1,5 +1,6 @@
 const authorizer = require("../authorizers/user")
 const userSerializer = require("../serializers/user")
+const { User } = require("../models")
 
 module.exports = {
   usernames: function(req, res) {

--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto')
 const buildSerializer = require("../serializers/build")
+const { Build, User, Site } = require("../models")
 
 module.exports = {
   github: function(req, res) {

--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto')
+const config = require("../../config")
 const buildSerializer = require("../serializers/build")
 const { Build, User, Site } = require("../models")
 

--- a/api/models/build-log.js
+++ b/api/models/build-log.js
@@ -1,3 +1,5 @@
+const config = require("../../config")
+
 const associate = ({ BuildLog, Build }) => {
   BuildLog.belongsTo(Build, {
     foreignKey: "build",

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -1,4 +1,5 @@
 const Sequelize = require('sequelize');
+const config = require("../../config")
 
 const postgresConfig = config.postgres
 const database = postgresConfig.database

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -1,3 +1,5 @@
+const config = require("../../config")
+
 const associate = ({ Site, Build, User }) => {
   Site.hasMany(Build, {
     foreignKey: "site",

--- a/api/policies/buildCallback.js
+++ b/api/policies/buildCallback.js
@@ -1,3 +1,5 @@
+const { Build } = require("../models")
+
 module.exports = function (req, res, next) {
   const id = Number(req.param("id") || req.param("build_id"))
 

--- a/api/serializers/build-log.js
+++ b/api/serializers/build-log.js
@@ -1,3 +1,5 @@
+const { BuildLog, Build } = require("../models")
+
 const serialize = (serializable) => {
   if (serializable.length !== undefined) {
     const buildLogIds = serializable.map(buildLog => buildLog.id)

--- a/api/serializers/build.js
+++ b/api/serializers/build.js
@@ -1,3 +1,5 @@
+const { Build, User, Site } = require("../models")
+
 const serialize = (serializable) => {
   if (serializable.length !== undefined) {
     const buildIds = serializable.map(build => build.id)

--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -1,3 +1,5 @@
+const { Build, User, Site } = require("../models")
+
 const serialize = (serializable) => {
   if (serializable.length !== undefined) {
     const siteIds = serializable.map(site => site.id)

--- a/api/serializers/user.js
+++ b/api/serializers/user.js
@@ -1,3 +1,5 @@
+const { Build, User, Site } = require("../models")
+
 const serialize = (serializable) => {
   if (serializable.length !== undefined) {
     const userIds = serializable.map(user => user.id)

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -1,4 +1,5 @@
 const Github = require("github")
+const config = require("../../config")
 const { User } = require("../models")
 
 const createRepoForOrg = (github, options) => {

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -1,4 +1,5 @@
 const Github = require("github")
+const { User } = require("../models")
 
 const createRepoForOrg = (github, options) => {
   return new Promise((resolve, reject) => {

--- a/api/services/S3Proxy.js
+++ b/api/services/S3Proxy.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk')
+const { Site, User } = require("../models")
 
 const s3Config = config.s3
 const S3 = new AWS.S3({

--- a/api/services/S3Proxy.js
+++ b/api/services/S3Proxy.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk')
+const config = require("../../config")
 const { Site, User } = require("../models")
 
 const s3Config = config.s3

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -1,4 +1,5 @@
 var AWS = require('aws-sdk')
+const config = require("../../config")
 var buildConfig = config.build
 var s3Config = config.s3
 

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -1,4 +1,5 @@
 const GitHub = require("./GitHub")
+const config = require("../../config")
 const { Build, Site, User } = require("../models")
 
 const createSite = ({ user, siteParams }) => {

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -1,4 +1,5 @@
 const GitHub = require("./GitHub")
+const { Build, Site, User } = require("../models")
 
 const createSite = ({ user, siteParams }) => {
   const template = siteParams.template

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -1,6 +1,7 @@
 const GitHub = require("./GitHub")
 const GitHubStrategy = require('passport-github').Strategy
 const passport = require('passport')
+const { User } = require("../models")
 
 var githubVerifyCallback = (accessToken, refreshToken, profile, callback) => {
   var user

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -1,6 +1,7 @@
 const GitHub = require("./GitHub")
 const GitHubStrategy = require('passport-github').Strategy
 const passport = require('passport')
+const config = require("../../config")
 const { User } = require("../models")
 
 var githubVerifyCallback = (accessToken, refreshToken, profile, callback) => {

--- a/app.js
+++ b/app.js
@@ -1,8 +1,3 @@
-global.config = require("./config")
-
-//Object.assign(global, require("./api/models"))
-//global.sequelize = Build.sequelize
-
 global.Promise = require("bluebird")
 
 // If settings present, start New Relic
@@ -20,6 +15,7 @@ const session = require("express-session")
 const RedisStore = require("connect-redis")(session)
 const responses = require("./api/responses")
 
+const config = require("./config")
 const app = express()
 
 if (config.redis) {

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 global.config = require("./config")
 
-Object.assign(global, require("./api/models"))
-global.sequelize = Build.sequelize
+//Object.assign(global, require("./api/models"))
+//global.sequelize = Build.sequelize
 
 global.Promise = require("bluebird")
 

--- a/test/api/bootstrap.test.js
+++ b/test/api/bootstrap.test.js
@@ -7,7 +7,7 @@ AWS.mock('SQS', 'sendMessage', function (params, callback) {
 const app = require("../../app")
 
 const _cleanDatabase = () => {
-  const models = sequelize.models
+  const models = require("../../api/models")
   const promises = Object.keys(models).map(name => {
     return models[name].destroy({ where: {} })
   })

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -1,10 +1,11 @@
-var expect = require("chai").expect
-var cookie = require('cookie')
-var nock = require("nock")
-var request = require("supertest-as-promised")
-var factory = require("../support/factory")
-var githubAPINocks = require("../support/githubAPINocks")
-var session = require("../support/session")
+const expect = require("chai").expect
+const cookie = require('cookie')
+const nock = require("nock")
+const request = require("supertest-as-promised")
+const factory = require("../support/factory")
+const githubAPINocks = require("../support/githubAPINocks")
+const session = require("../support/session")
+const { User } = require("../../../api/models")
 
 var sessionCookieFromResponse = (response) => {
   var header = response.headers["set-cookie"][0]

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -2,6 +2,7 @@ const expect = require("chai").expect
 const cookie = require('cookie')
 const nock = require("nock")
 const request = require("supertest-as-promised")
+const config = require("../../../config")
 const factory = require("../support/factory")
 const githubAPINocks = require("../support/githubAPINocks")
 const session = require("../support/session")

--- a/test/api/requests/build-logs.test.js
+++ b/test/api/requests/build-logs.test.js
@@ -3,6 +3,7 @@ const request = require("supertest-as-promised")
 const factory = require("../support/factory")
 const session = require("../support/session")
 const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
+const { BuildLog, Site, User } = require("../../../api/models")
 
 describe("Build Log API", () => {
   describe("POST /v0/build/:build_id/log/:token", () => {

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -4,6 +4,7 @@ const sinon = require("sinon")
 const factory = require("../support/factory")
 const session = require("../support/session")
 const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
+const { Build, User } = require("../../../api/models")
 
 describe("Build API", () => {
   var buildResponseExpectations = (response, build) => {

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -9,6 +9,8 @@ const githubAPINocks = require("../support/githubAPINocks")
 const session = require("../support/session")
 const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
 
+const { Build, Site, User } = require("../../../api/models")
+
 describe("Site API", () => {
   var siteResponseExpectations = (response, site) => {
     expect(response.owner).to.equal(site.owner)

--- a/test/api/requests/webhook.test.js
+++ b/test/api/requests/webhook.test.js
@@ -2,6 +2,8 @@ const crypto = require('crypto')
 const expect = require("chai").expect
 const request = require("supertest-as-promised")
 const factory = require("../support/factory")
+const { Build, Site, User } = require("../../../api/models")
+
 
 describe("Webhook API", () => {
   const signWebhookPayload = (payload) => {

--- a/test/api/requests/webhook.test.js
+++ b/test/api/requests/webhook.test.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto')
 const expect = require("chai").expect
 const request = require("supertest-as-promised")
+const config = require("../../../config")
 const factory = require("../support/factory")
 const { Build, Site, User } = require("../../../api/models")
 

--- a/test/api/support/factory/build-log.js
+++ b/test/api/support/factory/build-log.js
@@ -1,4 +1,5 @@
 const buildFactory = require("./build")
+const { BuildLog } = require("../../../../api/models")
 
 const buildLog = (overrides) => {
   return Promise.props(_attributes(overrides)).then(attributes => {

--- a/test/api/support/factory/build.js
+++ b/test/api/support/factory/build.js
@@ -1,5 +1,6 @@
 const siteFactory = require("./site")
 const userFactory = require("./user")
+const { Build } = require("../../../../api/models")
 
 const build = (overrides) => {
   return Promise.props(_attributes(overrides)).then(attributes => {

--- a/test/api/support/factory/site.js
+++ b/test/api/support/factory/site.js
@@ -1,4 +1,5 @@
 const userFactory = require("./user")
+const { Site } = require("../../../../api/models")
 
 const site = (overrides) => {
   let site, users

--- a/test/api/support/factory/user.js
+++ b/test/api/support/factory/user.js
@@ -1,3 +1,5 @@
+const { User } = require("../../../../api/models")
+
 const user = (overrides) => {
   return Promise.props(_attributes(overrides)).then(attributes => {
     return User.create(attributes)

--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -1,4 +1,5 @@
 const nock = require("nock")
+const config = require("../../../config")
 
 const accessToken = ({ authorizationCode, accessToken, scope } = {}) => {
   authorizationCode = authorizationCode || "auth-code-123abc"

--- a/test/api/support/session.js
+++ b/test/api/support/session.js
@@ -1,5 +1,6 @@
 const crypto = require("crypto")
 const factory = require("./factory")
+const config = require("../../../config")
 
 const session = (user) => {
   return Promise.resolve(user || factory.user()).then(user => {

--- a/test/api/unit/models/build-log.test.js
+++ b/test/api/unit/models/build-log.test.js
@@ -1,6 +1,6 @@
 const expect = require("chai").expect
-
 const factory = require("../../support/factory")
+const { BuildLog } = require("../../../../api/models")
 
 describe("BuildLog model", () => {
   describe("before validate hook", () => {

--- a/test/api/unit/models/build-log.test.js
+++ b/test/api/unit/models/build-log.test.js
@@ -1,5 +1,6 @@
 const expect = require("chai").expect
 const factory = require("../../support/factory")
+const config = require("../../../../config")
 const { BuildLog } = require("../../../../api/models")
 
 describe("BuildLog model", () => {

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -1,7 +1,7 @@
 const expect = require("chai").expect
 const SQS = require("../../../../api/services/SQS")
-
 const factory = require("../../support/factory")
+const { Build } = require("../../../../api/models")
 
 describe("Build model", () => {
   describe("before validate hook", () => {

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -1,7 +1,7 @@
 const expect = require("chai").expect
 const sinon = require("sinon")
-
 const factory = require("../../support/factory")
+const { Site } = require("../../../../api/models")
 
 describe("Site model", () => {
   describe("before validate hook", () => {

--- a/test/api/unit/models/user.test.js
+++ b/test/api/unit/models/user.test.js
@@ -1,4 +1,5 @@
 const expect = require("chai").expect
+const { User } = require("../../../../api/models")
 
 describe("User model", () => {
   describe("validations", () => {

--- a/test/api/unit/services/GitHub.test.js
+++ b/test/api/unit/services/GitHub.test.js
@@ -1,4 +1,5 @@
 const expect = require("chai").expect
+const config = require("../../../../config")
 const factory = require("../../support/factory")
 const GitHub = require("../../../../api/services/GitHub")
 const githubAPINocks = require("../../support/githubAPINocks")

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -2,6 +2,7 @@ const expect = require("chai").expect
 const factory = require("../../support/factory")
 const GitHub = require("../../../../api/services/SQS")
 const SQS = require("../../../../api/services/SQS")
+const { Build, Site, User } = require("../../../../api/models")
 
 describe("SQS", () => {
   describe(".sendBuildMessage(build)", () => {

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -1,4 +1,5 @@
 const expect = require("chai").expect
+const config = require("../../../../config")
 const factory = require("../../support/factory")
 const GitHub = require("../../../../api/services/SQS")
 const SQS = require("../../../../api/services/SQS")

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -4,6 +4,7 @@ const nock = require("nock")
 const factory = require("../../support/factory")
 const githubAPINocks = require("../../support/githubAPINocks")
 const SiteCreator = require("../../../../api/services/SiteCreator")
+const { Build, Site, User } = require("../../../../api/models")
 
 describe("SiteCreator", () => {
   describe(".createSite({ siteParams, user })", () => {


### PR DESCRIPTION
Sails exposed a number of global objects, namely models, services, and configs. This commit removes the legacy code that was imitating that behavior and replaces it with explicit requires.