### PR TITLE
Use Federalist preview URLs instead of S3 URLs for view links in branch API responses

### DIFF
--- a/api/models/site.js
+++ b/api/models/site.js
@@ -1,3 +1,4 @@
+const url = require("url")
 const config = require("../../config")
 
 const associate = ({ Site, Build, User }) => {
@@ -49,7 +50,7 @@ const viewLinkForBranch = function(branch) {
   } else if (branch === this.defaultBranch) {
     return `${s3Root}/site/${this.owner}/${this.repository}`
   } else {
-    return `${s3Root}/preview/${this.owner}/${this.repository}/${branch}`
+    return url.resolve(config.app.hostname, `/preview/${this.owner}/${this.repository}/${branch}`)
   }
 }
 

--- a/config/app.js
+++ b/config/app.js
@@ -1,0 +1,3 @@
+module.exports = {
+  hostname: process.env.APP_HOSTNAME || "http://localhost:1337",
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -15,6 +15,7 @@ env:
   NEW_RELIC_APP_NAME: federalist-prod
   NODE_ENV: production
   APP_ENV: production
+  APP_HOSTNAME: https://federalist.fr.cloud.gov
   LOG_LEVEL: info
   NPM_CONFIG_PRODUCTION: true
   NODE_MODULES_CACHE: false

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -15,6 +15,7 @@ services:
 env:
   NODE_ENV: production
   APP_ENV: staging
+  APP_HOSTNAME: https://federalist-staging.fr.cloud.gov
   LOG_LEVEL: verbose
   NPM_CONFIG_PRODUCTION: true
   NODE_MODULES_CACHE: false

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -43,10 +43,10 @@ describe("Site model", () => {
     })
 
     context("for a preview branch", () => {
-      it("should return an S3 preview link", done => {
+      it("should return a federalist preview link", done => {
         factory.site().then(site => {
           const viewLink = site.viewLinkForBranch("preview-branch")
-          expect(viewLink).to.equal(`${s3BaseURL}/preview/${site.owner}/${site.repository}/preview-branch`)
+          expect(viewLink).to.equal(`http://localhost:1337/preview/${site.owner}/${site.repository}/preview-branch`)
           done()
         }).catch(done)
       })


### PR DESCRIPTION
The view links in the API responses for previews were S3 URLs, which don't support the public/private preview functionality. This commit adds an env variables named `APP_HOSTNAME` which tells Federalist what its hostname is. It then uses that hostname to generate a Federalist preview URL instead of an S3 one.

In a future commit, we should consider changing the build callback URL, build token URL, and GitHub callback URL to use the `APP_HOSTNAME` variable instead of needing to be set in the environment.

Ref #825