### PR TITLE
Fix issues with Bluebird promises

### DIFF
--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -59,7 +59,7 @@ const createBuildForWebhookRequest = (request) => {
   const user = findUserForWebhookRequest(request)
   const site = findSiteForWebhookRequest(request)
 
-  return Promise.props([ user, site ]).then((models) => {
+  return Promise.all([user, site]).then((models) => {
     buildParams = {
       user: models[0],
       site: models[1],

--- a/app.js
+++ b/app.js
@@ -1,5 +1,4 @@
 const config = require("./config")
-global.Promise = require("bluebird")
 
 const logger = require("winston")
 logger.level = config.log.level


### PR DESCRIPTION
We worked on removing bluebird in #845. The work turned out to be incomplete, because we were still (incorrectly) using `Promise.props` and were still exposing the global `Promise` object.

The `Promise.props` call still worked because in JS you can treat an array like an object where the indexes are keys and we happened to be using it as such. Since we didn't remove the global Promise object, this issue was hidden until we pushed to production where the problem reveals itself.

The commit replaces `Promise.props` with the native `Promise.all` in `master`.