### PR TITLE
Use connect-session-sequelize as the session store instead of connect…

### DIFF
--- a/api/models/index.js
+++ b/api/models/index.js
@@ -23,4 +23,4 @@ Object.keys(sequelize.models).forEach(key => {
   sequelize.models[key].associate(sequelize.models)
 })
 
-module.exports = sequelize.models
+module.exports = Object.assign({ sequelize }, sequelize.models)

--- a/app.js
+++ b/app.js
@@ -20,16 +20,12 @@ const bodyParser = require('body-parser')
 const methodOverride = require('method-override')
 const expressWinston = require("express-winston")
 const session = require("express-session")
-const RedisStore = require("connect-redis")(session)
+const PostgresStore = require("connect-session-sequelize")(session.Store)
 const responses = require("./api/responses")
 
 const app = express()
-
-if (config.redis) {
-  config.session.store = new RedisStore(config.redis)
-} else {
-  config.session.store = new session.MemoryStore()
-}
+const sequelize = require("./api/models").sequelize
+config.session.store = new PostgresStore({ db: sequelize })
 
 app.use(session(config.session))
 app.use(express.static("public"))

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -3,29 +3,10 @@ const cfenv = require("cfenv")
 
 const appEnv = cfenv.getAppEnv()
 
-// Session Config
-const redisCreds = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-redis`)
-if (redisCreds) {
-  module.exports.session = {
-    cookie: {
-      secure: true,
-    },
-  }
-  module.exports.redis = {
-    host: redisCreds.hostname,
-    port: redisCreds.port,
-    db: 0,
-    pass: redisCreds.password,
-  }
-} else {
-  throw new Error("No redis credentials found.")
-}
-
 // Database Config
 const rdsCreds = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-rds`)
 if (rdsCreds) {
   module.exports.postgres: {
-    adapter: 'sails-postgresql',
     database: rdsCreds.db_name,
     host: rdsCreds.host,
     user: rdsCreds.username,

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,6 @@ memory: 256MB
 instances: 5
 services:
 - federalist-production-rds
-- federalist-production-redis
 - federalist-production-s3
 - federalist-production-env
 env:

--- a/migrations/20170310123627-add-sessions-table.js
+++ b/migrations/20170310123627-add-sessions-table.js
@@ -1,0 +1,13 @@
+module.exports.up = (db, callback) => {
+  db.createTable("Sessions", {
+    sid: "string",
+    expires: "timestamp",
+    data: "text",
+    createdAt: "timestamp",
+    updatedAt: "timestamp",
+  }, callback)
+}
+
+module.exports.down = (db, callback) => {
+  db.dropTable("Sessions", callback)
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bluebird": "^3.4.6",
     "body-parser": "^1.16.1",
     "cfenv": "^1.0.0",
-    "connect-redis": "3.0.2",
+    "connect-session-sequelize": "^4.1.0",
     "core-js": "^2.4.1",
     "db-migrate": "^0.9.17",
     "deep-extend": "^0.4.1",

--- a/test/api/bootstrap.test.js
+++ b/test/api/bootstrap.test.js
@@ -7,7 +7,7 @@ AWS.mock('SQS', 'sendMessage', function (params, callback) {
 const app = require("../../app")
 
 const _cleanDatabase = () => {
-  const models = require("../../api/models")
+  const models = require("../../api/models").sequelize.models
   const promises = Object.keys(models).map(name => {
     return models[name].destroy({ where: {} })
   })

--- a/test/api/support/session.js
+++ b/test/api/support/session.js
@@ -3,8 +3,9 @@ const factory = require("./factory")
 const config = require("../../../config")
 
 const session = (user) => {
+  const sessionKey = crypto.randomBytes(8).toString("hex")
+
   return Promise.resolve(user || factory.user()).then(user => {
-    const sessionKey = crypto.randomBytes(8).toString("hex")
     const sessionBody = {
       cookie: {
         originalMaxAge: null,
@@ -17,9 +18,9 @@ const session = (user) => {
       },
       authenticated: true
     }
-    config.session.store.set(sessionKey, sessionBody)
-
-    var signedSessionKey = sessionKey + "." + crypto
+    return config.session.store.set(sessionKey, sessionBody)
+  }).then(() => {
+    const signedSessionKey = sessionKey + "." + crypto
       .createHmac('sha256', config.session.secret)
       .update(sessionKey)
       .digest('base64')


### PR DESCRIPTION
…-redis

We've had trouble with our redis connection in cloud.gov resulting in some downtime. This commit remediates by switching off of the redis session store and instead using the postgres database as the session store.

This commit adds a connect addapter and configures it to connect to our database.

Ref #677