### PR TITLE
Don't bind to localhost:1337 during tests

### DIFF
--- a/test/api/bootstrap.test.js
+++ b/test/api/bootstrap.test.js
@@ -1,7 +1,5 @@
 const AWSMocks = require("./support/aws-mocks")
 
-const app = require("../../app")
-
 const _cleanDatabase = () => {
   const models = require("../../api/models").sequelize.models
   const promises = Object.keys(models).map(name => {
@@ -11,17 +9,9 @@ const _cleanDatabase = () => {
 }
 
 before(function(done) {
-  app.listen(1337, (err) => {
-    if (err) return done(err)
-
-    _cleanDatabase().then(() => {
-      done(null, app);
-    }).catch(err => {
-      done(err)
-    })
+  _cleanDatabase().then(() => {
+    done()
+  }).catch(err => {
+    done(err)
   })
-});
-
-after((done) => {
-  done()
-});
+})

--- a/test/api/requests/build-logs.test.js
+++ b/test/api/requests/build-logs.test.js
@@ -1,5 +1,6 @@
 const expect = require("chai").expect
 const request = require("supertest-as-promised")
+const app = require("../../../app")
 const factory = require("../support/factory")
 const session = require("../support/session")
 const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
@@ -17,7 +18,7 @@ describe("Build Log API", () => {
       factory.build().then(model => {
         build = model
 
-        return request("localhost:1337")
+        return request(app)
           .post(`/v0/build/${build.id}/log/${build.token}`)
           .type("json")
           .send({
@@ -42,7 +43,7 @@ describe("Build Log API", () => {
 
     it("should respond with a 400 if the params are not correct", done => {
       factory.build().then(build => {
-        return request("localhost:1337")
+        return request(app)
           .post(`/v0/build/${build.id}/log/${build.token}`)
           .type("json")
           .send({
@@ -62,7 +63,7 @@ describe("Build Log API", () => {
       factory.build().then(model => {
         build = model
 
-        return request("localhost:1337")
+        return request(app)
           .post(`/v0/build/${build.id}/log/invalid-token`)
           .type("json")
           .send({
@@ -81,7 +82,7 @@ describe("Build Log API", () => {
     })
 
     it("should respond with a 404 if no build is found for the given id", done => {
-      const buildLogRequest = request("localhost:1337")
+      const buildLogRequest = request(app)
         .post(`/v0/build/fake-id/log/fake-build-token`)
         .type("json")
         .send({
@@ -100,7 +101,7 @@ describe("Build Log API", () => {
   describe("GET /v0/build/:build_id/log", () => {
     it("should require authentication", done => {
       factory.buildLog().then(buildLog => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/build/${buildLog.build}/log`)
           .expect(403)
       }).then(response => {
@@ -126,7 +127,7 @@ describe("Build Log API", () => {
         let user = site.Users[0]
         return session(user)
       }).then(cookie => {
-        return request("localhost:1337")
+        return request(app)
           .get(`/v0/build/${build.id}/log`)
           .set("Cookie", cookie)
           .expect(200)
@@ -150,7 +151,7 @@ describe("Build Log API", () => {
       }).then(user => {
         return session(user)
       }).then(cookie => {
-        return request("localhost:1337")
+        return request(app)
           .get(`/v0/build/${build.id}/log`)
           .set("Cookie", cookie)
           .expect(403)
@@ -162,7 +163,7 @@ describe("Build Log API", () => {
 
     it("should response with a 404 if the given build does not exist", done => {
       session().then(cookie => {
-        return request("localhost:1337")
+        return request(app)
           .get(`/v0/build/fake-id/log`)
           .set("Cookie", cookie)
           .expect(404)

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -1,6 +1,7 @@
 const expect = require("chai").expect
 const request = require("supertest-as-promised")
 const sinon = require("sinon")
+const app = require("../../../app")
 const factory = require("../support/factory")
 const session = require("../support/session")
 const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
@@ -23,7 +24,7 @@ describe("Build API", () => {
   describe("POST /v0/build", () => {
     it("should require authentication", done => {
       factory.site().then(site => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/build/`)
           .send({
             site: site.id,
@@ -51,7 +52,7 @@ describe("Build API", () => {
         site = promisedValues.site
         user = promisedValues.user
 
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/build/`)
           .send({
             site: site.id,
@@ -79,7 +80,7 @@ describe("Build API", () => {
         site: factory.site(),
         cookie: session(),
       }).then(({ site, cookie }) => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/build/`)
           .send({
             site: site.id,
@@ -97,7 +98,7 @@ describe("Build API", () => {
   describe("GET /v0/build/:id", () => {
     it("should require authentication", done => {
       factory.build().then(build => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/build/${build.id}`)
           .expect(403)
       }).then(response => {
@@ -121,7 +122,7 @@ describe("Build API", () => {
           User.findById(build.user)
         )
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/build/${build.id}`)
           .set("Cookie", cookie)
           .expect(200)
@@ -139,7 +140,7 @@ describe("Build API", () => {
         build = model
         return session(factory.user())
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/build/${build.id}`)
           .set("Cookie", cookie)
           .expect(403)
@@ -153,7 +154,7 @@ describe("Build API", () => {
   describe("GET /v0/build", () => {
     it("should require authentication", done => {
       factory.build().then(build => {
-        return request("http://localhost:1337")
+        return request(app)
           .get("/v0/build")
           .expect(403)
       }).then(response => {
@@ -175,7 +176,7 @@ describe("Build API", () => {
         builds = models
         return session(user)
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get("/v0/build")
           .set("Cookie", cookie)
           .expect(200)
@@ -207,7 +208,7 @@ describe("Build API", () => {
         expect(builds).to.have.length(3)
         return session(user)
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get("/v0/build")
           .set("Cookie", cookie)
           .expect(200)
@@ -223,7 +224,7 @@ describe("Build API", () => {
     var postBuildStatus = (options) => {
       const buildToken = options.buildToken || options.build.token
 
-      return request("http://localhost:1337")
+      return request(app)
         .post(`/v0/build/${options.build.id}/status/${buildToken}`)
         .type("json")
         .send({

--- a/test/api/requests/published-branch.test.js
+++ b/test/api/requests/published-branch.test.js
@@ -1,6 +1,7 @@
 const AWSMocks = require("../support/aws-mocks")
 const expect = require("chai").expect
 const request = require("supertest-as-promised")
+const app = require("../../../app")
 const config = require("../../../config")
 const factory = require("../support/factory")
 const session = require("../support/session")
@@ -15,7 +16,7 @@ describe("Published Files API", () => {
   describe("GET /v0/site/:site_id/published-branch", () => {
     it("should require authentication", done => {
       factory.site().then(site => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${site.id}/published-branch`)
           .expect(403)
       }).then(response => {
@@ -51,7 +52,7 @@ describe("Published Files API", () => {
       }).then(promisedValues => {
         site = promisedValues.site
 
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${site.id}/published-branch`)
           .set("Cookie", promisedValues.cookie)
           .expect(200)
@@ -72,7 +73,7 @@ describe("Published Files API", () => {
       const cookie = session(user)
 
       Promise.props({ user, site, cookie }).then(promisedValues => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${promisedValues.site.id}/published-branch`)
           .set("Cookie", promisedValues.cookie)
           .expect(403)
@@ -86,7 +87,7 @@ describe("Published Files API", () => {
   describe("GET /v0/site/:site_id/published-branch/:branch", () => {
     it("should require authentication", done => {
       factory.site().then(site => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${site.id}/published-branch/${site.defaultBranch}`)
           .expect(403)
       }).then(response => {
@@ -125,7 +126,7 @@ describe("Published Files API", () => {
       }).then(promisedValues => {
         site = promisedValues.site
 
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${site.id}/published-branch/master`)
           .set("Cookie", promisedValues.cookie)
           .expect(200)
@@ -144,7 +145,7 @@ describe("Published Files API", () => {
       const cookie = session(user)
 
       Promise.props({ user, site, cookie }).then(promisedValues => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${promisedValues.site.id}/published-branch/master`)
           .set("Cookie", promisedValues.cookie)
           .expect(403)

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -4,6 +4,7 @@ const nock = require("nock")
 const request = require("supertest-as-promised")
 const sinon = require("sinon")
 
+const app = require("../../../app")
 const factory = require("../support/factory")
 const githubAPINocks = require("../support/githubAPINocks")
 const session = require("../support/session")
@@ -31,7 +32,7 @@ describe("Site API", () => {
   describe("GET /v0/site", () => {
     it("should require authentication", done => {
       factory.build().then(build => {
-        return request("http://localhost:1337")
+        return request(app)
           .get("/v0/site")
           .expect(403)
       }).then(response => {
@@ -53,7 +54,7 @@ describe("Site API", () => {
         sites = models
         return session(user)
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get("/v0/site")
           .set("Cookie", cookie)
           .expect(200)
@@ -89,7 +90,7 @@ describe("Site API", () => {
         expect(site).to.have.length(3)
         return session(factory.user())
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get("/v0/site")
           .set("Cookie", cookie)
           .expect(200)
@@ -105,7 +106,7 @@ describe("Site API", () => {
   describe("GET /v0/site/:id", () => {
     it("should require authentication", done => {
       factory.site().then(site => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${site.id}`)
           .expect(403)
       }).then(response => {
@@ -123,7 +124,7 @@ describe("Site API", () => {
         site = model
         return session(site.Users[0])
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${site.id}`)
           .set("Cookie", cookie)
           .expect(200)
@@ -141,7 +142,7 @@ describe("Site API", () => {
         site = model
         return session(factory.user())
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get(`/v0/site/${site.id}`)
           .set("Cookie", cookie)
           .expect(403)
@@ -165,7 +166,7 @@ describe("Site API", () => {
     })
 
     it("should require authentication", done => {
-      const newSiteRequest = request("http://localhost:1337")
+      const newSiteRequest = request(app)
         .post(`/v0/site`)
         .send({
           organization: "partner-org",
@@ -186,7 +187,7 @@ describe("Site API", () => {
       const siteRepository = crypto.randomBytes(3).toString("hex")
 
       session().then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/site`)
           .send({
             owner: siteOwner,
@@ -224,7 +225,7 @@ describe("Site API", () => {
 
         githubAPINocks.repo()
 
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/site`)
           .send({
             owner: site.owner,
@@ -266,7 +267,7 @@ describe("Site API", () => {
       })
 
       session().then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/site`)
           .send({
             owner: siteOwner,
@@ -294,7 +295,7 @@ describe("Site API", () => {
 
     it("should respond with a 400 if no user or repository is specified", done => {
       session().then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/site`)
           .send({
             defaultBranch: "master",
@@ -317,7 +318,7 @@ describe("Site API", () => {
         site: factory.site({ users: Promise.all([userPromise]) }),
         cookie: session(userPromise),
       }).then(({ site, cookie }) => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/site`)
           .send({
             owner: site.owner,
@@ -349,7 +350,7 @@ describe("Site API", () => {
       githubAPINocks.webhook()
 
       session().then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/site`)
           .send({
             owner: siteOwner,
@@ -383,7 +384,7 @@ describe("Site API", () => {
 
         return session()
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/site`)
           .send({
             owner: site.owner,
@@ -415,7 +416,7 @@ describe("Site API", () => {
       })
 
       session().then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .post(`/v0/site`)
           .send({
             owner: siteOwner,
@@ -444,7 +445,7 @@ describe("Site API", () => {
 
     it("should require authentication", done => {
       factory.site().then(site => {
-        return request("http://localhost:1337")
+        return request(app)
           .delete(`/v0/site/${site.id}`)
           .expect(403)
       }).then(response => {
@@ -462,7 +463,7 @@ describe("Site API", () => {
         site = model
         return session(site.Users[0])
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .delete(`/v0/site/${site.id}`)
           .set("Cookie", cookie)
           .expect(200)
@@ -485,7 +486,7 @@ describe("Site API", () => {
         site = model
         return session(factory.user())
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .delete(`/v0/site/${site.id}`)
           .set("Cookie", cookie)
           .expect(403)
@@ -516,7 +517,7 @@ describe("Site API", () => {
           return Promise.resolve()
         })
 
-        return request("http://localhost:1337")
+        return request(app)
           .delete(`/v0/site/${site.id}`)
           .set("Cookie", results.cookie)
           .expect(200)
@@ -530,7 +531,7 @@ describe("Site API", () => {
   describe("PUT /v0/site/:id", () => {
     it("should require authentication", done => {
       factory.site().then(site => {
-        return request("http://localhost:1337")
+        return request(app)
           .put(`/v0/site/${site.id}`)
           .send({
             defaultBranch: "master"
@@ -551,7 +552,7 @@ describe("Site API", () => {
         site = model
         return session(site.Users[0])
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .put(`/v0/site/${site.id}`)
           .send({
             config: "new-config",
@@ -582,7 +583,7 @@ describe("Site API", () => {
         site = model
         return session(factory.user())
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .put(`/v0/site/${site.id}`)
           .send({
             repository: "new-repo-name"
@@ -607,7 +608,7 @@ describe("Site API", () => {
         expect(site.Builds).to.have.length(0)
         return session(site.Users[0])
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .put(`/v0/site/${site.id}`)
           .send({
             repository: "new-repo-name"
@@ -639,7 +640,7 @@ describe("Site API", () => {
       }).then(results => {
         site = results.site
 
-        return request("http://localhost:1337")
+        return request(app)
           .put(`/v0/site/${site.id}`)
           .send({
             config: "",
@@ -674,7 +675,7 @@ describe("Site API", () => {
       }).then(results => {
         site = results.site
 
-        return request("http://localhost:1337")
+        return request(app)
           .put(`/v0/site/${site.id}`)
           .send({
             config: "new-config: true",

--- a/test/api/requests/user.test.js
+++ b/test/api/requests/user.test.js
@@ -5,6 +5,7 @@ const Promise = require("bluebird")
 const request = require("supertest-as-promised")
 const sinon = require("sinon")
 
+const app = require("../../../app")
 const factory = require("../support/factory")
 const githubAPINocks = require("../support/githubAPINocks")
 const session = require("../support/session")
@@ -20,7 +21,7 @@ describe("User API", () => {
   describe("GET /v0/me", () => {
     it("should require authentication", done => {
       factory.user().then(user => {
-        return request("http://localhost:1337")
+        return request(app)
           .get("/v0/me")
           .expect(403)
       }).then(response => {
@@ -36,7 +37,7 @@ describe("User API", () => {
         user = model
         return session(user)
       }).then(cookie => {
-        return request("http://localhost:1337")
+        return request(app)
           .get("/v0/me")
           .set("Cookie", cookie)
           .expect(200)

--- a/test/api/requests/webhook.test.js
+++ b/test/api/requests/webhook.test.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto')
 const expect = require("chai").expect
 const request = require("supertest-as-promised")
+const app = require("../../../app")
 const config = require("../../../config")
 const factory = require("../support/factory")
 const { Build, Site, User } = require("../../../api/models")
@@ -42,7 +43,7 @@ describe("Webhook API", () => {
         const payload = buildWebhookPayload(user, site)
         const signature = signWebhookPayload(payload)
 
-        return request("http://localhost:1337")
+        return request(app)
           .post("/webhook/github")
           .send(payload)
           .set({
@@ -69,7 +70,7 @@ describe("Webhook API", () => {
         const payload = buildWebhookPayload({ username: username }, site)
         const signature = signWebhookPayload(payload)
 
-        return request("http://localhost:1337")
+        return request(app)
           .post("/webhook/github")
           .send(payload)
           .set({
@@ -102,7 +103,7 @@ describe("Webhook API", () => {
         payload.repository.full_name = `${site.owner.toUpperCase()}/${site.repository.toUpperCase()}`
         const signature = signWebhookPayload(payload)
 
-        return request("http://localhost:1337")
+        return request(app)
           .post("/webhook/github")
           .send(payload)
           .set({
@@ -133,7 +134,7 @@ describe("Webhook API", () => {
         payload.commits = []
         const signature = signWebhookPayload(payload)
 
-        return request("http://localhost:1337")
+        return request(app)
           .post("/webhook/github")
           .send(payload)
           .set({
@@ -158,7 +159,7 @@ describe("Webhook API", () => {
         })
         const signature = signWebhookPayload(payload)
 
-        request("http://localhost:1337")
+        request(app)
           .post("/webhook/github")
           .send(payload)
           .set({
@@ -182,7 +183,7 @@ describe("Webhook API", () => {
         const payload = buildWebhookPayload(user, site)
         const signature = "123abc"
 
-        request("http://localhost:1337")
+        request(app)
           .post("/webhook/github")
           .send(payload)
           .set({


### PR DESCRIPTION
This commit changes the request specs so they require the app and pass it into supertest instead of listening on a port and pointing supertest at that. This has the advantage of making the tests more portable and means the test suite can run at the same time as the app.