### PR TITLE
Refactor template grid

### DIFF
--- a/assets/app/components/AddSite/TemplateSiteList/index.js
+++ b/assets/app/components/AddSite/TemplateSiteList/index.js
@@ -5,9 +5,33 @@ import TemplateSite from './templateSite';
 const propTypes = {
   templates: React.PropTypes.object.isRequired,
   handleSubmitTemplate: React.PropTypes.func.isRequired
-}
+};
+
+const MAX_CELLS_PER_ROW = 3;
+const CELL_WIDTHS = ['', 'whole', 'half', 'third', 'fourth'];
+
+/**
+ * Create a two-dimensional array of values that represent one or more rows
+ * of values, with `perRow` values per row.
+ *
+ * @param {array<*>} values
+ * @param {integer} perRow
+ * @return {array<array<*>>}
+ */
+const createRowsOf = (values, perRow) => {
+  let row = [];
+  const rows = [row];
+  values.forEach((val, index) => {
+    if (index === perRow) {
+      rows.push(row = []);
+    }
+    row.push(val);
+  });
+  return rows;
+};
 
 class TemplateList extends React.Component {
+
   constructor(props) {
     super(props);
 
@@ -27,6 +51,41 @@ class TemplateList extends React.Component {
   render() {
     const { templates } = this.props;
 
+    const templateKeys = Object.keys(templates);
+    // if there are fewer templates than cells per row,
+    // fill the space with them
+    const cellsPerRow = Math.min(templateKeys.length, MAX_CELLS_PER_ROW);
+    // generate a two-dimensional array of template keys
+    const templateRows = createRowsOf(templateKeys, cellsPerRow);
+    // i.e. 'whole', 'half', 'third', or 'fourth'
+    const cellSize = CELL_WIDTHS[cellsPerRow];
+
+    let index = 0;
+
+    const templateGrid = templateRows.map((row, rowIndex) => {
+      return (
+        <div className="usa-grid" key={rowIndex}>
+          {row.map((templateName, cellIndex) => {
+            const template = templates[templateName];
+            return (
+              <div className={`usa-width-one-${cellSize}`}>
+                <TemplateSite
+                  name={templateName}
+                  key={cellIndex}
+                  index={index++}
+                  thumb={templateName}
+                  active={this.state.activeChildId}
+                  handleChooseActive={this.handleChooseActive}
+                  handleSubmit={this.props.handleSubmitTemplate}
+                  defaultOwner={this.props.defaultOwner}
+                  {...template} />
+              </div>
+            );
+          })}
+        </div>
+      );
+    });
+
     return (
       <div>
         <div className="usa-grid">
@@ -34,24 +93,7 @@ class TemplateList extends React.Component {
             <h2>Choose from one of our templates</h2>
           </div>
         </div>
-        <div className="usa-grid">
-          {Object.keys(templates).map((templateName, index) => {
-            const template = templates[templateName];
-
-            return (
-              <TemplateSite
-                name={templateName}
-                key={index}
-                index={index}
-                thumb={templateName}
-                active={this.state.activeChildId}
-                handleChooseActive={this.handleChooseActive}
-                handleSubmit={this.props.handleSubmitTemplate}
-                defaultOwner={this.props.defaultOwner}
-                {...template} />
-            );
-          })}
-        </div>
+        {templateGrid}
       </div>
     );
   }

--- a/assets/app/components/AddSite/TemplateSiteList/index.js
+++ b/assets/app/components/AddSite/TemplateSiteList/index.js
@@ -68,10 +68,11 @@ class TemplateList extends React.Component {
           {row.map((templateName, cellIndex) => {
             const template = templates[templateName];
             return (
-              <div className={`usa-width-one-${cellSize}`}>
+              <div
+                  className={`usa-width-one-${cellSize}`}
+                  key={cellIndex}>
                 <TemplateSite
                   name={templateName}
-                  key={cellIndex}
                   index={index++}
                   thumb={templateName}
                   active={this.state.activeChildId}

--- a/assets/app/components/AddSite/TemplateSiteList/templateSite.js
+++ b/assets/app/components/AddSite/TemplateSiteList/templateSite.js
@@ -63,7 +63,7 @@ class TemplateSite extends React.Component {
     const { props } = this;
 
     return (
-      <div className="usa-width-one-fourth template-block">
+      <div className="template-block">
         <div className="usa-alert usa-alert-info">
           <div className="usa-alert-heading">
             <h3>{props.title}</h3>

--- a/assets/app/components/AddSite/index.js
+++ b/assets/app/components/AddSite/index.js
@@ -12,7 +12,7 @@ const propTypes = {
   storeState: React.PropTypes.shape({
     user: React.PropTypes.shape({
       username: React.PropTypes.string,
-      id: React.PropTypes.string
+      id: React.PropTypes.number
     }),
     error: React.PropTypes.string
   })


### PR DESCRIPTION
This is a refactoring of the template grid on the TemplateSiteList component that:

1. Switches the grid size from 4 to 3 cells wide, because 4 was really not nice
1. Accommodates (theoretically) any number of templates, even when the count is less than the number of available "slots"

Here's a preview with the current 4 templates:

![image](https://cloud.githubusercontent.com/assets/113896/23730779/3d72d010-041e-11e7-9a5c-755a2b5424ce.png)

I've also tested it with 1, 2, 3, and 5 templates—no problem!

I made one other unrelated change in 668e81a to resolve a warning about `storeState.user.id` having the wrong prop type: it was `string`, but it was getting a number, so I changed it to `number`. No more console warnings!

Tests pass locally, but I haven't looked at the coverage for this view yet, so it's hard to say whether I've broken anything.

This is the first time I've committed any React or JSX code, so please let me know if I've done anything egregious or weird. I ran `eslint` on the whole AddSite directory, and it didn't report any warnings or errors. 😬 