### PR TITLE
Allow sites to specify an image path for template images

### DIFF
--- a/config/templates.js
+++ b/config/templates.js
@@ -6,6 +6,7 @@ module.exports = {
     example: 'https://federalist-proxy.app.cloud.gov/site/18f/federalist-uswds-template/',
     title: 'U.S. Web Design Standards',
     description: 'A flexible Jekyll implementation of the U.S. Web Design Standards',
+    thumb: "/images/uswds.thumb.png",
   },
   'team': {
     owner: '18f',
@@ -14,6 +15,7 @@ module.exports = {
     example: 'https://pages.18f.gov/federalist-modern-team-template/',
     title: 'Multi-page Template',
     description: 'Simple Jekyll site to showcase the work of an organization',
+    thumb: "/images/team.thumb.png",
   },
   'landing': {
     owner: '18f',
@@ -22,5 +24,6 @@ module.exports = {
     example: 'http://federalist.18f.gov.s3-website-us-east-1.amazonaws.com/site/18F/federalist-landing-page-template/',
     title: 'Single-page template',
     description: 'Single page to host information about a specific topic or report',
+    thumb: "/images/landing.thumb.png",
   },
 };

--- a/frontend/components/AddSite/TemplateSiteList/index.js
+++ b/frontend/components/AddSite/TemplateSiteList/index.js
@@ -74,7 +74,7 @@ class TemplateList extends React.Component {
                 <TemplateSite
                   name={templateName}
                   index={index++}
-                  thumb={templateName}
+                  thumb={template.thumb}
                   active={this.state.activeChildId}
                   handleChooseActive={this.handleChooseActive}
                   handleSubmit={this.props.handleSubmitTemplate}

--- a/frontend/components/AddSite/TemplateSiteList/templateSite.js
+++ b/frontend/components/AddSite/TemplateSiteList/templateSite.js
@@ -71,7 +71,7 @@ class TemplateSite extends React.Component {
           <div className="usa-alert-text">
             <a data-action="name-site" className="thumbnail">
               <img
-                src={`/images/${props.thumb}.thumb.png`}
+                src={props.thumb}
                 alt={`Thumbnail screenshot for the ${props.title} template`} />
             </a>
             <p>{props.description}</p>


### PR DESCRIPTION
This commit adds a `thumb` prop to the template configuration. Here, a link to a thumbnail image for the template can be set. This will allow template maintainers to link to external template URLs and avoid having to PR Federalist to change the thumbnail when the template changes.

This commit should be followed up with commits to link to template thumbs in the templates' respective repos so they can be maintained there.