### PR TITLE
Add demo branch and demo domain to site

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -102,6 +102,8 @@ module.exports = {
     }).then(() => {
       const params = Object.assign(site, req.body)
       return site.update({
+        demoBranch: params.demoBranch,
+        demoDomain: params.demoDomain,
         config: params.config,
         previewConfig: params.previewConfig,
         defaultBranch: params.defaultBranch,
@@ -116,7 +118,15 @@ module.exports = {
         site: siteId,
         branch: site.defaultBranch,
       })
-    }).then(build => {
+    }).then(() => {
+      if (site.demoDomain && site.demoBranch) {
+        return Build.create({
+          user: req.user.id,
+          site: siteId,
+          branch: site.demoBranch,
+        })
+      }
+    }).then(() => {
       return siteSerializer.serialize(site)
     }).then(siteJSON => {
       res.send(siteJSON)

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -1,6 +1,19 @@
 const url = require("url")
 const config = require("../../config")
 
+const afterValidate = (site) => {
+  if (site.defaultBranch == site.demoBranch) {
+    const error = new Error("Default branch and demo branch cannot be the same")
+    error.status = 403
+    throw error
+  }
+  if (site.domain && site.domain == site.demoDomain) {
+    const error = new Error("Domain and demo domain cannot be the same")
+    error.status = 403
+    throw error
+  }
+}
+
 const associate = ({ Site, Build, User }) => {
   Site.hasMany(Build, {
     foreignKey: "site",
@@ -49,6 +62,8 @@ const viewLinkForBranch = function(branch) {
     return this.domain
   } else if (branch === this.defaultBranch) {
     return `${s3Root}/site/${this.owner}/${this.repository}`
+  } else if (branch === this.demoBranch && this.demoDomain) {
+    return this.demoDomain
   } else {
     return url.resolve(config.app.hostname, `/preview/${this.owner}/${this.repository}/${branch}`)
   }
@@ -56,6 +71,12 @@ const viewLinkForBranch = function(branch) {
 
 module.exports = (sequelize, DataTypes) => {
   const Site = sequelize.define("Site", {
+    demoBranch: {
+      type: DataTypes.STRING,
+    },
+    demoDomain: {
+      type: DataTypes.STRING,
+    },
     config: {
       type: DataTypes.STRING,
     },
@@ -100,6 +121,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     hooks: {
       beforeValidate,
+      afterValidate,
     }
   })
 

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -37,6 +37,10 @@ const defaultBranch = (build) => {
   return build.branch === build.Site.defaultBranch
 }
 
+const demoBranch = (build) => {
+  return build.branch === build.Site.demoBranch
+}
+
 const pathForBuild = (build) => {
   if (defaultBranch(build)) {
     return `site/${build.Site.owner}/${build.Site.repository}`
@@ -48,6 +52,8 @@ const pathForBuild = (build) => {
 const baseURLForBuild = (build) => {
   if (defaultBranch(build) && build.Site.domain) {
     return baseURLForCustomDomain(build.Site.domain)
+  } else if (demoBranch(build) && build.Site.demoDomain) {
+    return baseURLForCustomDomain(build.Site.demoDomain)
   } else {
     return "/" + pathForBuild(build)
   }

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -13,6 +13,8 @@ class SiteSettings extends React.Component {
 
     this.state = {
       enableSave: false,
+      demoBranch: site.demoBranch || '',
+      demoDomain: site.demoDomain || '',
       config: site.config || '',
       previewConfig: site.previewConfig || '',
       defaultBranch: site.defaultBranch || '',
@@ -125,6 +127,36 @@ class SiteSettings extends React.Component {
                    type="text"
                    placeholder="https://example.com"
                    value={ state.domain }
+                   onChange={this.onChange} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="usa-grid">
+          <div className="usa-width-one-whole">
+            <div className="form-group">
+              <div className="usa-alert usa-alert-info">
+                <div className="usa-alert-body">
+                  <h3 className="usa-alert-heading">Demo Site</h3>
+                  <p className="usa-alert-text">
+                    Setup a branch to be deployed to a demo url.
+                  </p>
+                  <p>Branch name:</p>
+                  <input
+                   name="demoBranch"
+                   className="form-control"
+                   type="text"
+                   placeholder="Branch name"
+                   value={ state.demoBranch }
+                   onChange={this.onChange} />
+                  <p>Demo domain:</p>
+                  <input
+                   name="demoDomain"
+                   className="form-control"
+                   type="text"
+                   placeholder="https://preview.example.com"
+                   value={ state.demoDomain }
                    onChange={this.onChange} />
                 </div>
               </div>

--- a/migrations/20170503175438-add-demo-columns-to-site.js
+++ b/migrations/20170503175438-add-demo-columns-to-site.js
@@ -1,0 +1,22 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  db.addColumn("site", "demoDomain", { type: "string" }, (err) => {
+    if (err) {
+      callback(err)
+    } else {
+      db.addColumn("site", "demoBranch", { type: "string" }, callback)
+    }
+  })
+};
+
+exports.down = function(db, callback) {
+  db.removeColumn("site", "demoDomain", (err) => {
+    if (err) {
+      callback(err)
+    } else {
+      db.removeColumn("site", "demoBranch", callback)
+    }
+  })
+};

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -13,6 +13,12 @@
     "id": {
       "type": "integer"
     },
+    "demoBranch": {
+      "type": "string"
+    },
+    "demoDomain": {
+      "type": "string"
+    },
     "config": {
       "type": "string"
     },

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -199,6 +199,12 @@ paths:
           schema:
             type: object
             properties:
+              demoBranch:
+                type: string
+                description: The name of the branch served on the demo URL
+              demoDomain:
+                type: string
+                description: The domain where the demo branch's site is served
               config:
                 type: string
                 description: Jekyll configs for the site.
@@ -271,12 +277,21 @@ paths:
           schema:
             type: object
             properties:
+              demoBranch:
+                type: string
+                description: The name of the branch served on the demo URL
+              demoDomain:
+                type: string
+                description: The domain where the demo branch's site is served
               config:
                 type: string
                 description: Jekyll configs for the site.
               defaultBranch:
                 type: string
                 description: The default branch for the site.
+              domain:
+                type: string
+                description: The domain where the site is served
               engine:
                 type: string
                 description: The build engine to use when building the new site

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -614,6 +614,38 @@ describe("Site API", () => {
         return Site.findById(site.id, { include: [ User, Build ] })
       }).then(site => {
         expect(site.Builds).to.have.length(1)
+        expect(site.Builds[0].branch).to.equal(site.defaultBranch)
+        done()
+      }).catch(done)
+    })
+
+    it("should trigger a rebuild of the demo branch if one is present", done => {
+      factory.site({
+        repository: "old-repo-name",
+        demoBranch: "demo",
+        demoDomain: "https://demo.example.gov"
+      }).then(site => {
+        return Site.findById(site.id, { include: [ User, Build ] })
+      }).then(model => {
+        site = model
+        expect(site.Builds).to.have.length(0)
+        return session(site.Users[0])
+      }).then(cookie => {
+        return request(app)
+          .put(`/v0/site/${site.id}`)
+          .send({
+            repository: "new-repo-name"
+          })
+          .set("Cookie", cookie)
+          .expect(200)
+      }).then(resp => {
+        return Site.findById(site.id, { include: [ User, Build ] })
+      }).then(site => {
+        expect(site.Builds).to.have.length(2)
+        const demoBuild = site.Builds.find(candidateBuild => {
+          return candidateBuild.branch === site.demoBranch
+        })
+        expect(demoBuild).to.not.be.undefined
         done()
       }).catch(done)
     })

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -42,6 +42,27 @@ describe("Site model", () => {
       })
     })
 
+    context("for the demo branch", () => {
+      it("should return a federalist preview link if there is no demo domain", done => {
+        factory.site({ demoBranch: "demo-branch" }).then(site => {
+          const viewLink = site.viewLinkForBranch("demo-branch")
+          expect(viewLink).to.equal(`http://localhost:1337/preview/${site.owner}/${site.repository}/demo-branch`)
+          done()
+        }).catch(done)
+      })
+
+      it("should return the demo domain if there is a demo domain", done => {
+        factory.site({
+          demoDomain: "https://demo.example.gov",
+          demoBranch: "demo-branch",
+        }).then(site => {
+          const viewLink = site.viewLinkForBranch("demo-branch")
+          expect(viewLink).to.equal("https://demo.example.gov")
+          done()
+        }).catch(done)
+      })
+    })
+
     context("for a preview branch", () => {
       it("should return a federalist preview link", done => {
         factory.site().then(site => {
@@ -51,5 +72,31 @@ describe("Site model", () => {
         }).catch(done)
       })
     })
+  })
+
+  it("should not let the domain and demoDomain be equal", done => {
+    Site.create({
+      owner: "owner",
+      repository: "repository",
+      domain: "https://www.example.gov",
+      demoDomain: "https://www.example.gov",
+    }).catch(err => {
+      expect(err.status).to.equal(403)
+      expect(err.message).to.equal("Domain and demo domain cannot be the same")
+      done()
+    }).catch(done)
+  })
+
+  it("should not let the defaultBranch and demoBranch be equal", done => {
+    Site.create({
+      owner: "owner",
+      repository: "repository",
+      defaultBranch: "preview",
+      demoBranch: "preview",
+    }).catch(err => {
+      expect(err.status).to.equal(403)
+      expect(err.message).to.equal("Default branch and demo branch cannot be the same")
+      done()
+    }).catch(done)
   })
 })


### PR DESCRIPTION
This commit adds a feature that allows users to publish content to a new custom url named a "beta url". There are 2 configs for this: the beta domain and the beta branch.

A few changes were made to make this happen

- Add the attributes to the site model
- Add the inputs for the attributes to the site settings screen
- Change the SQS service to set the base url for the beta branch
- Change the site model to validate that the default and beta branch aren't the same
- Change the site model to validate that the domain and beta domain are not the same
- Trigger a rebuild of the default and beta branch when a site's configs are changed