### PR TITLE
Add builds loading state

### DIFF
--- a/api/controllers/build.js
+++ b/api/controllers/build.js
@@ -1,6 +1,7 @@
 const authorizer = require("../authorizers/build")
 const buildSerializer = require("../serializers/build")
-const { Build } = require("../models")
+const siteAuthorizer = require("../authorizers/site")
+const { Build, Site } = require("../models")
 
 var decodeb64 = (str) => {
   return new Buffer(str, 'base64').toString('utf8');
@@ -8,10 +9,31 @@ var decodeb64 = (str) => {
 
 module.exports = {
   find: (req, res) => {
-    Build.findAll({ where: { user: req.user.id } }).then(builds => {
+    let site
+
+    Promise.resolve(Number(req.params["site_id"])).then(id => {
+      if (isNaN(id)) {
+        throw 404
+      }
+      return Site.findById(id)
+    }).then(model => {
+      if (!model) {
+        throw 404
+      }
+
+      site = model
+      return siteAuthorizer.findOne(req.user, site)
+    }).then(() => {
+      return Build.findAll({
+        where: { site: site.id },
+        order: [["createdAt", "DESC"]],
+      })
+    }).then(builds => {
       return buildSerializer.serialize(builds)
     }).then(buildsJSON => {
       res.json(buildsJSON)
+    }).catch(err => {
+      res.error(err)
     })
   },
 

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -32,17 +32,25 @@ const beforeValidate = (build) => {
 }
 
 const completeJob = function(err) {
+  const completedAt = new Date()
+  const { Site } = this.sequelize.models
+
   if (err) {
     return this.update({
       state: "error",
       error: completeJobErrorMessage(err),
-      completedAt: new Date(),
+      completedAt: completedAt,
     })
   } else {
     return this.update({
       state: "success",
       error: "",
-      completedAt: new Date(),
+      completedAt: completedAt,
+    }).then(build => {
+      return Site.update(
+        { publishedAt: completedAt },
+        { where: { id: this.site } }
+      ).then(() => build)
     })
   }
 }

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -82,6 +82,9 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },
+    publishedAt: {
+      type: DataTypes.DATE,
+    },
     repository: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/api/routers/build.js
+++ b/api/routers/build.js
@@ -4,7 +4,7 @@ const buildCallback = require("../policies/buildCallback")
 const passport = require("../policies/passport")
 const sessionAuth = require("../policies/sessionAuth")
 
-router.get("/v0/build", passport, sessionAuth, BuildController.find)
+router.get("/v0/site/:site_id/build", passport, sessionAuth, BuildController.find)
 router.post("/v0/build", passport, sessionAuth, BuildController.create)
 router.get("/v0/build/:id", passport, sessionAuth, BuildController.findOne)
 router.post("/v0/build/:id/status/:token", buildCallback, BuildController.status)

--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -1,16 +1,16 @@
-const { Build, User, Site } = require("../models")
+const { Site } = require("../models")
 
 const serialize = (serializable) => {
   if (serializable.length !== undefined) {
     const siteIds = serializable.map(site => site.id)
-    const query = Site.findAll({ where: { id: siteIds }, include: [ User, Build ] })
+    const query = Site.findAll({ where: { id: siteIds } })
 
     return query.then(sites => {
       return sites.map(site => serializeObject(site))
     })
   } else {
     const site = serializable
-    const query = Site.findById(site.id, { include: [ User, Build ] })
+    const query = Site.findById(site.id)
 
     return query.then(site => {
       return serializeObject(site)
@@ -20,10 +20,6 @@ const serialize = (serializable) => {
 
 const serializeObject = (site) => {
   const json = site.toJSON()
-  json.users = site.Users.map(user => user.toJSON())
-  json.builds = site.Builds.map(build => build.toJSON())
-  delete json.Users
-  delete json.Builds
   return json
 }
 

--- a/frontend/actions/actionCreators/buildActions.js
+++ b/frontend/actions/actionCreators/buildActions.js
@@ -1,4 +1,15 @@
+const buildsFetchStartedType = "BUILDS_FETCH_STARTED"
+const buildsReceivedType = "BUILDS_RECEIVED"
 const buildRestartedType = "BUILD_RESTARTED";
+
+const buildsFetchStarted = () => ({
+  type: buildsFetchStartedType,
+})
+
+const buildsReceived = (builds) => ({
+  type: buildsReceivedType,
+  builds,
+})
 
 const buildRestarted = build => ({
   type: buildRestartedType,
@@ -6,5 +17,7 @@ const buildRestarted = build => ({
 });
 
 export {
+  buildsFetchStarted, buildsFetchStartedType,
+  buildsReceived, buildsReceivedType,
   buildRestarted, buildRestartedType,
 };

--- a/frontend/actions/buildActions.js
+++ b/frontend/actions/buildActions.js
@@ -2,14 +2,30 @@ import api from '../util/federalistApi';
 import { dispatch } from '../store';
 
 import {
+  buildsFetchStarted as createBuildsFetchStartedAction,
+  buildsReceived as createBuildsReceivedAction,
   buildRestarted as createBuildRestartedAction,
 } from "./actionCreators/buildActions";
+
+const dispatchBuildsFetchStartedAction = () => {
+  dispatch(createBuildsFetchStartedAction())
+}
+
+const dispatchBuildsReceivedAction = builds => {
+  dispatch(createBuildsReceivedAction(builds))
+}
 
 const dispatchBuildRestartedAction = build => {
   dispatch(createBuildRestartedAction(build))
 };
 
 export default {
+  fetchBuilds(site) {
+    dispatchBuildsFetchStartedAction()
+    return api.fetchBuilds(site)
+      .then(dispatchBuildsReceivedAction)
+  },
+
   restartBuild(build) {
     return api.restartBuild(build)
       .then(dispatchBuildRestartedAction);

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -8,7 +8,6 @@ class SiteBuildLogs extends React.Component {
   }
 
   buildLogs() {
-
     if (this.props.buildLogs.isLoading || !this.props.buildLogs.data) {
       return [];
     } else {
@@ -59,7 +58,6 @@ class SiteBuildLogs extends React.Component {
   }
 
   renderLoadingState() {
-    // TODO: Replace with a loading component
     return <LoadingIndicator/>
   }
 

--- a/frontend/components/site/sitePublishedFilesTable.js
+++ b/frontend/components/site/sitePublishedFilesTable.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import publishedFileActions from "../../actions/publishedFileActions";
+import LoadingIndicator from '../loadingIndicator'
 
 class SitePublishedBranch extends React.Component {
   componentDidMount() {
@@ -56,8 +57,7 @@ class SitePublishedBranch extends React.Component {
   }
 
   renderLoadingState() {
-    // TODO: Replace with a loading component
-    return <p>Loading published files</p>
+    return <LoadingIndicator/>
   }
 
   renderEmptyState() {

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -60,29 +60,17 @@ class SiteContainer extends React.Component {
 
   render () {
     const { storeState, children, params, location } = this.props;
-    const site = this.getCurrentSite(storeState.sites, params.id);
+
+    const site = this.getCurrentSite(storeState.sites, params.id)
+    const builds = storeState.builds
+    const buildLogs = storeState.buildLogs
     const publishedBranches = storeState.publishedBranches.filter(branch => {
       return branch.site.id === site.id
     })
     const publishedFiles = storeState.publishedFiles
+    const childConfigs = { site, builds, buildLogs, publishedBranches, publishedFiles }
+
     const pageTitle = this.getPageTitle(location.pathname);
-
-    let childConfigs;
-
-    // I'm not crazy about tying these to route paths
-    // as it makes it harder to change things.
-    switch(pageTitle) {
-      case 'logs':
-        childConfigs = {
-          buildLogs: storeState.buildLogs,
-        };
-        break;
-      case 'settings':
-      case 'builds':
-      case 'published':
-      default:
-        childConfigs = { site, publishedBranches, publishedFiles };
-    }
 
     if (!site) {
       return null;

--- a/frontend/components/siteList/publishedState.js
+++ b/frontend/components/siteList/publishedState.js
@@ -2,38 +2,23 @@ import React from 'react';
 import moment from "moment";
 
 const propTypes = {
-  builds: React.PropTypes.array
+  site: React.PropTypes.shape({
+    publishedAt: React.PropTypes.string,
+  })
 };
 
-const getLastBuildTime = (builds) => {
-  if (builds.length) {
-    let sorted = builds.slice().filter(build => {
-      return build.completedAt
-    }).sort((a, b) => {
-      let aCompletedAt = new Date(a.completedAt);
-      let bCompletedAt = new Date(b.completedAt);
-      return aCompletedAt > bCompletedAt;
-    });
-    let last = sorted.pop();
-    if (last) {
-      return last.completedAt
-    }
-  }
-};
-
-const getPublishedState = (builds) => {
-  let lastBuildTime = getLastBuildTime(builds)
-  if (lastBuildTime) {
-    let formattedBuildTime = moment(lastBuildTime).format('MMMM Do YYYY, h:mm:ss a')
+const getPublishedState = (site) => {
+  if (site.publishedAt) {
+    let formattedBuildTime = moment(site.publishedAt).format('MMMM Do YYYY, h:mm:ss a')
     return `This site was last published at ${formattedBuildTime}.`;
   } else {
     return 'Please wait for build to complete or check logs for error message.';
   }
 };
 
-const PublishedState = ({ builds = [] }) =>
+const PublishedState = ({ site = {} }) =>
   <p>
-    {getPublishedState(builds)}
+    {getPublishedState(site)}
   </p>
 
 PublishedState.propTypes = propTypes;

--- a/frontend/components/siteList/siteListItem.js
+++ b/frontend/components/siteList/siteListItem.js
@@ -7,14 +7,12 @@ const propTypes = {
     repository: React.PropTypes.string,
     owner: React.PropTypes.string,
     id: React.PropTypes.number,
-    builds: React.PropTypes.array,
+    publishedAt: React.PropTypes.string,
     viewLink: React.PropTypes.string
   })
 };
 
-const getViewLink = (hasLink, viewLink, repo) => {
-  if (!hasLink) return null;
-
+const getViewLink = (viewLink, repo) => {
   return <a
     className="icon icon-view"
     href={ viewLink }
@@ -28,10 +26,10 @@ const SiteListItem = ({ site }) =>
       <Link to={`/sites/${site.id}`}>
         { site.owner } / { site.repository }
       </Link>
-      <PublishedState builds={ site.builds } />
+      <PublishedState site={site} />
     </div>
     <div className="sites-list-item-actions">
-      { getViewLink(!!site.builds.length, site.viewLink, site.repository) }
+      { getViewLink(site.viewLink, site.repository) }
     </div>
   </li>
 

--- a/frontend/reducers.js
+++ b/frontend/reducers.js
@@ -3,6 +3,7 @@ import alert from './reducers/alert';
 import publishedBranches from './reducers/publishedBranches';
 import publishedFiles from './reducers/publishedFiles';
 import sites from './reducers/sites';
+import builds from './reducers/builds';
 import user from './reducers/user';
 
 export default {
@@ -11,5 +12,6 @@ export default {
   publishedBranches,
   publishedFiles,
   sites,
+  builds,
   user
 };

--- a/frontend/reducers/builds.js
+++ b/frontend/reducers/builds.js
@@ -1,0 +1,30 @@
+import {
+  buildsFetchStartedType as BUILDS_FETCH_STARTED,
+  buildsReceivedType as BUILDS_RECEIVED,
+  buildRestartedType as BUILD_RESTARTED,
+} from "../actions/actionCreators/buildActions";
+
+const initialState = {
+  isLoading: false,
+}
+
+export default function builds(state = initialState, action) {
+  switch (action.type) {
+  case BUILDS_FETCH_STARTED:
+    return {
+      isLoading: true,
+    }
+  case BUILDS_RECEIVED:
+    return {
+      isLoading: false,
+      data: action.builds,
+    }
+  case BUILD_RESTARTED:
+    return {
+      isLoading: false,
+      data: [action.build, ...state.data]
+    }
+  default:
+    return state;
+  }
+}

--- a/frontend/reducers/sites.js
+++ b/frontend/reducers/sites.js
@@ -10,10 +10,6 @@ import {
   siteLoadingType as SITE_LOADING
 } from '../actions/actionCreators/siteActions';
 
-import {
-  buildRestartedType as BUILD_RESTARTED,
-} from '../actions/actionCreators/buildActions';
-
 const initialState = [];
 
 export default function sites(state = initialState, action) {
@@ -40,17 +36,6 @@ export default function sites(state = initialState, action) {
 
   case SITE_DELETED:
     return state.filter((site) => site.id != action.siteId);
-
-  case BUILD_RESTARTED:
-    return state.map(site => {
-      if (site.id === action.build.site.id) {
-        return Object.assign({}, site, {
-          builds: [action.build, ...site.builds],
-        })
-      } else {
-        return site
-      }
-    })
 
   default:
     return state;

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -14,6 +14,10 @@ export default {
     });
   },
 
+  fetchBuilds(site) {
+    return this.fetch(`site/${site.id}/build`)
+  },
+
   fetchBuildLogs(build) {
     return this.fetch(`build/${build.id}/log`);
   },

--- a/migrations/20170502134639-add-published-at-to-site.js
+++ b/migrations/20170502134639-add-published-at-to-site.js
@@ -1,0 +1,93 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+var Promise = require("bluebird")
+
+const addPublishedAtColumn = (db) => {
+  return new Promise((resolve, reject) => {
+    db.addColumn("site", "publishedAt", { type: "timestamp" }, (err) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+const fetchSiteIds = (db) => {
+  return new Promise((resolve, reject) => {
+    db.all("SELECT id FROM site", (err, data) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(data.map(row => row.id))
+      }
+    })
+  })
+}
+
+const fetchBuildCreatedAtForSite = (db, siteId) => {
+  const sql = `
+    SELECT "createdAt"
+    FROM build
+    WHERE site = ${siteId} AND state = 'success'
+    ORDER BY "createdAt" DESC
+    LIMIT 1
+  `
+  return new Promise((resolve, reject) => {
+    db.all(sql, (err, data) => {
+      if (err) {
+        reject(err)
+      } else if (data.length === 0) {
+        resolve()
+      } else {
+        resolve(data[0].createdAt)
+      }
+    })
+  })
+}
+
+const setPublishedAtForSite = (db, siteId, publishedAt) => {
+  const sql = `
+    UPDATE site
+    SET "publishedAt" = '${publishedAt.toISOString()}'
+    WHERE id = ${siteId}
+  `
+
+  return new Promise((resolve, reject) => {
+    db.runSql(sql, (err) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+exports.up = function(db, callback) {
+  let siteIds
+  const buildCreatedAts = []
+
+  addPublishedAtColumn(db).then(() => {
+    return fetchSiteIds(db)
+  }).then(ids => {
+    siteIds = ids
+    return Promise.each(siteIds, (siteId) => {
+      return fetchBuildCreatedAtForSite(db, siteId).then(createdAt => buildCreatedAts.push(createdAt))
+    })
+  }).then(() => {
+    return Promise.each(siteIds, (siteId, index) => {
+      const publishedAt = buildCreatedAts[index]
+      if (publishedAt) {
+        return setPublishedAtForSite(db, siteId, publishedAt)
+      }
+    })
+  }).then(() => {
+    callback()
+  }).catch(callback)
+};
+
+exports.down = function(db, callback) {
+  db.removeColumn("site", "publishedAt", callback)
+};

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -36,7 +36,8 @@
       "type": "boolean"
     },
     "publishedAt": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "repository": {
       "type": "string"

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -2,24 +2,16 @@
   "type": "object",
   "required": [
     "id",
-    "builds",
     "defaultBranch",
     "engine",
     "owner",
     "repository",
     "siteRoot",
-    "users",
     "viewLink"
   ],
   "properties": {
     "id": {
       "type": "integer"
-    },
-    "builds": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
     },
     "config": {
       "type": "string"
@@ -48,15 +40,6 @@
     },
     "siteRoot": {
       "type": "string"
-    },
-    "users": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "not": {
-          "required": ["githubAccessToken", "githubUserId"]
-        }
-      }
     },
     "viewLink": {
       "type": "string"

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -35,6 +35,9 @@
     "publicPreview": {
       "type": "boolean"
     },
+    "publishedAt": {
+      "type": "string"
+    },
     "repository": {
       "type": "string"
     },

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -11,19 +11,6 @@ produces:
   - application/json
 paths:
   /build:
-    get:
-      summary: Fetch all of the user's builds
-      responses:
-        200:
-          description: An array of builds
-          schema:
-            type: array
-            items:
-              $ref: "Build.json"
-        403:
-          description: Not authorized
-          schema:
-            $ref: "Error.json"
     post:
       summary: Create a build
       parameters:
@@ -49,6 +36,20 @@ paths:
           description: Bad request
           schema:
             $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+  /site/{site_id}/build:
+    get:
+      summary: Fetch all of the user's builds
+      responses:
+        200:
+          description: An array of builds
+          schema:
+            type: array
+            items:
+              $ref: "Build.json"
         403:
           description: Not authorized
           schema:

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -42,7 +42,7 @@ paths:
             $ref: "Error.json"
   /site/{site_id}/build:
     get:
-      summary: Fetch all of the user's builds
+      summary: Fetch all of the user's builds for a given site
       responses:
         200:
           description: An array of builds

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -20,11 +20,6 @@ describe("Site API", () => {
     expect(response.engine).to.equal(site.engine)
     expect(response.defaultBranch).to.equal(site.defaultBranch)
     expect(response.publicPreview).to.equal(site.publicPreview)
-
-    expect(response.users.map(user => user.id))
-      .to.have.members(site.Users.map(user => user.id))
-
-    expect(response.builds).to.be.a("array")
     expect(response.siteRoot).to.be.a("string")
     expect(response.viewLink).to.be.a("string")
   }

--- a/test/frontend/actions/actionCreators/buildActionsTest.js
+++ b/test/frontend/actions/actionCreators/buildActionsTest.js
@@ -1,9 +1,40 @@
 import { expect } from "chai";
 import {
+  buildsFetchStarted, buildsFetchStartedType,
+  buildsReceived, buildsReceivedType,
   buildRestarted, buildRestartedType,
 } from "../../../../frontend/actions/actionCreators/buildActions";
 
 describe("buildActions actionCreators", () => {
+  describe("builds fetch started", () => {
+    it("constructs properly", () => {
+      const actual = buildsFetchStarted()
+      expect(actual).to.deep.equal({
+        type: buildsFetchStartedType
+      })
+    })
+
+    it("exports its type", () => {
+      expect(buildsFetchStartedType).to.equal("BUILDS_FETCH_STARTED")
+    })
+  })
+
+  describe("builds received", () => {
+    it("constructs properly", () => {
+      const builds = ["🔧", "🔨", "⛏"]
+      const actual = buildsReceived(builds)
+
+      expect(actual).to.deep.equal({
+        type: buildsReceivedType,
+        builds,
+      })
+    })
+
+    it("exports its type", () => {
+      expect(buildsReceivedType).to.deep.equal("BUILDS_RECEIVED")
+    })
+  })
+
   describe("build restarted", () => {
     it("constructs properly", () => {
       const build = {

--- a/test/frontend/actions/buildActionsTest.js
+++ b/test/frontend/actions/buildActionsTest.js
@@ -7,20 +7,29 @@ proxyquire.noCallThru();
 describe("buildActions", () => {
   let fixture;
   let dispatch;
+  let buildsFetchStartedActionCreator;
+  let buildsReceivedActionCreator;
   let buildRestartedActionCreator;
+  let fetchBuilds;
   let restartBuild;
 
   beforeEach(() => {
     dispatch = spy();
+    buildsFetchStartedActionCreator = stub()
+    buildsReceivedActionCreator = stub()
     buildRestartedActionCreator = stub();
 
+    fetchBuilds = stub()
     restartBuild = stub();
 
     fixture = proxyquire("../../../frontend/actions/buildActions", {
       "./actionCreators/buildActions": {
+        buildsFetchStarted: buildsFetchStartedActionCreator,
+        buildsReceived: buildsReceivedActionCreator,
         buildRestarted: buildRestartedActionCreator,
       },
       "../util/federalistApi": {
+        fetchBuilds: fetchBuilds,
         restartBuild: restartBuild,
       },
       "../store": {
@@ -29,7 +38,28 @@ describe("buildActions", () => {
     }).default;
   });
 
-  it("restartBuild", () => {
+  it("fetchBuilds", done => {
+    const site = { id: "🎫" }
+    const builds = ["🔧", "🔨", "⛏"]
+    const buildsPromise = Promise.resolve(builds)
+    const startedAction = { action: "🚦" }
+    const receivedAction = { action: "🏁" }
+
+    fetchBuilds.withArgs(site).returns(buildsPromise)
+    buildsFetchStartedActionCreator.withArgs().returns(startedAction)
+    buildsReceivedActionCreator.withArgs(builds).returns(receivedAction)
+
+    const actual = fixture.fetchBuilds(site)
+
+    actual.then(() => {
+      expect(dispatch.calledTwice).to.be.true
+      expect(dispatch.calledWith(startedAction)).to.be.true
+      expect(dispatch.calledWith(receivedAction)).to.be.true
+      done()
+    })
+  })
+
+  it("restartBuild", done => {
     const build = {
       "we": "like to build it's true",
       "how": "about you?"
@@ -46,6 +76,7 @@ describe("buildActions", () => {
     actual.then(() => {
       expect(dispatch.calledOnce).to.be.true;
       expect(dispatch.calledWith(action)).to.be.true;
+      done()
     });
   });
 });

--- a/test/frontend/components/site/siteBuilds.test.js
+++ b/test/frontend/components/site/siteBuilds.test.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { expect } from "chai";
 import { shallow } from "enzyme";
+import LoadingIndicator from '../../../../frontend/components/loadingIndicator'
 import SiteBuilds from "../../../../frontend/components/site/siteBuilds";
 
 let user
+let site
 let build
 let props
 
@@ -13,8 +15,12 @@ describe("<SiteBuilds/>", () => {
       id: 1,
       username: "user123",
     }
+    site = {
+      id: "🎫",
+    }
     build = {
-      user: user.id,
+      user,
+      site,
       id: 1,
       branch: "master",
       createdAt: "2016-12-28T12:00:00",
@@ -22,14 +28,10 @@ describe("<SiteBuilds/>", () => {
       state: "success",
     }
     props = {
-      site: {
-        builds: [
-          build,
-        ],
-        users: [
-          user,
-        ],
-      },
+      builds: {
+        data: [build],
+        isLoading: false,
+      }
     }
   })
 
@@ -51,12 +53,30 @@ describe("<SiteBuilds/>", () => {
     expect(userCell.text()).to.equal(user.username)
   })
 
-  it("should render an empty string for the username for builds where the user cannot be found", () => {
-    build.user = user.id + 1
+  it("should render an empty string for the username for builds where there is no user", () => {
+    build.user = undefined
     const wrapper = shallow(<SiteBuilds {...props}/>)
     const userIndex = columnIndex(wrapper, "User")
 
     const userCell = wrapper.find("tr").at(1).find("td").at(userIndex)
     expect(userCell.text()).to.equal("")
+  })
+
+  it("should render an empty state if no builds are present", () => {
+    props = { builds: { isLoading: false, builds: [] } }
+    const wrapper = shallow(<SiteBuilds {...props}/>)
+
+    expect(wrapper.find("table")).to.have.length(0)
+    expect(wrapper.find("p")).to.have.length(1);
+    expect(wrapper.find("p").contains("This site does not have any builds")).to.be.true;
+  })
+
+  it("should render a loading state if the builds are loading", () => {
+    props = { builds: { isLoading: true } }
+
+    const wrapper = shallow(<SiteBuilds {...props} />);
+
+    expect(wrapper.find("table")).to.have.length(0);
+    expect(wrapper.find(LoadingIndicator)).to.have.length(1);
   })
 })

--- a/test/frontend/components/site/sitePublishedFilesTable.test.js
+++ b/test/frontend/components/site/sitePublishedFilesTable.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import LoadingIndicator from '../../../../frontend/components/loadingIndicator'
 import SitePublishedFilesTable from '../../../../frontend/components/site/sitePublishedFilesTable';
 
 
@@ -50,7 +51,7 @@ describe("<SitePublishedFilesTable/>", () => {
     }
 
     const wrapper = shallow(<SitePublishedFilesTable {...props} />)
-    expect(wrapper.find("p").contains("Loading published files")).to.be.true
+    expect(wrapper.find(LoadingIndicator)).to.have.length(1);
   })
 
   it("should render an empty state if there are no files", () => {

--- a/test/frontend/components/siteList/publishedState.test.js
+++ b/test/frontend/components/siteList/publishedState.test.js
@@ -4,51 +4,30 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import PublishedState from '../../../../frontend/components/siteList/publishedState';
 
-const NO_BUILDS_MESSAGE = 'Please wait for build to complete or check logs for error message.';
 const PUBLISHED_BASE = 'Please wait for build to complete or check logs for error message.';
 const MOST_RECENT_BUILD_TIME = "2015-09-04T15:11:23.000Z"
 const FORMATTED_MOST_RECENT_BUILD_TIME =  moment(MOST_RECENT_BUILD_TIME).format('MMMM Do YYYY, h:mm:ss a')
 const MOST_RECENT_BUILD = `This site was last published at ${FORMATTED_MOST_RECENT_BUILD_TIME}.`;
 
-let builds;
 let wrapper;
 
 describe('<PublishedState />', () => {
-  beforeEach(() => {
-    builds = [
-      {
-        completedAt: "2015-09-02T21:43:35.000Z"
-      },
-      {
-        completedAt: MOST_RECENT_BUILD_TIME
-      },
-      {
-        completedAt: undefined,
-      },
-    ];
-  })
 
   it('displays a fallback message if the site has no builds', () => {
     wrapper = shallow(<PublishedState />);
 
-    expect(wrapper.find('p').text()).to.equal(NO_BUILDS_MESSAGE);
+    expect(wrapper.find('p').text()).to.equal(PUBLISHED_BASE);
   });
 
   it('displays a fallback if build times cant be determined properly', () => {
-    wrapper = shallow(<PublishedState builds={[{completedAt: null}]}/>);
+    wrapper = shallow(<PublishedState site={{ publishedAt: undefined }} />);
 
     expect(wrapper.find('p').text()).to.equal(PUBLISHED_BASE);
   });
 
   it('displays the datetime of the most recent build', () => {
-    wrapper = shallow(<PublishedState builds={builds} />);
+    wrapper = shallow(<PublishedState site={{ publishedAt: MOST_RECENT_BUILD_TIME }} />);
 
     expect(wrapper.find('p').text()).to.equal(MOST_RECENT_BUILD);
   });
-
-  it('does not mutate builds prop', () => {
-    const buildsCopy = builds.concat()
-    wrapper = shallow(<PublishedState builds={builds} />);
-    expect(buildsCopy).to.deep.equal(builds)
-  })
 });

--- a/test/frontend/components/siteList/siteListItem.test.js
+++ b/test/frontend/components/siteList/siteListItem.test.js
@@ -12,7 +12,6 @@ const testSite = {
   repository: 'something',
   owner: 'someone',
   id: 1,
-  builds: [],
   viewLink: 'https://mysiteishere.biz'
 };
 
@@ -29,7 +28,7 @@ describe('<SiteListItem />', () => {
 
   it('outputs a published state component', () => {
     wrapper = shallow(<Fixture site={testSite}/>);
-    expect(wrapper.find(PublishedState).props()).to.deep.equals({builds: []})
+    expect(wrapper.find(PublishedState).props()).to.deep.equals({site: testSite})
     expect(wrapper.find(PublishedState)).to.have.length(1);
   });
 
@@ -42,12 +41,7 @@ describe('<SiteListItem />', () => {
     expect(wrapper.find(Link)).to.have.length(1);
   });
 
-  it('does not output a link tag when site `builds` array is empty', () => {
-    wrapper = shallow(<Fixture site={testSite}/>);
-    expect(wrapper.find('a')).to.have.length(0);
-  });
-
-  it('outputs a link tag when site `builds` array has a length', () => {
+  it('outputs a link tag to view the site', () => {
     const siteWithBuilds = Object.assign({}, testSite, {
       builds: [{}]
     });

--- a/test/frontend/reducers/buildsTest.js
+++ b/test/frontend/reducers/buildsTest.js
@@ -1,0 +1,66 @@
+import { expect } from "chai"
+import proxyquire from "proxyquire"
+
+proxyquire.noCallThru()
+
+describe("buildsReducer", () => {
+  let fixture;
+  const BUILDS_FETCH_STARTED = "builds fetch started 🏁🏎"
+  const BUILDS_RECEIVED = "builds received 🛬"
+  const BUILD_RESTARTED = "build restarted 🔄"
+
+  beforeEach(() => {
+    fixture = proxyquire("../../../frontend/reducers/builds.js", {
+      "../actions/actionCreators/buildActions": {
+        buildsFetchStartedType: BUILDS_FETCH_STARTED,
+        buildsReceivedType: BUILDS_RECEIVED,
+        buildRestartedType: BUILD_RESTARTED,
+      },
+    }).default;
+  });
+
+  it("ignores other actions and returns an initial state", () => {
+    const BUILDS = ["🛠", "⚒"]
+
+    const actual = fixture(undefined, {
+      type: "🙅‍",
+      builds: BUILDS,
+    })
+
+    expect(actual).to.deep.equal({ isLoading: false })
+  })
+
+  it("marks the state loading when a fetch is started", () => {
+    const actual = fixture({ isLoading: false }, {
+      type: BUILDS_FETCH_STARTED,
+    })
+
+    expect(actual).to.deep.equal({ isLoading: true })
+  })
+
+  it("sets the builds to the ones in the action when the fetch completes", () => {
+    const BUILDS = ["🛠", "⚒"]
+
+    const actual = fixture({ isLoading: true }, {
+      type: BUILDS_RECEIVED,
+      builds: BUILDS,
+    })
+
+    expect(actual).to.deep.equal({ isLoading: false, data: BUILDS })
+  })
+
+  it("records builds that are restarted", () => {
+    const BUILDS = ["🔧", "🔨"]
+    const RESTARTED_BUILD = "⛏"
+
+    const actual = fixture({ isLoading: false, data: BUILDS }, {
+      type: BUILD_RESTARTED,
+      build: RESTARTED_BUILD
+    })
+
+    expect(actual).to.deep.equal({
+      isLoading: false,
+      data: [RESTARTED_BUILD, ...BUILDS],
+    })
+  })
+})

--- a/test/frontend/reducers/sitesTest.js
+++ b/test/frontend/reducers/sitesTest.js
@@ -166,29 +166,4 @@ describe("sitesReducer", () => {
 
     expect(actual).to.deep.equal([ siteOne ]);
   });
-
-
-  it("adds the restarted build in the action to its site", () => {
-    const sitePendingRestart = {
-      id: "pick this one",
-      builds: ["finished build"],
-    };
-    const otherSite = {
-      id: "not this one",
-    };
-    const build = {
-      site: sitePendingRestart,
-    };
-    const restartedSite = Object.assign({}, sitePendingRestart, {
-      builds: [build, ...sitePendingRestart.builds],
-    });
-
-    const actual = fixture([sitePendingRestart, otherSite], {
-      type: BUILD_RESTARTED,
-      build: build
-    });
-
-    expect(actual).to.deep.equal([restartedSite, otherSite])
-  });
-
 });

--- a/test/frontend/reducersTest.js
+++ b/test/frontend/reducersTest.js
@@ -10,6 +10,7 @@ describe("maps reducers", () => {
   const PUBLISHED_BRANCHES = "published branches are here"
   const PUBLISHED_FILES = "published files are here"
   const SITES = "sites are here";
+  const BUILDS = "builds are here 🛠"
   const USER = "user is here";
 
   beforeEach(() => {
@@ -19,6 +20,7 @@ describe("maps reducers", () => {
       "./reducers/publishedBranches": PUBLISHED_BRANCHES,
       "./reducers/publishedFiles": PUBLISHED_FILES,
       "./reducers/sites": SITES,
+      "./reducers/builds": BUILDS,
       "./reducers/user": USER,
     }).default;
   });
@@ -41,6 +43,10 @@ describe("maps reducers", () => {
 
   it("maps sites reducer", () => {
     expect(fixture.sites).to.equal(SITES);
+  });
+
+  it("maps builds reducer", () => {
+    expect(fixture.builds).to.equal(BUILDS)
   });
 
   it("maps user reducer", () => {


### PR DESCRIPTION
This commit adds the loading state for builds. There's a good bit of legwork here because the builds are tightly coupled to sites in both the frontend and the API. This commit has changes to decouple them, and then add a loading state:

- Remove `builds` prop from the site API response
- Change the builds `find` action to be scoped to a given site
- Add a `publishedAt` attribute to the site model (since the frontend can no longer use the builds array in the site API response to calculate published times)
- Add a build reducer and associated actions
- Add a loading state to the `SiteBuilds` component.