### PR TITLE
Show correct error message when user attempts to add a site

### DIFF
--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -111,7 +111,7 @@ const repo = ({ accessToken, owner, repo, response } = {}) => {
 
   const typicalResponse = {
     permissions: {
-      admin: false,
+      admin: true,
       push: true,
       pull: true,
     }


### PR DESCRIPTION
Prior to this commit, Federalist would show an error message that read "You do not have write access to the repository" when a user attempted to add a new site. This suggested that the user only need attain write access to add a site, when in reality the user would need admin access. If the user got write permissions and went back to add the site, they'd see a write access error message.

This commit changes the logic used to display that error message to behave as follows:

- If the site is brand new, and the user does not have admin access, show an admin access error message
- If the site already exists, and the user does not have write access, show a write access error message
- If the repo does not exist, show a nonexistant repo error message

Ref #719