### PR TITLE
Base64 decode build log output in build log callback

### DIFF
--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -2,6 +2,12 @@ const buildAuthorizer = require("../authorizers/build")
 const buildLogSerializer = require("../serializers/build-log")
 const { Build, BuildLog } = require("../models")
 
+const decodeb64 = (str) => {
+  if (str) {
+    return new Buffer(str, 'base64').toString('utf8')
+  }
+}
+
 module.exports = {
   create: (req, res) => {
     Promise.resolve(Number(req.params["build_id"])).then(id => {
@@ -15,7 +21,7 @@ module.exports = {
       }
       return BuildLog.create({
         build: build.id,
-        output: req.body["output"],
+        output: decodeb64(req.body["output"]),
         source: req.body["source"],
       })
     }).then(buildLog => {

--- a/test/api/requests/build-logs.test.js
+++ b/test/api/requests/build-logs.test.js
@@ -7,6 +7,10 @@ const { BuildLog, Site, User } = require("../../../api/models")
 
 describe("Build Log API", () => {
   describe("POST /v0/build/:build_id/log/:token", () => {
+    const encode64 = (str) => {
+      return new Buffer(str, 'utf8').toString('base64');
+    }
+
     it("should create a build log with the given params", done => {
       let build
 
@@ -18,7 +22,7 @@ describe("Build Log API", () => {
           .type("json")
           .send({
             source: "build.sh",
-            output: "This is the output for build.sh",
+            output: encode64("This is the output for build.sh"),
           })
           .expect(200)
       }).then(response => {
@@ -43,7 +47,7 @@ describe("Build Log API", () => {
           .type("json")
           .send({
             src: "build.sh",
-            otpt: "This is the output for build.sh",
+            otpt: encode64("This is the output for build.sh"),
           })
           .expect(400)
       }).then(response => {
@@ -63,7 +67,7 @@ describe("Build Log API", () => {
           .type("json")
           .send({
             source: "build.sh",
-            body: "This is the output for build.sh",
+            output: encode64("This is the output for build.sh"),
           })
           .expect(403)
       }).then(response => {
@@ -82,7 +86,7 @@ describe("Build Log API", () => {
         .type("json")
         .send({
           source: "build.sh",
-          body: "This is the output for build.sh",
+          output: encode64("This is the output for build.sh"),
         })
         .expect(404)
 


### PR DESCRIPTION
The build container and builder now send the output for build logs as a
base64 enconded string. This commit properly handles that change in the
build log API.