### PR TITLE
Delete contents from S3 when a site is deleted

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -1,4 +1,5 @@
 const authorizer = require("../authorizers/site")
+const S3SiteRemover = require("../services/S3SiteRemover")
 const SiteCreator = require("../services/SiteCreator")
 const siteSerializer = require("../serializers/site")
 const { User, Site, Build } = require("../models")
@@ -57,6 +58,8 @@ module.exports = {
     }).then(json => {
       siteJSON = json
       return authorizer.destroy(req.user, site)
+    }).then(() => {
+      return S3SiteRemover.removeSite(site)
     }).then(() => {
       return site.destroy()
     }).then(() => {

--- a/api/responses/serverError.js
+++ b/api/responses/serverError.js
@@ -1,7 +1,7 @@
 const logger = require("winston")
 
 module.exports = (error = {}, { req, res }) => {
-  winston.error("Sending 500: ", error)
+  logger.error("Sending 500: ", error)
 
   res.status(500)
   return res.json({

--- a/api/services/S3SiteRemover.js
+++ b/api/services/S3SiteRemover.js
@@ -1,0 +1,54 @@
+const AWS = require("aws-sdk")
+const config = require("../../config")
+
+const s3Config = config.s3
+const s3Client = () => new AWS.S3({
+  accessKeyId: s3Config.accessKeyId,
+  secretAccessKey: s3Config.secretAccessKey,
+  region: s3Config.region,
+})
+
+const removeSite = site => {
+  return Promise.all([
+    getObjectsWithPrefix(`site/${site.owner}/${site.repository}`),
+    getObjectsWithPrefix(`preview/${site.owner}/${site.repository}`),
+  ]).then(objects => {
+    objects = objects[0].concat(objects[1])
+    return deleteObjects(objects)
+  })
+}
+
+const deleteObjects = objects => {
+  return new Promise((resolve, reject) => {
+    s3Client().deleteObjects({
+      Bucket: s3Config.bucket,
+      Delete: {
+        Objects: objects.map(object => ({ Key: object }))
+      },
+    }, (err, data) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(data)
+      }
+    })
+  })
+}
+
+const getObjectsWithPrefix = prefix => {
+  return new Promise((resolve, reject) => {
+    s3Client().listObjects({
+      Bucket: s3Config.bucket,
+      Prefix: prefix,
+    }, (err, data) => {
+      if (err) {
+        reject(err)
+      } else {
+        const keys = data.Contents.map(object => object.Key)
+        resolve(keys)
+      }
+    })
+  })
+}
+
+module.exports = { removeSite }

--- a/test/api/unit/services/S3SiteRemover.test.js
+++ b/test/api/unit/services/S3SiteRemover.test.js
@@ -1,0 +1,76 @@
+const AWS = require('aws-sdk-mock')
+const expect = require("chai").expect
+const proxyquire = require("proxyquire")
+const factory = require("../../support/factory")
+const config = require("../../../../config")
+
+const S3 = {
+  listObjects: () => Promise.resolve(),
+  deleteObjects: () => Promise.resolve(),
+}
+
+AWS.mock("S3", "listObjects", (params, cb) => S3.listObjects(params, cb))
+AWS.mock("S3", "deleteObjects", (params, cb) => S3.deleteObjects(params, cb))
+
+const S3SiteRemover = require("../../../../api/services/S3SiteRemover")
+
+describe("S3SiteRemover", () => {
+  describe(".removeSite(site)", () => {
+    it("should delete all objects in the `site/<org>/<repo>` and `preview/<org>/<repo> directories", done => {
+      const siteObjectsToDelete = []
+      const previewObjectsToDelete = []
+      let site
+      let objectsWereDeleted = false
+      let siteObjectsWereListed = false
+      let previewObjectsWereListed = false
+
+      S3.listObjects = (params, cb) => {
+        expect(params.Bucket).to.equal(config.s3.bucket)
+        if (params.Prefix === `site/${site.owner}/${site.repository}`) {
+          siteObjectsWereListed = true
+          cb(null, {
+            Contents: siteObjectsToDelete.map(Key => ({ Key }))
+          })
+        } else if (params.Prefix === `preview/${site.owner}/${site.repository}`) {
+          previewObjectsWereListed = true
+          cb(null, {
+            Contents: previewObjectsToDelete.map(Key => ({ Key }))
+          })
+        }
+      }
+      S3.deleteObjects = (params, cb) => {
+        expect(params.Bucket).to.equal(config.s3.bucket)
+
+        const objectsToDelete = siteObjectsToDelete.concat(previewObjectsToDelete)
+        expect(params.Delete.Objects).to.have.length(objectsToDelete.length)
+        params.Delete.Objects.forEach(object => {
+          const index = objectsToDelete.indexOf(object.Key)
+          expect(index).to.be.at.least(0)
+          objectsToDelete.splice(index, 1)
+        })
+        objectsWereDeleted = true
+        cb(null, {})
+      }
+
+      factory.site().then(model => {
+        site = model
+
+        const sitePrefix = `site/${site.owner}/${site.repository}`
+        siteObjectsToDelete.push(`${sitePrefix}/index.html`)
+        siteObjectsToDelete.push(`${sitePrefix}/redirect`)
+        siteObjectsToDelete.push(`${sitePrefix}/redirect/index.html`)
+        const previewPrefix = `preview/${site.owner}/${site.repository}`
+        previewObjectsToDelete.push(`${previewPrefix}/index.html`)
+        previewObjectsToDelete.push(`${previewPrefix}/redirect`)
+        previewObjectsToDelete.push(`${previewPrefix}/redirect/index.html`)
+
+        return S3SiteRemover.removeSite(site)
+      }).then(() => {
+        expect(siteObjectsWereListed).to.equal(true)
+        expect(previewObjectsWereListed).to.equal(true)
+        expect(objectsWereDeleted).to.equal(true)
+        done()
+      }).catch(done)
+    })
+  })
+})


### PR DESCRIPTION
This commit adds a S3SiteRemover service which deletes all of the objects related to a site from S3. This service is invoked on a site when that site is deleted by a user. It searches for previews and the live sites files and then deletes them.

Ref #289