### PR TITLE
Recognize empty strings in update site request body

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -95,12 +95,13 @@ module.exports = {
       }
       return authorizer.update(req.user, site)
     }).then(() => {
+      const params = Object.assign(site, req.body)
       return site.update({
-        config: req.body.config || site.config,
-        defaultBranch: req.body.defaultBranch || site.defaultBranch,
-        domain: req.body.domain || site.domain,
-        engine: req.body.engine || site.engine,
-        publicPreview: req.body.publicPreview || site.publicPreview,
+        config: params.config,
+        defaultBranch: params.defaultBranch,
+        domain: params.domain,
+        engine: params.engine,
+        publicPreview: params.publicPreview,
       })
     }).then(model => {
       let site = model


### PR DESCRIPTION
The Site API was not updating attributes for a site if the new value was an empty string. This was because values where being set as such:

```javascript
{
  config: req.body.config || site.config,
}
```

Since the empty string evaluates to false, this was falling back to the value on the site. This commit fixes the problem by creating a params object that is the result of merging the site and request body:

```javascript
const params = Object.assign(site, req.body)
{
  config: params.config,
}
```

Ref #759