### PR TITLE
Don't let users sign in twice

### DIFF
--- a/api/controllers/auth.js
+++ b/api/controllers/auth.js
@@ -6,7 +6,11 @@ const AuthController = {
   },
 
   github: function (req, res) {
-    passport.authenticate("github")(req, res, req.next)
+    if (req.session.authenticated) {
+      res.redirect("/")
+    } else {
+      passport.authenticate("github")(req, res, req.next)
+    }
   },
 
   callback: function (req, res) {

--- a/api/routers/auth.js
+++ b/api/routers/auth.js
@@ -4,7 +4,7 @@ const passport = require("../policies/passport")
 
 router.use(passport)
 
-router.get("/auth/github", AuthController.github)
+router.get("/auth/github", passport, AuthController.github)
 router.get("/auth/github/callback", AuthController.callback)
 router.get("/logout", AuthController.logout)
 

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -31,12 +31,22 @@ var sessionForCookie = (cookie) => {
 }
 
 describe("Authentication request", () => {
-  describe("GET /login", () => {
+  describe("GET /auth/github", () => {
     it("should redirect to GitHub for OAuth2 authentication", done => {
       request(app)
         .get("/auth/github")
         .expect("Location", /^https:\/\/github.com\/login\/oauth\/authorize.*/)
         .expect(302, done)
+    })
+
+    it("should redirect to the root URL if the users is logged in", done => {
+      session().then(cookie => {
+        request(app)
+          .get("/auth/github")
+          .set("Cookie", cookie)
+          .expect("Location", "/")
+          .expect(302, done)
+      })
     })
   })
 


### PR DESCRIPTION
Prior to this commit, if a user navigated to `/auth/github`, the authentication process would begin, regardless of whether that users was logged in or not. The result was that users who were logged in, could effectively login again, overwriting their session with a new logged in session.

This was harmless behavior until we added redirects after sign in. We added this for preview URLs. If an unauthenticated user attempted to view a preview, they would be redirected to the login url. After being logged in, they would be redirected back to the preview.

The problem arose when people attempted to view previews for sites they had not added, and therefore were not allowed to see. They would be redirected to the login, then redirected to the preview, then redirected back to login in a loop.

This commit fixes the issue, by redirecting logged in users to the root url if they attempt to re-authenticate.