### PR TITLE
Remove bluebird promises

### DIFF
--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -59,8 +59,11 @@ const createBuildForWebhookRequest = (request) => {
   const user = findUserForWebhookRequest(request)
   const site = findSiteForWebhookRequest(request)
 
-  return Promise.props({ user, site }).then((models) => {
-    buildParams = models
+  return Promise.props([ user, site ]).then((models) => {
+    buildParams = {
+      user: models[0],
+      site: models[1],
+    }
     return addUserToSite(buildParams)
   }).then(() => {
     return Build.create({

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "keywords": [],
   "dependencies": {
     "aws-sdk": "^2.1.36",
-    "bluebird": "^3.4.6",
     "body-parser": "^1.16.1",
     "cfenv": "^1.0.0",
     "connect-session-sequelize": "^4.1.0",
@@ -92,6 +91,7 @@
     "node-sass": "^3.4.2",
     "nodemon": "^1.3.7",
     "postcss-cli": "^2.3.2",
+    "promise-props": "^1.0.0",
     "proxyquire": "^1.7.10",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.3.1",

--- a/test/api/bootstrap.test.js
+++ b/test/api/bootstrap.test.js
@@ -1,3 +1,5 @@
+Promise.props = require("promise-props")
+
 const AWSMocks = require("./support/aws-mocks")
 
 const _cleanDatabase = () => {


### PR DESCRIPTION
This commit removes bluebird promises in favor of using native promises. The only function we used that was provided by bluebird was `Promise.props` so this commit pulls in the `promise-props` module to add that.