### PR TITLE
Respect path component of custom domains

### DIFF
--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -1,5 +1,6 @@
 const AWS = require('aws-sdk')
 const logger = require("winston")
+const url = require("url")
 const config = require("../../config")
 const buildConfig = config.build
 const s3Config = config.s3
@@ -38,10 +39,17 @@ var pathForBuild = (build) => {
 
 var baseURLForBuild = (build) => {
   if (defaultBranch(build) && build.Site.domain) {
-    return ""
+    return baseURLForCustomDomain(build.Site.domain)
   } else {
     return "/" + pathForBuild(build)
   }
+}
+
+var baseURLForCustomDomain = (domain) => {
+  if (!domain.match(/https?\:\/\//)) {
+    domain = "https://" + domain
+  }
+  return url.parse(domain).path.replace(/\/$/, "")
 }
 
 var sourceForBuild = (build) => {


### PR DESCRIPTION
Prior to this commit, Federalist did not respect the path component of custom URLs. This caused problems for sites that were not displayed at the root for their domain, e.g. `www.opm.gov/opm-site`. This commit modifies the service that sends builds to the build scheduler to send the path component for custom domains.

ref #812