### PR TITLE
Display loading indicator when waiting for user data to load

### DIFF
--- a/frontend/actions/userActions.js
+++ b/frontend/actions/userActions.js
@@ -15,7 +15,7 @@ const dispatchUserReceivedAction = user => {
 
 export default {
   fetchUser() {
-    dispatchUserFetchStartedAction
+    dispatchUserFetchStartedAction()
     return federalist.fetchUser()
       .then(dispatchUserReceivedAction)
   },

--- a/frontend/components/app.js
+++ b/frontend/components/app.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import store from '../store';
 import alertActions from '../actions/alertActions';
+import LoadingIndicator from "./loadingIndicator"
 import Header from './header';
 
 class App extends React.Component {
@@ -45,16 +46,25 @@ class App extends React.Component {
     const { children } = this.props;
     const storeState = this.state;
 
-    return (
-      <div>
-        <Header
-          username={this.getUsername(storeState)}
-        />
-        {children && React.cloneElement(children, {
-          storeState: storeState
-        })}
-      </div>
-    );
+    if (storeState.user.isLoading) {
+      return (
+        <div>
+          <Header/>
+          <LoadingIndicator/>
+        </div>
+      )
+    } else {
+      return (
+        <div>
+          <Header
+            username={this.getUsername(storeState)}
+          />
+          {children && React.cloneElement(children, {
+            storeState: storeState
+          })}
+        </div>
+      );
+    }
   }
 }
 

--- a/frontend/components/home.js
+++ b/frontend/components/home.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { pushHistory } from "../actions/routeActions"
-import LoadingIndicator from './loadingIndicator'
 
 const homeHTML = require("./home.html")
 
@@ -25,11 +24,7 @@ class Home extends React.Component {
   }
 
   render() {
-    if (!this.props.storeState.user.isLoading) {
-      return <div dangerouslySetInnerHTML={{ __html: homeHTML }}/>
-    } else {
-      return <LoadingIndicator/>
-    }
+    return <div dangerouslySetInnerHTML={{ __html: homeHTML }}/>
   }
 }
 

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import buildLogActions from "../../actions/buildLogActions";
+import LoadingIndicator from '../loadingIndicator'
 
 class SiteBuildLogs extends React.Component {
   componentDidMount() {
@@ -59,7 +60,7 @@ class SiteBuildLogs extends React.Component {
 
   renderLoadingState() {
     // TODO: Replace with a loading component
-    return <p>Loading build logs</p>
+    return <LoadingIndicator/>
   }
 
   renderEmptyState() {

--- a/test/frontend/actions/userActionsTest.js
+++ b/test/frontend/actions/userActionsTest.js
@@ -7,19 +7,20 @@ proxyquire.noCallThru();
 describe("userActions", () => {
   let fixture;
   let dispatch;
-  let userReceivedActionCreator, userLogoutActionCreator;
+  let userFetchStartedActionCreator, userReceivedActionCreator;
   let fetchUser;
 
   beforeEach(() => {
     dispatch = spy();
+
+    userFetchStartedActionCreator = stub()
     userReceivedActionCreator = stub();
-    userLogoutActionCreator = stub();
     fetchUser = stub();
 
     fixture = proxyquire("../../../frontend/actions/userActions", {
       "./actionCreators/userActions": {
+        userFetchStarted: userFetchStartedActionCreator,
         userReceived: userReceivedActionCreator,
-        userLogout: userLogoutActionCreator
       },
       "../util/federalistApi": {
         fetchUser: fetchUser
@@ -38,17 +39,18 @@ describe("userActions", () => {
         favoritePancake: "buttermilk"
       };
       const userPromise = Promise.resolve(user);
-      const action = {
-        action: "action"
-      };
+      const fetchStartedAction = { action: "started" }
+      const receivedAction = { action: "received" };
       fetchUser.withArgs().returns(userPromise);
-      userReceivedActionCreator.withArgs(user).returns(action);
+      userFetchStartedActionCreator.withArgs().returns(fetchStartedAction)
+      userReceivedActionCreator.withArgs(user).returns(receivedAction);
 
       const actual = fixture.fetchUser();
 
       actual.then(() => {
-        expect(dispatch.calledOnce).to.be.true;
-        expect(dispatch.calledWith(action)).to.be.true;
+        expect(dispatch.calledTwice).to.be.true;
+        expect(dispatch.calledWith(fetchStartedAction)).to.be.true;
+        expect(dispatch.calledWith(receivedAction)).to.be.true;
       });
     });
 

--- a/test/frontend/components/site/siteBuildLogs.test.js
+++ b/test/frontend/components/site/siteBuildLogs.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import LoadingIndicator from '../../../../frontend/components/loadingIndicator'
 import SiteBuildLogs from '../../../../frontend/components/site/siteBuildLogs';
 
 describe("<SiteBuildLogs/>", () => {
@@ -32,8 +33,7 @@ describe("<SiteBuildLogs/>", () => {
 
     const wrapper = shallow(<SiteBuildLogs {...props} />);
     expect(wrapper.find("table")).to.have.length(0);
-    expect(wrapper.find("p")).to.have.length(1);
-    expect(wrapper.find("p").contains("Loading build logs"))
+    expect(wrapper.find(LoadingIndicator)).to.have.length(1);
   })
 
   it("should render an empty state if there are no builds", () => {


### PR DESCRIPTION
This commit fixes a number of bugs that occured around the user loading states.

When the user data was loading, the site displayed a white screen instead of an indicator. This commit adds the indicator to the `<App/>` component while the user fetch is running.

When the user fetch was triggered, the `USER_FETCH_STARTED` action was not dispatched because the function was not actually invoked. This commit fixes that by adding the parens to invoke the function.

This commit removes the loading indicator from the Home component, since displaying it will be handled by the App component.

Finally, this commit adds the loading indicator to some of the components that were previously displaying loading messages.