### PR TITLE
Open branch preview links in a new tab

### DIFF
--- a/frontend/components/site/sitePreviewLinksTable.js
+++ b/frontend/components/site/sitePreviewLinksTable.js
@@ -4,7 +4,7 @@ const branchRow = ({ branch, site }) => (
   <tr key={branch.name}>
     <td>{branch.name}</td>
     <td>
-      <a href={previewURL({ branch, site })}>View</a>
+      <a href={previewURL({ branch, site })} target="_blank">View</a>
     </td>
   </tr>
 )

--- a/frontend/components/site/sitePublishedBranch.js
+++ b/frontend/components/site/sitePublishedBranch.js
@@ -58,7 +58,7 @@ class SitePublishedBranch extends React.Component {
     const viewFileLink = `${branch.viewLink}/${filename}`
     return <tr key={filename}>
       <td>{filename}</td>
-      <td><a href={viewFileLink}>View</a></td>
+      <td><a href={viewFileLink} target="_blank">View</a></td>
     </tr>
   }
 

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -53,7 +53,7 @@ class SitePublishedBranchesTable extends React.Component {
   }
 
   renderBranchViewLink(branch) {
-    return <a href={branch.viewLink}>View</a>
+    return <a href={branch.viewLink} target="_blank">View</a>
   }
 
   renderBranchFilesLink(branch) {


### PR DESCRIPTION
This commit adds a `target="blank"` attribute to links that open preview content so that they will open in a new tab. This is a response to customer requests for this behavior.

Ref #820