### PR TITLE
Replace deprecated req.param method

### DIFF
--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -4,7 +4,7 @@ const { Build, BuildLog } = require("../models")
 
 module.exports = {
   create: (req, res) => {
-    Promise.resolve(Number(req.param("build_id"))).then(id => {
+    Promise.resolve(Number(req.params["build_id"])).then(id => {
       if (isNaN(id)) {
         throw 404
       }
@@ -15,8 +15,8 @@ module.exports = {
       }
       return BuildLog.create({
         build: build.id,
-        output: req.param("output"),
-        source: req.param("source"),
+        output: req.body["output"],
+        source: req.body["source"],
       })
     }).then(buildLog => {
       return buildLogSerializer.serialize(buildLog)
@@ -30,7 +30,7 @@ module.exports = {
   find: (req, res) => {
     let build
 
-    Promise.resolve(Number(req.param("build_id"))).then(id => {
+    Promise.resolve(Number(req.params["build_id"])).then(id => {
       if (isNaN(id)) {
         throw 404
       }

--- a/api/controllers/build.js
+++ b/api/controllers/build.js
@@ -17,8 +17,8 @@ module.exports = {
 
   create: (req, res) => {
     const params = {
-      branch: req.param("branch"),
-      site: req.param("site"),
+      branch: req.body["branch"],
+      site: req.body["site"],
       user: req.user.id,
     }
     authorizer.create(req.user, params).then(() => {
@@ -35,7 +35,7 @@ module.exports = {
   findOne: (req, res) => {
     let build
 
-    Promise.resolve(Number(req.param("id"))).then(id => {
+    Promise.resolve(Number(req.params["id"])).then(id => {
       if (isNaN(id)) {
         throw 404
       }
@@ -59,7 +59,7 @@ module.exports = {
   status: (req, res) => {
     var message = decodeb64(req.body.message)
 
-    Promise.resolve(Number(req.param("id"))).then(id => {
+    Promise.resolve(Number(req.params["id"])).then(id => {
       if (isNaN(id)) {
         throw 404
       }

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -17,7 +17,7 @@ module.exports = {
   findOne: (req, res) => {
     let site
 
-    Promise.resolve(Number(req.param("id"))).then(id => {
+    Promise.resolve(Number(req.params["id"])).then(id => {
       if (isNaN(id)) {
         throw 404
       }
@@ -42,7 +42,7 @@ module.exports = {
     let site
     let siteJSON
 
-    Promise.resolve(Number(req.param("id"))).then(id => {
+    Promise.resolve(Number(req.params["id"])).then(id => {
       if (isNaN(id)) {
         throw 404
       }
@@ -83,7 +83,7 @@ module.exports = {
 
   update: (req, res) => {
     let site
-    let siteId = Number(req.param("id"))
+    let siteId = Number(req.params["id"])
 
     Promise.resolve(siteId).then(id => {
       if (isNaN(id)) {

--- a/api/policies/buildCallback.js
+++ b/api/policies/buildCallback.js
@@ -1,7 +1,7 @@
 const { Build } = require("../models")
 
 module.exports = function (req, res, next) {
-  const id = Number(req.param("id") || req.param("build_id"))
+  const id = Number(req.params["id"] || req.params["build_id"])
 
   Promise.resolve(id).then(id => {
     if (isNaN(id)) {
@@ -11,7 +11,7 @@ module.exports = function (req, res, next) {
   }).then(build => {
     if (!build) {
       res.notFound()
-    } else if (build.token !== req.param("token")) {
+    } else if (build.token !== req.params["token"]) {
       res.forbidden()
     } else {
       next()

--- a/api/services/S3Proxy.js
+++ b/api/services/S3Proxy.js
@@ -11,8 +11,8 @@ const S3 = new AWS.S3({
 })
 
 const findSite = (req) => {
-  const owner = req.param("owner")
-  const repository = req.param("repo")
+  const owner = req.params["owner"]
+  const repository = req.params["repo"]
 
   return Site.findOne({
     where: {


### PR DESCRIPTION
Express's req.param method was deprecated in Express 4. It has been replaced with either req.params, req.body, or req.query depending on the case.

This commit replaces the req.param method with the appropriate replacement wherever it appears.