### PR TITLE
Fix intermittent GitHub auth test failure

### DIFF
--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -12,10 +12,15 @@ const accessToken = ({ authorizationCode, accessToken, scope } = {}) => {
   }
 
   return nock("https://github.com")
-    .post("/login/oauth/access_token", {
-      client_id: config.passport.github.options.clientID,
-      client_secret: config.passport.github.options.clientSecret,
-      code: authorizationCode
+    .post("/login/oauth/access_token", (body) => {
+      const expectedBody = {
+        client_id: config.passport.github.options.clientID,
+        client_secret: config.passport.github.options.clientSecret,
+        code: authorizationCode,
+      }
+      return body.client_id === expectedBody.client_id &&
+        body.client_secret === expectedBody.client_secret &&
+        body.code === expectedBody.code
     })
     .reply(200, {
       token_type: "bearer",


### PR DESCRIPTION
There was an intermittent GitHub auth test failure that I was able to track down to an issue with the nock for the GitHub access token request. It appears that the `passport-oauth` strategy, which the `passport-github` strategy is built on occasionally sends an additional `redirect-uri` param. This appears to depend on the URL that `supertest` assigns the app when it sends the request. When this happens, the request body for the nock does not match.

This commit changes the request body matching the access token nock to use a function instead of an object so an exact match is not required and the additional params will no longer break the test.