### PR TITLE
Replace sails.log and morgan with winston

### DIFF
--- a/api/controllers/preview.js
+++ b/api/controllers/preview.js
@@ -1,9 +1,10 @@
+const logger = require("winston")
 const S3Proxy = require("../services/S3Proxy")
 
 module.exports = {
   proxy: function(req, res) {
     S3Proxy.proxy(req, res).catch(err => {
-      sails.log.error(err)
+      logger.error("Unhandled S3Proxy error: ", err)
       res.redirect('/?error=preview.login')
     })
   }

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -77,7 +77,6 @@ module.exports = {
     }).then(siteJSON => {
       res.send(siteJSON)
     }).catch(err => {
-      console.error(err)
       res.error(err)
     })
   },

--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto')
+const logger = require("winston")
 const config = require("../../config")
 const buildSerializer = require("../serializers/build")
 const { Build, User, Site } = require("../models")
@@ -23,7 +24,7 @@ module.exports = {
       if (err.message) {
         res.badRequest(err)
       } else {
-        sails.log.error(err)
+        logger.error(err)
         res.badRequest()
       }
     })

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -1,4 +1,5 @@
 const Sequelize = require('sequelize');
+const logger = require("winston")
 const config = require("../../config")
 
 const postgresConfig = config.postgres
@@ -10,7 +11,7 @@ const sequelize = new Sequelize(database, username, password, {
   dialect: "postgres",
   host: postgresConfig.host,
   port: postgresConfig.port,
-  logging: () => {} // TODO DO NOT LET ME MERGE THIS UNTIL I WIRE THIS UP TO A PROPER LOGGER sails.log.info,
+  logging: logger.info,
 })
 
 const Build = sequelize.import(__dirname + "/build")

--- a/api/responses/serverError.js
+++ b/api/responses/serverError.js
@@ -1,4 +1,8 @@
+const logger = require("winston")
+
 module.exports = (error = {}, { req, res }) => {
+  winston.error("Sending 500: ", error)
+
   res.status(500)
   return res.json({
     message: "Internal server error",

--- a/api/services/S3Proxy.js
+++ b/api/services/S3Proxy.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk')
+const logger = require("winston")
 const config = require("../../config")
 const { Site, User } = require("../models")
 
@@ -44,7 +45,7 @@ const pipeS3ObjectToResponse = ({ key, res }) => {
     headers['X-Frame-Options'] = 'SAMEORIGIN';
     res.set(headers)
   }).createReadStream().on("error", error => {
-    console.error(error)
+    logger.error("Error proxying S3 object: ", error)
     res.send(error.statusCode, error.message)
   }).pipe(res)
 }

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -1,7 +1,8 @@
-var AWS = require('aws-sdk')
+const AWS = require('aws-sdk')
+const logger = require("winston")
 const config = require("../../config")
-var buildConfig = config.build
-var s3Config = config.s3
+const buildConfig = config.build
+const s3Config = config.s3
 
 var buildContainerEnvironment = (build) => ({
   AWS_DEFAULT_REGION: s3Config.region,
@@ -76,7 +77,7 @@ SQS.sendBuildMessage = build => {
   }
   SQS.sqsClient.sendMessage(params, function(err, data) {
     if (err) {
-      console.error('There was an error, adding the job to SQS: ', err);
+      logger.error("There was an error, adding the job to SQS: ", err);
       build.completeJob(err);
     }
   })

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -1,3 +1,4 @@
+const logger = require("winston")
 const GitHub = require("./GitHub")
 const GitHubStrategy = require('passport-github').Strategy
 const passport = require('passport')
@@ -24,8 +25,7 @@ var githubVerifyCallback = (accessToken, refreshToken, profile, callback) => {
   }).then(() => {
     callback(null, user)
   }).catch(err => {
-    console.error("Authentication error: ")
-    console.error(err)
+    logger.warn("Authentication error: ", err)
     callback(err)
   })
 }

--- a/app.js
+++ b/app.js
@@ -1,21 +1,28 @@
+const config = require("./config")
 global.Promise = require("bluebird")
+
+const logger = require("winston")
+logger.level = config.log.level
+logger.remove(logger.transports.Console)
+logger.add(logger.transports.Console, {colorize: true})
 
 // If settings present, start New Relic
 var env = require('./services/environment.js')();
 if (env.NEW_RELIC_APP_NAME && env.NEW_RELIC_LICENSE_KEY) {
-  console.log('Activating New Relic: ', env.NEW_RELIC_APP_NAME);
+  logger.info('Activating New Relic: ', env.NEW_RELIC_APP_NAME);
   require('newrelic');
+} else {
+  logger.warn("Skipping New Relic Activation")
 }
 
 const express = require("express")
 const bodyParser = require('body-parser')
 const methodOverride = require('method-override')
-const morgan = require("morgan")
+const expressWinston = require("express-winston")
 const session = require("express-session")
 const RedisStore = require("connect-redis")(session)
 const responses = require("./api/responses")
 
-const config = require("./config")
 const app = express()
 
 if (config.redis) {
@@ -25,12 +32,25 @@ if (config.redis) {
 }
 
 app.use(session(config.session))
-app.use(morgan("dev"))
 app.use(express.static("public"))
 app.use(bodyParser.urlencoded({ extended: false }))
 app.use(bodyParser.json())
 app.use(methodOverride())
 app.use(responses)
+
+if (logger.levels[logger.level] >= 2) {
+  app.use(expressWinston.logger({
+    transports: [
+      new logger.transports.Console({ colorize: true })
+    ],
+    requestWhitelist: expressWinston.requestWhitelist.concat("body"),
+  }))
+}
+app.use(expressWinston.errorLogger({
+  transports: [
+    new logger.transports.Console({ json: true, colorize: true })
+  ],
+}))
 
 const routers = require("./api/routers")
 app.use(routers)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
+const logger = require("winston")
+
 const app = require("./app")
 app.listen(process.env.PORT || 1337, () => {
-  console.log("Server running!")
+  logger.info("Server running!")
 })

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "deep-extend": "^0.4.1",
     "express": "^4.14.1",
     "express-session": "^1.5.0",
+    "express-winston": "^2.3.0",
     "github": "^0.2.4",
     "method-override": "^2.3.7",
     "moment": "^2.10.3",
-    "morgan": "^1.8.1",
     "newrelic": "^1.22.0",
     "passport": "^0.2.1",
     "passport-github": "^0.1.5",
@@ -29,6 +29,7 @@
     "underscore": "^1.8.3",
     "urlsafe-base64": "^1.0.0",
     "whatwg-fetch": "^1.0.0",
+    "winston": "^2.3.1",
     "yamljs": "^0.2.8"
   },
   "scripts": {

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -91,7 +91,6 @@ describe("Authentication request", () => {
             .get("/auth/github/callback?code=auth-code-123abc")
             .expect(302)
         }).then(response => {
-          console.log(response.headers)
           var cookie = sessionCookieFromResponse(response)
           return sessionForCookie(cookie)
         }).then(session => {


### PR DESCRIPTION
This commit consolidates all logging functionality under winston, the
same logging module we use in federalist-builder. It uses the same
configurations to set the logging level, but uses a winston based
logging middleware, and uses winston's logging functions in places where
logging happens.