### PR TITLE
Add loading state for published files list table

### DIFF
--- a/frontend/actions/actionCreators/publishedFileActions.js
+++ b/frontend/actions/actionCreators/publishedFileActions.js
@@ -1,4 +1,9 @@
+const publishedFilesFetchStartedType = "SITE_PUBLISHED_FILES_FETCH_STARTED"
 const publishedFilesReceivedType = "SITE_PUBLISHED_FILES_RECEIVED"
+
+const publishedFilesFetchStarted = () => ({
+  type: publishedFilesFetchStartedType,
+})
 
 const publishedFilesReceived = files => ({
   type: publishedFilesReceivedType,
@@ -6,5 +11,6 @@ const publishedFilesReceived = files => ({
 })
 
 export {
+  publishedFilesFetchStartedType, publishedFilesFetchStarted,
   publishedFilesReceivedType, publishedFilesReceived,
 }

--- a/frontend/actions/publishedFileActions.js
+++ b/frontend/actions/publishedFileActions.js
@@ -2,8 +2,13 @@ import api from '../util/federalistApi';
 import { dispatch } from '../store';
 
 import {
+  publishedFilesFetchStarted as createPublishedFilesFetchStartedAction,
   publishedFilesReceived as createPublishedFilesReceivedAction,
 } from "./actionCreators/publishedFileActions";
+
+const dispatchPublishedfilesFetchStartedAction = () => {
+  dispatch(createPublishedFilesFetchStartedAction())
+}
 
 const dispatchPublishedFilesReceivedAction = files => {
   dispatch(createPublishedFilesReceivedAction(files))
@@ -11,6 +16,7 @@ const dispatchPublishedFilesReceivedAction = files => {
 
 export default {
   fetchPublishedFiles(site, branch) {
+    dispatchPublishedfilesFetchStartedAction()
     return api.fetchPublishedFiles(site, branch)
       .then(dispatchPublishedFilesReceivedAction)
   },

--- a/frontend/components/site/sitePublishedFilesTable.js
+++ b/frontend/components/site/sitePublishedFilesTable.js
@@ -10,8 +10,8 @@ class SitePublishedBranch extends React.Component {
 
   publishedFiles() {
     const branch = this.props.params.name
-    if (this.props.publishedFiles) {
-      return this.props.publishedFiles.filter(file => {
+    if (this.props.publishedFiles.data && !this.props.publishedFiles.isLoading) {
+      return this.props.publishedFiles.data.filter(file => {
         return file.publishedBranch.name === branch
       })
     } else {
@@ -21,7 +21,9 @@ class SitePublishedBranch extends React.Component {
 
   render() {
     const files = this.publishedFiles()
-    if (!files.length) {
+    if (this.props.publishedFiles.isLoading) {
+      return this.renderLoadingState()
+    } else if (!files.length) {
       return this.renderEmptyState()
     } else {
       return this.renderPublishedFilesTable(files)
@@ -51,6 +53,11 @@ class SitePublishedBranch extends React.Component {
       <td>{file.name}</td>
       <td><a href={viewFileLink} target="_blank">View</a></td>
     </tr>
+  }
+
+  renderLoadingState() {
+    // TODO: Replace with a loading component
+    return <p>Loading published files</p>
   }
 
   renderEmptyState() {

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -64,9 +64,7 @@ class SiteContainer extends React.Component {
     const publishedBranches = storeState.publishedBranches.filter(branch => {
       return branch.site.id === site.id
     })
-    const publishedFiles = storeState.publishedFiles.filter(file => {
-      return file.publishedBranch.site.id === site.id
-    })
+    const publishedFiles = storeState.publishedFiles
     const pageTitle = this.getPageTitle(location.pathname);
 
     let childConfigs;

--- a/frontend/reducers/publishedFiles.js
+++ b/frontend/reducers/publishedFiles.js
@@ -1,11 +1,23 @@
 import {
+  publishedFilesFetchStartedType as PUBLISHED_FILES_FETCH_STARTED,
   publishedFilesReceivedType as PUBLISHED_FILES_RECEIVED,
 } from "../actions/actionCreators/publishedFileActions";
 
-export default function publishedFiles(state = [], action) {
+const initialState = {
+  isLoading: false,
+}
+
+export default function publishedFiles(state = initialState, action) {
   switch (action.type) {
+  case PUBLISHED_FILES_FETCH_STARTED:
+    return {
+      isLoading: true,
+    }
   case PUBLISHED_FILES_RECEIVED:
-    return action.files;
+    return {
+      isLoading: false,
+      data: action.files,
+    }
   default:
     return state;
   }

--- a/test/frontend/actions/actionCreators/publishedFileActionsTest.js
+++ b/test/frontend/actions/actionCreators/publishedFileActionsTest.js
@@ -1,9 +1,23 @@
 import { expect } from "chai"
 import {
+  publishedFilesFetchStarted, publishedFilesFetchStartedType,
   publishedFilesReceived, publishedFilesReceivedType,
 } from "../../../../frontend/actions/actionCreators/publishedFileActions";
 
 describe("publishedFilesActions actionCreators", () => {
+  describe("published files fetch started", () => {
+    it("constructs properly", () => {
+      const actual = publishedFilesFetchStarted()
+      expect(actual).to.deep.equal({
+        type: publishedFilesFetchStartedType
+      })
+    })
+
+    it("exports its type", () => {
+      expect(publishedFilesFetchStartedType).to.equal("SITE_PUBLISHED_FILES_FETCH_STARTED")
+    })
+  })
+
   describe("published files received", () => {
     it("constructs properly", () => {
       const files = ["File 1", "File 2"]

--- a/test/frontend/actions/publishedFileActionsTest.js
+++ b/test/frontend/actions/publishedFileActionsTest.js
@@ -7,17 +7,20 @@ proxyquire.noCallThru()
 describe("publishedFileActions", () => {
   let fixture
   let dispatch
+  let publishedFilesFetchStartedActionCreator
   let publishedFilesReceivedActionCreator
   let fetchPublishedFiles
 
   beforeEach(() => {
     dispatch = spy()
+    publishedFilesFetchStartedActionCreator = stub()
     publishedFilesReceivedActionCreator = stub()
 
     fetchPublishedFiles = stub()
 
     fixture = proxyquire("../../../frontend/actions/publishedFileActions", {
       "./actionCreators/publishedFileActions": {
+        publishedFilesFetchStarted: publishedFilesFetchStartedActionCreator,
         publishedFilesReceived: publishedFilesReceivedActionCreator,
       },
       "../util/federalistApi": {
@@ -29,18 +32,21 @@ describe("publishedFileActions", () => {
     }).default
   })
 
-  it("fetchPublishedFilees", done => {
+  it("fetchPublishedFiles", done => {
     const files = ["File 1", "File 2"]
     const publishedFilesPromise = Promise.resolve(files)
-    const action = { action: "action" }
+    const startedAction = { action: "started" }
+    const receivedAction = { action: "received" }
     fetchPublishedFiles.withArgs().returns(publishedFilesPromise)
-    publishedFilesReceivedActionCreator.withArgs(files).returns(action)
+    publishedFilesFetchStartedActionCreator.withArgs().returns(startedAction)
+    publishedFilesReceivedActionCreator.withArgs(files).returns(receivedAction)
 
     const actual = fixture.fetchPublishedFiles()
 
     actual.then(() => {
-      expect(dispatch.calledOnce).to.be.true
-      expect(dispatch.calledWith(action)).to.be.true
+      expect(dispatch.calledTwice).to.be.true
+      expect(dispatch.calledWith(startedAction)).to.be.true
+      expect(dispatch.calledWith(receivedAction)).to.be.true
       done()
     })
   })

--- a/test/frontend/components/site/sitePublishedFilesTable.test.js
+++ b/test/frontend/components/site/sitePublishedFilesTable.test.js
@@ -9,9 +9,12 @@ describe("<SitePublishedFilesTable/>", () => {
     const publishedBranch = { name: "master", viewLink: "www.example.gov/master" }
     const props = {
       params: { id: 1, name: "master" },
-      publishedFiles: [
-        { name: "abc", publishedBranch }
-      ]
+      publishedFiles: {
+        isLoading: false,
+        data: [
+          { name: "abc", publishedBranch },
+        ],
+      }
     }
 
     const wrapper = shallow(<SitePublishedFilesTable {...props} />)
@@ -21,15 +24,16 @@ describe("<SitePublishedFilesTable/>", () => {
   it("should render a table with the files for the given branch", () => {
     const correctBranch = { name: "master", viewLink: "www.example.gov/master" }
     const incorrectBranch = { name: "preview", viewLink: "www.example.gov/preview" }
-    //const correctFiles = ["abc", "abc/def", "ghi"]
-    //const incorrectFiles = ["xyz"]
     const props = {
       params: { id: 1, name: "master" },
-      publishedFiles: [
-        { name: "abc", publishedBranch: correctBranch },
-        { name: "abc/def", publishedBranch: correctBranch },
-        { name: "xyz", publishedBranch: incorrectBranch },
-      ]
+      publishedFiles: {
+        isLoading: false,
+        data: [
+          { name: "abc", publishedBranch: correctBranch },
+          { name: "abc/def", publishedBranch: correctBranch },
+          { name: "xyz", publishedBranch: incorrectBranch },
+        ],
+      },
     }
 
     const wrapper = shallow(<SitePublishedFilesTable {...props} />)
@@ -39,10 +43,20 @@ describe("<SitePublishedFilesTable/>", () => {
     expect(wrapper.find("table").contains("xyz")).to.be.false
   })
 
+  it("should render a loading state if the files are loading", () => {
+    const props = {
+      params: { id: 1, name: "master" },
+      publishedFiles: { isLoading: true }
+    }
+
+    const wrapper = shallow(<SitePublishedFilesTable {...props} />)
+    expect(wrapper.find("p").contains("Loading published files")).to.be.true
+  })
+
   it("should render an empty state if there are no files", () => {
     const props = {
       params: { id: 1, name: "master" },
-      publishedFiles: []
+      publishedFiles: { isLoading: false, data: [] }
     }
 
     const wrapper = shallow(<SitePublishedFilesTable {...props} />)

--- a/test/frontend/reducers/publishedFilesTest.js
+++ b/test/frontend/reducers/publishedFilesTest.js
@@ -5,17 +5,19 @@ proxyquire.noCallThru();
 
 describe("publishedFilesReducer", () => {
   let fixture
+  const PUBLISHED_FILES_FETCH_STARTED = "published files fetch started"
   const PUBLISHED_FILES_RECEIVED = "published files received"
 
   beforeEach(() => {
     fixture = proxyquire("../../../frontend/reducers/publishedFiles", {
       "../actions/actionCreators/publishedFileActions": {
+        publishedFilesFetchStartedType: PUBLISHED_FILES_FETCH_STARTED,
         publishedFilesReceivedType: PUBLISHED_FILES_RECEIVED,
       }
     }).default
   })
 
-  it("ignores other actions and returns an empty array", () => {
+  it("ignores other actions and returns an initial state", () => {
     const FILES = ["File 1", "File 2"]
 
     const actual = fixture(undefined, {
@@ -23,28 +25,33 @@ describe("publishedFilesReducer", () => {
       type: "the wrong type",
     })
 
-    expect(actual).to.deep.equal([])
+    expect(actual).to.deep.equal({ isLoading: false })
+  })
+
+  it("marks is loading true when a fetch is started", () => {
+    const actual = fixture({ isLoading: false }, {
+      type: PUBLISHED_FILES_FETCH_STARTED,
+    })
+
+    expect(actual).to.deep.equal({ isLoading: true })
   })
 
   it("records the files received in the action", () => {
     const FILES = ["File 1", "File 2"]
 
-    const actual = fixture([], {
+    const actual = fixture({ isLoading: true }, {
       type: PUBLISHED_FILES_RECEIVED,
       files: FILES,
     })
 
-    expect(actual).to.deep.equal(FILES)
+    expect(actual).to.deep.equal({ isLoading: false, data: FILES })
   })
 
-  it("overrides the files received in the action", () => {
-    const FILES = ["FILE 1", "FILE 2"]
-
-    const actual = fixture(["FILE 3"], {
-      type: PUBLISHED_FILES_RECEIVED,
-      files: FILES,
+  it("overrides the files and marks is loading true when a new fetch starts", () => {
+    const actual = fixture({ isLoading: false, data: ["FILE 3"] }, {
+      type: PUBLISHED_FILES_FETCH_STARTED,
     })
 
-    expect(actual).to.deep.equal(FILES)
+    expect(actual).to.deep.equal({ isLoading: true})
   })
 })


### PR DESCRIPTION
This commit changes the redux state for published files so that it can be used to determine if published files are being loaded. It also changes the published files list table so that it displays a loading message when files are loading.