### PR TITLE
Lowercase owner and repo before looking for existing site at site creation

### DIFF
--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -73,7 +73,7 @@ const createSiteFromExistingRepo = ({ siteParams, user }) => {
   const { owner, repository } = siteParams
 
   return Site.findOne({
-    where: { owner, repository },
+    where: { owner: owner, repository: repository },
     include: [ User ],
   }).then(model => {
     site = model
@@ -129,8 +129,8 @@ const paramsForNewBuildSource = (templateName) => {
 }
 
 const paramsForNewSite = (params) => ({
-  owner: params.owner,
-  repository: params.repository,
+  owner: params.owner ? params.owner.toLowerCase() : undefined,
+  repository: params.repository ? params.repository.toLowerCase() : undefined,
   defaultBranch: params.defaultBranch,
   engine: params.engine,
 })

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "watch:client:js": "watchify frontend/main.js -o public/js/bundle.js -t [ babelify --presets [ es2015 react stage-2 ] ]",
     "test": "npm run test:prepare && npm run test:server && npm run test:client",
     "test:prepare": "NODE_ENV=test npm run migrate:up && npm run build",
-    "test:server": "NODE_ENV=test mocha --timeout 6000 test/api/bootstrap.test.js test/api/unit/**/*.test.js test/api/requests/**/*.test.js",
+    "test:server": "NODE_ENV=test mocha --timeout 1000 test/api/bootstrap.test.js test/api/unit/**/*.test.js test/api/requests/**/*.test.js",
     "test:client": "mocha --compilers js:babel-register --recursive ./test/frontend",
     "test:client:watch": "watch 'npm run test:client' ./frontend ./test/frontend",
     "coverage:client": "istanbul cover _mocha -- --compilers js:babel-register --recursive ./test/frontend",

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -297,6 +297,23 @@ describe("SiteCreator", () => {
           done()
         }).catch(done)
       })
+
+      it("should reject if the user has already added the site and the site name is a different case", done => {
+        const user = factory.user()
+        const site = factory.site({ users: Promise.all([user]) })
+
+        Promise.props({ user, site }).then(({ user, site }) => {
+          githubAPINocks.repo()
+          return SiteCreator.createSite({ user, siteParams: {
+            owner: site.owner.toUpperCase(),
+            repository: site.repository.toUpperCase(),
+          }})
+        }).catch(err => {
+          expect(err.status).to.equal(400)
+          expect(err.message).to.equal("You've already added this site to Federalist")
+          done()
+        }).catch(done)
+      })
     })
 
     context("when the site is created from a template", () => {


### PR DESCRIPTION
The check to make sure a site was not added twice by looking for the owner / repo name was broken if the name of the site to be added contained uppercase characters. This was because we lowercase the name of the site / repo when adding then, but not when checking for their existence.

This commit lowercases the name of the owner and repo before checking for their existence.

ref #851