### PR TITLE
Filter incomplete builds before sorting to find last published date

### DIFF
--- a/assets/app/components/siteList/publishedState.js
+++ b/assets/app/components/siteList/publishedState.js
@@ -7,13 +7,17 @@ const propTypes = {
 
 const getLastBuildTime = (builds) => {
   if (builds.length) {
-    let sorted = builds.sort((a, b) => {
+    let sorted = builds.slice().filter(build => {
+      return build.completedAt
+    }).sort((a, b) => {
       let aCompletedAt = new Date(a.completedAt);
       let bCompletedAt = new Date(b.completedAt);
       return aCompletedAt > bCompletedAt;
     });
-    let last = sorted.slice().pop();
-    return last.completedAt
+    let last = sorted.pop();
+    if (last) {
+      return last.completedAt
+    }
   }
 };
 

--- a/test/client/app/components/siteList/publishedState.test.js
+++ b/test/client/app/components/siteList/publishedState.test.js
@@ -19,10 +19,12 @@ describe('<PublishedState />', () => {
       {
         completedAt: "2015-09-02T21:43:35.000Z"
       },
-
       {
         completedAt: MOST_RECENT_BUILD_TIME
-      }
+      },
+      {
+        completedAt: undefined,
+      },
     ];
   })
 


### PR DESCRIPTION
The publishedState component was displaying "Please wait for build to complete or check logs for error message." for sites with builds that had been published. This component is intended to show the `completedAt` date for the last published build.

The issue was that these sites had builds that had yet to complete, meaning their `completedAt` prop was `undefined`. When the builds were being sorted to get the most recently completed build, the builds with `undefined` for their completed at date always went at the end, meaning they were recognized as the most recent complete build. This commit fixes the issue by filtering out builds with an `undefined` completed at date before sorting builds.

FWIW, the reason the sort function was broken is that in JavaScript `1 < undefined` and `1 > undefined` both return false somehow.

Ref #793