### PR TITLE
Redirect to preview after sign in

### DIFF
--- a/api/controllers/preview.js
+++ b/api/controllers/preview.js
@@ -4,8 +4,13 @@ const S3Proxy = require("../services/S3Proxy")
 module.exports = {
   proxy: function(req, res) {
     S3Proxy.proxy(req, res).catch(err => {
-      logger.error("Unhandled S3Proxy error: ", err)
-      res.redirect('/?error=preview.login')
+      if (!req.authenticated && err.status === 403) {
+        req.session.authRedirectPath = req.path
+        req.session.save(() => res.redirect("/auth/github"))
+      } else {
+        logger.error("Unhandled S3Proxy error: ", err)
+        res.redirect('/?error=preview.login')
+      }
     })
   }
 }

--- a/api/policies/sessionAuth.js
+++ b/api/policies/sessionAuth.js
@@ -1,4 +1,5 @@
 module.exports = function(req, res, next) {
+  req.session.authRedirectPath = undefined
   if (req.session.authenticated) {
     return next();
   } else {

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -45,7 +45,11 @@ passport.callback = (req, res) => {
   passport.authenticate("github")(req, res, () => {
     if (req.user) {
       req.session.authenticated = true
-      res.redirect("/")
+      if (req.session.authRedirectPath) {
+        res.redirect(req.session.authRedirectPath)
+      } else {
+        res.redirect("/")
+      }
     } else {
       res.status(401).send("Unauthorized")
     }


### PR DESCRIPTION
Prior to this commit, users who were not signed in attempting to look at a preview were redirected to the home page. In order to see the preview, they would have to login, then go back to see the preview.

This commit smooths that process out by redirecting back to previews after sign in. It does this by saving the URL the user was attempting to visit in the session, then redirecting to the sign in path. After sign in, it redirects back to the URL.

Ref #117