### PR TITLE
Use separate custom configs for site and preview builds

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -103,6 +103,7 @@ module.exports = {
       const params = Object.assign(site, req.body)
       return site.update({
         config: params.config,
+        previewConfig: params.previewConfig,
         defaultBranch: params.defaultBranch,
         domain: params.domain,
         engine: params.engine,

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -74,6 +74,9 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    previewConfig: {
+      type: DataTypes.STRING,
+    },
     publicPreview: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -5,7 +5,7 @@ const config = require("../../config")
 const buildConfig = config.build
 const s3Config = config.s3
 
-var buildContainerEnvironment = (build) => ({
+const buildContainerEnvironment = (build) => ({
   AWS_DEFAULT_REGION: s3Config.region,
   AWS_ACCESS_KEY_ID: s3Config.accessKeyId,
   AWS_SECRET_ACCESS_KEY: s3Config.secretAccessKey,
@@ -15,7 +15,7 @@ var buildContainerEnvironment = (build) => ({
   BASEURL: baseURLForBuild(build),
   CACHE_CONTROL: buildConfig.cacheControl,
   BRANCH: build.branch,
-  CONFIG: build.Site.config,
+  CONFIG: siteConfig(build),
   REPOSITORY: build.Site.repository,
   OWNER: build.Site.owner,
   SITE_PREFIX: pathForBuild(build),
@@ -25,11 +25,19 @@ var buildContainerEnvironment = (build) => ({
   SOURCE_OWNER: sourceForBuild(build).owner,
 })
 
-var defaultBranch = (build) => {
+const siteConfig = (build) => {
+  if (defaultBranch(build)) {
+    return build.Site.config
+  } else {
+    return build.Site.previewConfig
+  }
+}
+
+const defaultBranch = (build) => {
   return build.branch === build.Site.defaultBranch
 }
 
-var pathForBuild = (build) => {
+const pathForBuild = (build) => {
   if (defaultBranch(build)) {
     return `site/${build.Site.owner}/${build.Site.repository}`
   } else {
@@ -37,7 +45,7 @@ var pathForBuild = (build) => {
   }
 }
 
-var baseURLForBuild = (build) => {
+const baseURLForBuild = (build) => {
   if (defaultBranch(build) && build.Site.domain) {
     return baseURLForCustomDomain(build.Site.domain)
   } else {
@@ -45,19 +53,19 @@ var baseURLForBuild = (build) => {
   }
 }
 
-var baseURLForCustomDomain = (domain) => {
+const baseURLForCustomDomain = (domain) => {
   if (!domain.match(/https?\:\/\//)) {
     domain = "https://" + domain
   }
   return url.parse(domain).path.replace(/\/$/, "")
 }
 
-var sourceForBuild = (build) => {
+const sourceForBuild = (build) => {
   return build.source || {}
 }
 
-var sqsConfig = config.sqs
-var SQS = {
+const sqsConfig = config.sqs
+const SQS = {
   sqsClient: new AWS.SQS({
     accessKeyId: sqsConfig.accessKeyId,
     secretAccessKey: sqsConfig.secretAccessKey,

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -14,6 +14,7 @@ class SiteSettings extends React.Component {
     this.state = {
       enableSave: false,
       config: site.config || '',
+      previewConfig: site.previewConfig || '',
       defaultBranch: site.defaultBranch || '',
       domain: site.domain || '',
       publicPreview: site.publicPreview
@@ -118,7 +119,7 @@ class SiteSettings extends React.Component {
         <div className="usa-grid">
           <div className="usa-width-one-whole">
             <div className="form-group">
-               <label htmlFor="config" className="">Custom configuration</label>
+              <label htmlFor="config" className="">Site custom configuration</label>
               <textarea
                 name="config"
                 className="form-control"
@@ -127,9 +128,29 @@ class SiteSettings extends React.Component {
             </div>
             <div className="usa-alert usa-alert-info">
               <div className="usa-alert-body">
-                <h3 className="usa-alert-heading">Configuration</h3>
+                <h3 className="usa-alert-heading">Site configuration</h3>
                 <p className="usa-alert-text">
-                  Add additional configuration in yaml to be added to your <code>_config.yml</code> file when we render your site.
+                  Add additional configuration in yaml to be added to your <code>_config.yml</code> file when we build your site's default branch.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="usa-grid">
+          <div className="usa-width-one-whole">
+            <div className="form-group">
+              <label htmlFor="previewConfig" className="">Preview custom configuration</label>
+              <textarea
+                name="previewConfig"
+                className="form-control"
+                value={state.previewConfig}
+                onChange={this.onChange} />
+            </div>
+            <div className="usa-alert usa-alert-info">
+              <div className="usa-alert-body">
+                <h3 className="usa-alert-heading">Preview configuration</h3>
+                <p className="usa-alert-text">
+                  Add additional configuration in yaml to be added to your <code>_config.yml</code> file when we build a preview branch for your site.
                 </p>
               </div>
             </div>

--- a/migrations/20170327192453-add-preview-config-to-site.js
+++ b/migrations/20170327192453-add-preview-config-to-site.js
@@ -1,0 +1,22 @@
+//const dbm = global.dbm || require('db-migrate');
+//const type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  db.addColumn("site", "previewConfig", "text", (err) => {
+    if (err) {
+      callback(err)
+    } else {
+      db.runSql("UPDATE site SET \"previewConfig\" = config", (err) => {
+        if (err) {
+          callback(err)
+        } else {
+          callback()
+        }
+      })
+    }
+  })
+};
+
+exports.down = function(db, callback) {
+  db.removeColumn("site", "previewConfig", callback)
+};

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -37,6 +37,9 @@
     "owner": {
       "type": "string"
     },
+    "previewConfig": {
+      "type": "string"
+    },
     "publicPreview": {
       "type": "boolean"
     },

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -210,6 +210,9 @@ paths:
               owner:
                 type: string
                 description: The owner of the GitHub repo for the site
+              previewConfig:
+                type: string
+                description: Jekyll configs for the site in the preview environment
               publicPreview:
                 type: string
                 description: Whether public previews are enabled for the site
@@ -279,6 +282,9 @@ paths:
               owner:
                 type: string
                 description: The owner of the GitHub repo for the site
+              previewConfig:
+                type: string
+                description: Jekyll configs for the site in the preview environment
               publicPreview:
                 type: string
                 description: Whether public previews are enabled for the site

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -511,7 +511,7 @@ describe("Site API", () => {
     it("should allow a user to update a site associated with their account", done => {
       var site, response
 
-      factory.site({ config: "old-config" }).then(site => {
+      factory.site({ config: "old-config", previewConfig: "old-preview-config" }).then(site => {
         return Site.findById(site.id, { include: [ User ] })
       }).then(model => {
         site = model
@@ -520,7 +520,8 @@ describe("Site API", () => {
         return request("http://localhost:1337")
           .put(`/v0/site/${site.id}`)
           .send({
-            config: "new-config"
+            config: "new-config",
+            previewConfig: "new-preview-config",
           })
           .set("Cookie", cookie)
           .expect(200)
@@ -530,8 +531,10 @@ describe("Site API", () => {
       }).then(site => {
         validateAgainstJSONSchema("PUT", "/site/{id}", 200, response.body)
 
-        expect(response.body).to.have.property("config", "new-config")
-        expect(site).to.have.property("config", "new-config")
+        expect(response.body.config).to.equal("new-config")
+        expect(site.config).to.equal("new-config")
+        expect(response.body.previewConfig).to.equal("new-preview-config")
+        expect(site.previewConfig).to.equal("new-preview-config")
         siteResponseExpectations(response.body, site)
 
         done()

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -216,14 +216,34 @@ describe("SQS", () => {
       }).catch(done)
     })
 
-    it("should set CONFIG in the message to the YAML config for the site", done => {
-      factory.site({ config: "plugins_dir: _plugins" }).then(site => {
-        return factory.build({ site: site })
+    it("should set CONFIG in the message to the YAML config for the site on the default branch", done => {
+      factory.site({
+        defaultBranch: "master",
+        config: "plugins_dir: _plugins",
+        previewConfig: "plugins_dir: _preview_plugins",
+      }).then(site => {
+        return factory.build({ site, branch: "master" })
       }).then(build => {
         return Build.findById(build.id, { include: [Site, User] })
       }).then(build => {
         const message = SQS.messageBodyForBuild(build)
         expect(messageEnv(message, "CONFIG")).to.equal("plugins_dir: _plugins")
+        done()
+      }).catch(done)
+    })
+
+    it("should set CONFIG in the message to the YAML config for the site on a preview branch", done => {
+      factory.site({
+        defaultBranch: "master",
+        config: "plugins_dir: _plugins",
+        previewConfig: "plugins_dir: _preview_plugins",
+      }).then(site => {
+        return factory.build({ site, branch: "preview" })
+      }).then(build => {
+        return Build.findById(build.id, { include: [Site, User] })
+      }).then(build => {
+        const message = SQS.messageBodyForBuild(build)
+        expect(messageEnv(message, "CONFIG")).to.equal("plugins_dir: _preview_plugins")
         done()
       }).catch(done)
     })


### PR DESCRIPTION
This commit adds a new, separate text area which, in addition to the pre-existing config text area, can be used to set separate custom configs for site and preview builds. Site builds get the configs in the site configuration text area, and preview builds get the configs in the preview configuration text area.

Ref #333