### PR TITLE
Save session before redirecting on authentication

### DIFF
--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -12,10 +12,15 @@ const accessToken = ({ authorizationCode, accessToken, scope } = {}) => {
   }
 
   return nock("https://github.com")
-    .post("/login/oauth/access_token", {
-      client_id: config.passport.github.options.clientID,
-      client_secret: config.passport.github.options.clientSecret,
-      code: authorizationCode
+    .post("/login/oauth/access_token", (body) => {
+      const expectedBody = {
+        client_id: config.passport.github.options.clientID,
+        client_secret: config.passport.github.options.clientSecret,
+        code: authorizationCode,
+      }
+      return body.client_id === expectedBody.client_id &&
+        body.client_secret === expectedBody.client_secret &&
+        body.code === expectedBody.code
     })
     .reply(200, {
       token_type: "bearer",


### PR DESCRIPTION
This commit addresses a race condition in the session store.

We change the session when we authenticate, then redirect before saving. This meant that the next request could load the old session. The old session would not be marked as authenticated, so auth would fail. I haven't observed this bug on staging or prod, but have seen it occasionally running locally.

This commit fixes the issue by calling `session.save` and waiting for the session to save before triggering the redirect.