### PR TITLE
Add loading state for build logs

### DIFF
--- a/frontend/actions/actionCreators/buildLogActions.js
+++ b/frontend/actions/actionCreators/buildLogActions.js
@@ -1,4 +1,9 @@
+const buildLogsFetchStartedType = "BUILD_LOGS_FETCH_STARTED"
 const buildLogsReceivedType = "BUILD_LOGS_RECEIVED";
+
+const buildLogsFetchStarted = () => ({
+  type: buildLogsFetchStartedType,
+})
 
 const buildLogsReceived = logs => ({
   type: buildLogsReceivedType,
@@ -6,5 +11,6 @@ const buildLogsReceived = logs => ({
 });
 
 export {
+  buildLogsFetchStartedType, buildLogsFetchStarted,
   buildLogsReceivedType, buildLogsReceived,
 }

--- a/frontend/actions/buildLogActions.js
+++ b/frontend/actions/buildLogActions.js
@@ -2,8 +2,13 @@ import api from '../util/federalistApi';
 import { dispatch } from '../store';
 
 import {
+  buildLogsFetchStarted as createBuildLogsFetchStartedAction,
   buildLogsReceived as createBuildLogsReceivedAction,
 } from "./actionCreators/buildLogActions";
+
+const dispatchBuildLogsFetchStartedAction = () => {
+  dispatch(createBuildLogsFetchStartedAction())
+}
 
 const dispatchBuildLogsReceivedAction = logs => {
   dispatch(createBuildLogsReceivedAction(logs));
@@ -11,6 +16,7 @@ const dispatchBuildLogsReceivedAction = logs => {
 
 export default {
   fetchBuildLogs(build) {
+    dispatchBuildLogsFetchStartedAction()
     return api.fetchBuildLogs(build)
       .then(dispatchBuildLogsReceivedAction);
   },

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -7,26 +7,26 @@ class SiteBuildLogs extends React.Component {
   }
 
   buildLogs() {
-    if (!this.props.buildLogs) {
-      return [];
-    }
 
-    return this.props.buildLogs.filter(log => {
-      return log.build.id === parseInt(this.props.params.buildId);
-    }).sort((a, b) => {
-      return new Date(a.createdAt) - new Date(b.createdAt);
-    });
+    if (this.props.buildLogs.isLoading || !this.props.buildLogs.data) {
+      return [];
+    } else {
+      return this.props.buildLogs.data
+    }
   }
 
   render() {
-    if (this.buildLogs().length > 0) {
-      return this.renderBuildLogsTable()
-    } else {
+    const buildLogs = this.buildLogs()
+    if (this.props.buildLogs.isLoading) {
+      return this.renderLoadingState()
+    } else if (!buildLogs.length) {
       return this.renderEmptyState()
+    } else {
+      return this.renderBuildLogsTable(buildLogs)
     }
   }
 
-  renderBuildLogsTable() {
+  renderBuildLogsTable(buildLogs) {
     return (
       <table>
         <thead>
@@ -37,7 +37,7 @@ class SiteBuildLogs extends React.Component {
           </tr>
         </thead>
         <tbody>
-          { this.buildLogs().map(log => this.renderBuildLogRow(log)) }
+          { buildLogs.map(log => this.renderBuildLogRow(log)) }
         </tbody>
       </table>
     )
@@ -55,6 +55,11 @@ class SiteBuildLogs extends React.Component {
         <td>{ log.createdAt }</td>
       </tr>
     )
+  }
+
+  renderLoadingState() {
+    // TODO: Replace with a loading component
+    return <p>Loading build logs</p>
   }
 
   renderEmptyState() {

--- a/frontend/reducers/buildLogs.js
+++ b/frontend/reducers/buildLogs.js
@@ -1,11 +1,23 @@
 import {
+  buildLogsFetchStartedType as BUILD_LOGS_FETCH_STARTED,
   buildLogsReceivedType as BUILD_LOGS_RECEIVED,
 } from "../actions/actionCreators/buildLogActions";
 
-export default function buildLogs(state = [], action) {
+const initialState = {
+  isLoading: false,
+}
+
+export default function buildLogs(state = initialState, action) {
   switch (action.type) {
+  case BUILD_LOGS_FETCH_STARTED:
+    return {
+      isLoading: true,
+    }
   case BUILD_LOGS_RECEIVED:
-    return action.logs;
+    return {
+      isLoading: false,
+      data: action.logs,
+    }
   default:
     return state;
   }

--- a/test/frontend/actions/actionCreators/buildLogActionsTest.js
+++ b/test/frontend/actions/actionCreators/buildLogActionsTest.js
@@ -1,9 +1,24 @@
 import { expect } from "chai";
 import {
+  buildLogsFetchStarted, buildLogsFetchStartedType,
   buildLogsReceived, buildLogsReceivedType,
 } from "../../../../frontend/actions/actionCreators/buildLogActions";
 
 describe("buildLogActions actionCreators", () => {
+  describe("build logs fetch started", () => {
+    it("constructs properly", () => {
+      const actual = buildLogsFetchStarted()
+
+      expect(actual).to.deep.equal({
+        type: buildLogsFetchStartedType,
+      })
+    })
+
+    it("exports its type", () => {
+      expect(buildLogsFetchStartedType).to.equal("BUILD_LOGS_FETCH_STARTED")
+    })
+  })
+
   describe("build logs received", () => {
     it("constructs properly", () => {
       const logs = ["Log 1", "Log2 "];

--- a/test/frontend/actions/buildLogActionsTest.js
+++ b/test/frontend/actions/buildLogActionsTest.js
@@ -7,17 +7,20 @@ proxyquire.noCallThru();
 describe("buildActions", () => {
   let fixture;
   let dispatch;
+  let buildLogsFetchStartedActionCreator
   let buildLogsReceivedActionCreator;
   let fetchBuildLogs;
 
   beforeEach(() => {
     dispatch = spy();
+    buildLogsFetchStartedActionCreator = stub()
     buildLogsReceivedActionCreator = stub();
 
     fetchBuildLogs = stub();
 
     fixture = proxyquire("../../../frontend/actions/buildLogActions", {
       "./actionCreators/buildActions": {
+        buildLogsFetchStarted: buildLogsFetchStartedActionCreator,
         buildLogsReceived: buildLogsReceivedActionCreator,
       },
       "../util/federalistApi": {
@@ -32,17 +35,18 @@ describe("buildActions", () => {
   it("fetchBuildLogs", () => {
     const logs = ["Log 1", "Log 2"];
     const buildLogsPromise = Promise.resolve(logs);
-    const action = {
-      action: "action"
-    };
+    const fetchStartedAction = { action: "fetchStarted" }
+    const receivedAction = { action: "received" };
     fetchBuildLogs.withArgs().returns(buildLogsPromise);
-    buildLogsReceivedActionCreator.withArgs(logs).returns(action);
+    buildLogsFetchStartedActionCreator.withArgs().returns(fetchStartedAction)
+    buildLogsReceivedActionCreator.withArgs(logs).returns(receivedAction);
 
     const actual = fixture.fetchBuildLogs();
 
     actual.then(() => {
-      expect(dispatch.calledOnce).to.be.true;
-      expect(dispatch.calledWith(action)).to.be.true;
+      expect(dispatch.calledTwice).to.be.true;
+      expect(dispatch.calledWith(fetchStartedAction)).to.be.true
+      expect(dispatch.calledWith(receivedAction)).to.be.true;
     });
   });
 });

--- a/test/frontend/components/site/siteBuildLogs.test.js
+++ b/test/frontend/components/site/siteBuildLogs.test.js
@@ -4,13 +4,15 @@ import { shallow } from 'enzyme';
 import SiteBuildLogs from '../../../../frontend/components/site/siteBuildLogs';
 
 describe("<SiteBuildLogs/>", () => {
-  it("should render a table with build logs for the given build", () => {
+  it("should render a table with build logs", () => {
     const props = {
-      params: { buildId: 1 },
-      buildLogs: [
-        { build: { id: 1 }, output: "output 1", source: "source 1" },
-        { build: { id: 1 }, output: "output 2", source: "source 2" },
-      ],
+      buildLogs: {
+        isLoading: false,
+        data: [
+          { build: { id: 1 }, output: "output 1", source: "source 1" },
+          { build: { id: 1 }, output: "output 2", source: "source 2" },
+        ],
+      },
     };
 
     const wrapper = shallow(<SiteBuildLogs {...props} />);
@@ -21,27 +23,25 @@ describe("<SiteBuildLogs/>", () => {
     expect(wrapper.find("table").contains("source 2")).to.be.true;
   });
 
-  it("should not render logs for another build", () => {
+  it("should render a loading state if builds are loading", () => {
     const props = {
-      params: { buildId: 1 },
-      buildLogs: [
-        { build: { id: 1 } , output: "output 1", source: "source 1" },
-        { build: { id: 2 }, output: "output 2", source: "source 2" },
-      ],
+      buildLogs: {
+        isLoading: true,
+      }
     };
 
     const wrapper = shallow(<SiteBuildLogs {...props} />);
-    expect(wrapper.find("table")).to.have.length(1);
-    expect(wrapper.find("table").contains("output 1")).to.be.true;
-    expect(wrapper.find("table").contains("output 2")).to.be.false;
-    expect(wrapper.find("table").contains("source 1")).to.be.true;
-    expect(wrapper.find("table").contains("source 2")).to.be.false;
-  });
+    expect(wrapper.find("table")).to.have.length(0);
+    expect(wrapper.find("p")).to.have.length(1);
+    expect(wrapper.find("p").contains("Loading build logs"))
+  })
 
   it("should render an empty state if there are no builds", () => {
     const props = {
-      params: { buildId: 1 },
-      buildLogs: [],
+      buildLogs: {
+        data: [],
+        isLoading: false,
+      }
     };
 
     const wrapper = shallow(<SiteBuildLogs {...props} />);

--- a/test/frontend/reducers/buildLogsTest.js
+++ b/test/frontend/reducers/buildLogsTest.js
@@ -5,17 +5,19 @@ proxyquire.noCallThru();
 
 describe("buildLogsReducer", () => {
   let fixture;
+  const BUILD_LOGS_FETCH_STARTED = "build logs fetch started!"
   const BUILD_LOGS_RECEIVED = "build logs received!";
 
   beforeEach(() => {
     fixture = proxyquire("../../../frontend/reducers/buildLogs.js", {
       "../actions/actionCreators/buildLogActions": {
+        buildLogsFetchStartedType: BUILD_LOGS_FETCH_STARTED,
         buildLogsReceivedType: BUILD_LOGS_RECEIVED,
       }
     }).default;
   });
 
-  it("ignores other actions and returns an empty array", () => {
+  it("ignores other actions and returns an initial state", () => {
     const LOGS = ["Log 1", "Log 2"]
 
     const actual = fixture(undefined, {
@@ -23,28 +25,36 @@ describe("buildLogsReducer", () => {
       logs: LOGS
     });
 
-    expect(actual).to.deep.equal([]);
+    expect(actual).to.deep.equal({ isLoading: false });
   });
+
+  it("marks the state loading when a fetch is started", () => {
+    const actual = fixture({ isLoading: false }, {
+      type: BUILD_LOGS_FETCH_STARTED
+    })
+
+    expect(actual).to.deep.equal({ isLoading: true })
+  })
 
   it("records the build logs received in the action", () => {
     const LOGS = ["Log 1", "Log 2"]
 
-    const actual = fixture([], {
+    const actual = fixture({ isLoading: true }, {
       type: BUILD_LOGS_RECEIVED,
       logs: LOGS
     });
 
-    expect(actual).to.deep.equal(LOGS);
+    expect(actual).to.deep.equal({ isLoading: false, data: LOGS });
   });
 
-  it("overrides the build logs with the ones received in the action", () => {
+  it("sets the builds logs to the ones in the action when the fetch completes", () => {
     const LOGS = ["Log 1", "Log 2"]
 
-    const actual = fixture(["Log 3"], {
+    const actual = fixture({ isLoading: true }, {
       type: BUILD_LOGS_RECEIVED,
       logs: LOGS
     });
 
-    expect(actual).to.deep.equal(LOGS);
+    expect(actual).to.deep.equal({ isLoading: false, data: LOGS });
   });
 });


### PR DESCRIPTION
This commit changes the redux state for build logs so that it marks when a build log data is being loaded from the API. Additionally, it displays a loading message in place of the build logs table when the data is loading.