### PR TITLE
Site loading state

### DIFF
--- a/frontend/actions/actionCreators/siteActions.js
+++ b/frontend/actions/actionCreators/siteActions.js
@@ -3,20 +3,6 @@ const siteAddedType = "SITE_ADDED";
 const siteUpdatedType = "SITE_UPDATED";
 const siteDeletedType = "SITE_DELETED";
 const siteBranchesReceivedType = "SITE_BRANCHES_RECEIVED";
-const siteInvalidType = 'SITE_INVALID';
-const siteLoadingType = 'SITE_LOADING';
-
-const siteLoading = (site, loading) => ({
-  type: siteLoadingType,
-  site,
-  loading
-});
-
-const siteInvalid = (site, invalid) => ({
-  type: siteInvalidType,
-  site,
-  invalid
-});
 
 const sitesReceived = sites => ({
   type: sitesReceivedType,
@@ -51,6 +37,4 @@ export {
   siteUpdated, siteUpdatedType,
   siteDeleted, siteDeletedType,
   siteBranchesReceived, siteBranchesReceivedType,
-  siteInvalid, siteInvalidType,
-  siteLoading, siteLoadingType
 };

--- a/frontend/actions/actionCreators/siteActions.js
+++ b/frontend/actions/actionCreators/siteActions.js
@@ -1,8 +1,13 @@
+const sitesFetchStartedType = "SITES_FETCH_STARTED"
 const sitesReceivedType = "SITES_RECEIVED";
 const siteAddedType = "SITE_ADDED";
 const siteUpdatedType = "SITE_UPDATED";
 const siteDeletedType = "SITE_DELETED";
 const siteBranchesReceivedType = "SITE_BRANCHES_RECEIVED";
+
+const sitesFetchStarted = () => ({
+  type: sitesFetchStartedType,
+})
 
 const sitesReceived = sites => ({
   type: sitesReceivedType,
@@ -32,6 +37,7 @@ const siteBranchesReceived = (siteId, branches) => ({
 });
 
 export {
+  sitesFetchStarted, sitesFetchStartedType,
   sitesReceived, sitesReceivedType,
   siteAdded, siteAddedType,
   siteUpdated, siteUpdatedType,

--- a/frontend/actions/dispatchActions.js
+++ b/frontend/actions/dispatchActions.js
@@ -5,17 +5,11 @@ import {
   siteUpdated as createSiteUpdatedAction,
   siteDeleted as createSiteDeletedAction,
   siteBranchesReceived as createSiteBranchesReceivedAction,
-  siteInvalid as createSiteInvalidAction,
-  siteLoading as createSiteLoadingAction
 } from './actionCreators/siteActions';
 import { pushHistory } from './routeActions';
 
 const updateRouterToSitesUri = () => {
   pushHistory(`/sites`);
-};
-
-const updateRouterToSpecificSiteUri = siteId => {
-  pushHistory(`/sites/${siteId}`);
 };
 
 const dispatchSitesReceivedAction = sites => {
@@ -38,22 +32,11 @@ const dispatchSiteBranchesReceivedAction = (siteId, branches) => {
   dispatch(createSiteBranchesReceivedAction(siteId, branches));
 };
 
-const dispatchSiteInvalidAction = (site, isInvalid) => {
-  dispatch(createSiteInvalidAction(site, isInvalid));
-};
-
-const dispatchSiteLoadingAction = (site, isLoading) => {
-  dispatch(createSiteLoadingAction(site, isLoading));
-}
-
 export {
   updateRouterToSitesUri,
-  updateRouterToSpecificSiteUri,
   dispatchSitesReceivedAction,
   dispatchSiteAddedAction,
   dispatchSiteUpdatedAction,
   dispatchSiteDeletedAction,
   dispatchSiteBranchesReceivedAction,
-  dispatchSiteInvalidAction,
-  dispatchSiteLoadingAction
 };

--- a/frontend/actions/dispatchActions.js
+++ b/frontend/actions/dispatchActions.js
@@ -1,5 +1,6 @@
 import { dispatch } from '../store';
 import {
+  sitesFetchStarted as createSitesFetchStartedAction,
   sitesReceived as createSitesReceivedAction,
   siteAdded as createSiteAddedAction,
   siteUpdated as createSiteUpdatedAction,
@@ -11,6 +12,10 @@ import { pushHistory } from './routeActions';
 const updateRouterToSitesUri = () => {
   pushHistory(`/sites`);
 };
+
+const dispatchSitesFetchStartedAction = () => {
+  dispatch(createSitesFetchStartedAction())
+}
 
 const dispatchSitesReceivedAction = sites => {
   dispatch(createSitesReceivedAction(sites));
@@ -34,6 +39,7 @@ const dispatchSiteBranchesReceivedAction = (siteId, branches) => {
 
 export {
   updateRouterToSitesUri,
+  dispatchSitesFetchStartedAction,
   dispatchSitesReceivedAction,
   dispatchSiteAddedAction,
   dispatchSiteUpdatedAction,

--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -4,6 +4,7 @@ import alertActions from './alertActions';
 
 import {
   updateRouterToSitesUri,
+  dispatchSitesFetchStartedAction,
   dispatchSitesReceivedAction,
   dispatchSiteAddedAction,
   dispatchSiteUpdatedAction,
@@ -19,6 +20,7 @@ const alertError = error => {
 
 export default {
   fetchSites() {
+    dispatchSitesFetchStartedAction()
     return federalist.fetchSites()
       .then(dispatchSitesReceivedAction)
       .catch(alertError);

--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -4,14 +4,11 @@ import alertActions from './alertActions';
 
 import {
   updateRouterToSitesUri,
-  updateRouterToSpecificSiteUri,
   dispatchSitesReceivedAction,
   dispatchSiteAddedAction,
   dispatchSiteUpdatedAction,
   dispatchSiteDeletedAction,
   dispatchSiteBranchesReceivedAction,
-  dispatchSiteInvalidAction,
-  dispatchSiteLoadingAction
 } from './dispatchActions';
 
 
@@ -50,25 +47,7 @@ export default {
   fetchBranches(site) {
     return github.fetchBranches(site)
       .then(dispatchSiteBranchesReceivedAction.bind(null, site.id))
-      .then(() => site);
-  },
-
-  siteExists(site) {
-    return github.getRepo(site)
       .then(() => site)
-      .catch((error) => {
-        dispatchSiteLoadingAction(site, false);
-        dispatchSiteInvalidAction(site, true);
-
-        throw new Error(error);
-      });
+      .catch(alertError);
   },
 };
-
-function throwRuntime(error) {
-  const runtimeErrors = ['TypeError'];
-  const isRuntimeError = runtimeErrors.find((e) => e === error.name);
-  if (isRuntimeError) {
-    throw error;
-  }
-}

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -49,8 +49,12 @@ class SiteContainer extends React.Component {
     return pathname.split('/').pop();
   }
 
-  getCurrentSite(sites, siteId) {
-    return sites.find((site) => {
+  getCurrentSite(sitesState, siteId) {
+    if (sitesState.isLoading) {
+      return null
+    }
+
+    return sitesState.data.find((site) => {
       // force type coersion
       return site.id == siteId;
     });

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -39,9 +39,7 @@ class SiteContainer extends React.Component {
     const currentSite = this.getCurrentSite(storeState.sites, params.id);
 
     if (currentSite) {
-      siteActions.siteExists(currentSite).then(() => {
-        return siteActions.fetchBranches(currentSite)
-      });
+      siteActions.fetchBranches(currentSite)
     } else {
       replaceHistory('/sites');
     }

--- a/frontend/components/siteList/siteList.js
+++ b/frontend/components/siteList/siteList.js
@@ -2,17 +2,22 @@ import React from 'react';
 import AlertBanner from '../alertBanner';
 import SiteListItem from './siteListItem';
 import LinkButton from '../linkButton';
+import LoadingIndicator from '../loadingIndicator';
 
 const propTypes = {
   storeState: React.PropTypes.object
 };
 
-const getSites = (sites) => {
-  if (!sites.length) {
+const getSites = (sitesState) => {
+  if (sitesState.isLoading) {
+    return <LoadingIndicator/>
+  }
+
+  if (!sitesState.data.length) {
     return (
       <div className="usa-grid">
         <h1>No sites yet.</h1>
-        <p>Add one now. (This message may also appear briefly before your site list loads).</p>
+        <p>Add one now.</p>
       </div>
     );
   }
@@ -21,7 +26,7 @@ const getSites = (sites) => {
     <div className="usa-grid">
       <h2>Websites</h2>
       <ul className="sites-list">
-        {sites.map((site, index) => {
+        {sitesState.data.map((site, index) => {
             return <SiteListItem key={ index } site={ site } />
         })}
       </ul>

--- a/frontend/reducers/sites.js
+++ b/frontend/reducers/sites.js
@@ -1,4 +1,5 @@
 import {
+  sitesFetchStartedType as SITES_FETCH_STARTED,
   sitesReceivedType as SITES_RECEIVED,
   siteAddedType as SITE_ADDED,
   siteUpdatedType as SITE_UPDATED,
@@ -6,34 +7,53 @@ import {
   siteBranchesReceivedType as SITE_BRANCHES_RECEIVED,
 } from '../actions/actionCreators/siteActions';
 
-const initialState = [];
+const initialState = { isLoading: false };
 
 export default function sites(state = initialState, action) {
   switch (action.type) {
 
+  case SITES_FETCH_STARTED:
+    return { isLoading: true }
+
   case SITES_RECEIVED:
-    return action.sites || initialState;
+    return { isLoading: false, data: action.sites || [] }
 
   case SITE_ADDED:
-    return action.site ? [...state, action.site] : state;
+    if (action.site) {
+      return {
+        isLoading: false,
+        data: state.data.concat(action.site),
+      }
+    } else {
+      return state
+    }
 
   case SITE_UPDATED:
-    return mapPropertyToMatchingSite(state, action.siteId, action.site);
+    return {
+      isLoading: false,
+      data: mapPropertyToMatchingSite(state.data, action.siteId, action.site),
+    }
 
   case SITE_BRANCHES_RECEIVED:
     const branches = action.branches;
-    return mapPropertyToMatchingSite(state, action.siteId, { branches });
+    return {
+      isLoading: false,
+      data: mapPropertyToMatchingSite(state.data, action.siteId, { branches }),
+    }
 
   case SITE_DELETED:
-    return state.filter((site) => site.id != action.siteId);
+    return {
+      isLoading: false,
+      data: state.data.filter((site) => site.id != action.siteId),
+    }
 
   default:
     return state;
   }
 }
 
-const mapPropertyToMatchingSite = (state, siteId, properties) => {
-  return state.map((site) => {
+const mapPropertyToMatchingSite = (data, siteId, properties) => {
+  return data.map((site) => {
     if (site.id !== siteId) return site;
     return Object.assign({}, site, properties);
   });

--- a/frontend/reducers/sites.js
+++ b/frontend/reducers/sites.js
@@ -3,23 +3,13 @@ import {
   siteAddedType as SITE_ADDED,
   siteUpdatedType as SITE_UPDATED,
   siteDeletedType as SITE_DELETED,
-  siteAssetsReceivedType as SITE_ASSETS_RECEIVED,
-  siteConfigsReceivedType as SITE_CONFIGS_RECEIVED,
   siteBranchesReceivedType as SITE_BRANCHES_RECEIVED,
-  siteInvalidType as SITE_INVALID,
-  siteLoadingType as SITE_LOADING
 } from '../actions/actionCreators/siteActions';
 
 const initialState = [];
 
 export default function sites(state = initialState, action) {
   switch (action.type) {
-
-  case SITE_LOADING:
-    return mapPropertyToMatchingSite(state, action.site.id, {loading: action.loading});
-
-  case SITE_INVALID:
-    return mapPropertyToMatchingSite(state, action.site.id, {invalid: action.invalid});
 
   case SITES_RECEIVED:
     return action.sites || initialState;

--- a/frontend/util/githubApi.js
+++ b/frontend/util/githubApi.js
@@ -20,6 +20,8 @@ const github = {
 
     return fetch(url, params).then((data) => {
       return data;
+    }).catch((error) => {
+      alertActions.httpError(error.message);
     });
   },
 

--- a/test/frontend/actions/actionCreators/siteActionsTest.js
+++ b/test/frontend/actions/actionCreators/siteActionsTest.js
@@ -5,8 +5,6 @@ import {
   siteUpdated, siteUpdatedType,
   siteDeleted, siteDeletedType,
   siteBranchesReceived, siteBranchesReceivedType,
-  siteInvalid, siteInvalidType,
-  siteLoading, siteLoadingType
 } from "../../../../frontend/actions/actionCreators/siteActions";
 
 describe("siteActions actionCreators", () => {
@@ -106,50 +104,6 @@ describe("siteActions actionCreators", () => {
 
     it("exports its type", () => {
       expect(siteBranchesReceivedType).to.equal("SITE_BRANCHES_RECEIVED");
-    });
-  });
-
-  describe('siteInvalid', () => {
-    it('constructs properly', () => {
-      const site = {
-        id: 1,
-        name: 'hotseatcantsitdown'
-      };
-      const invalid = true;
-
-      const actual = siteInvalid(site, invalid);
-
-      expect(actual).to.deep.equal({
-        type: siteInvalidType,
-        site,
-        invalid
-      });
-    });
-
-    it ('exports its type', () => {
-      expect(siteInvalidType).to.equal('SITE_INVALID');
-    });
-  });
-
-  describe('siteLoading', () => {
-    it('constructs properly', () => {
-      const site = {
-        id: 1,
-        name: 'hotseatcantsitdown'
-      };
-      const loading = false;
-
-      const actual = siteLoading(site, false);
-
-      expect(actual).to.deep.equal({
-        type: siteLoadingType,
-        site,
-        loading
-      });
-    });
-
-    it ('exports its type', () => {
-      expect(siteLoadingType).to.equal('SITE_LOADING');
     });
   });
 

--- a/test/frontend/actions/actionCreators/siteActionsTest.js
+++ b/test/frontend/actions/actionCreators/siteActionsTest.js
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import {
+  sitesFetchStarted, sitesFetchStartedType,
   sitesReceived, sitesReceivedType,
   siteAdded, siteAddedType,
   siteUpdated, siteUpdatedType,
@@ -8,6 +9,19 @@ import {
 } from "../../../../frontend/actions/actionCreators/siteActions";
 
 describe("siteActions actionCreators", () => {
+  describe("sitesFetchStarted", () => {
+    it("constructs propery", () => {
+      const actual = sitesFetchStarted()
+      expect(actual).to.deep.equal({
+        type: sitesFetchStartedType,
+      })
+    })
+
+    it("exports its type", () => {
+      expect(sitesFetchStartedType).to.equal("SITES_FETCH_STARTED")
+    })
+  })
+
   describe("sitesReceived", () => {
     it("constructs properly", () => {
       const sites = [{

--- a/test/frontend/actions/dispatchActionsTest.js
+++ b/test/frontend/actions/dispatchActionsTest.js
@@ -7,7 +7,8 @@ proxyquire.noCallThru();
 describe("dispatchActions", () => {
   let fixture;
   let dispatch;
-  let sitesReceivedActionCreator, siteAddedActionCreator, siteDeletedActionCreator,
+  let sitesFetchStartedActionCreator, sitesReceivedActionCreator,
+      siteAddedActionCreator, siteDeletedActionCreator,
       siteUpdatedActionCreator, siteBranchesReceivedActionCreator,
       updateRouterActionCreator, pushHistory;
 
@@ -17,6 +18,7 @@ describe("dispatchActions", () => {
 
   beforeEach(() => {
     dispatch = spy();
+    sitesFetchStartedActionCreator = stub();
     sitesReceivedActionCreator = stub();
     updateRouterActionCreator = stub();
     siteAddedActionCreator = stub();
@@ -27,6 +29,7 @@ describe("dispatchActions", () => {
 
     fixture = proxyquire("../../../frontend/actions/dispatchActions", {
       "./actionCreators/siteActions": {
+        sitesFetchStarted: sitesFetchStartedActionCreator,
         sitesReceived: sitesReceivedActionCreator,
         siteAdded: siteAddedActionCreator,
         siteUpdated: siteUpdatedActionCreator,
@@ -46,6 +49,14 @@ describe("dispatchActions", () => {
     fixture.updateRouterToSitesUri();
     expect(pushHistory.calledWith("/sites")).to.be.true;
   });
+
+  it("dispatchSitesFetchStartedAction", () => {
+    sitesFetchStartedActionCreator.returns(action)
+
+    fixture.dispatchSitesFetchStartedAction()
+
+    expect(dispatch.calledWith(action)).to.be.true
+  })
 
   it("dispatchSitesReceivedAction", () => {
     const sites = [ site ];

--- a/test/frontend/actions/dispatchActionsTest.js
+++ b/test/frontend/actions/dispatchActionsTest.js
@@ -9,8 +9,7 @@ describe("dispatchActions", () => {
   let dispatch;
   let sitesReceivedActionCreator, siteAddedActionCreator, siteDeletedActionCreator,
       siteUpdatedActionCreator, siteBranchesReceivedActionCreator,
-      updateRouterActionCreator, siteLoadingActionCreator,
-      siteInvalidActionCreator, pushHistory;
+      updateRouterActionCreator, pushHistory;
 
   const action = { whatever: "bub" };
   const site = { site: "site1" };
@@ -24,8 +23,6 @@ describe("dispatchActions", () => {
     siteUpdatedActionCreator = stub();
     siteDeletedActionCreator = stub();
     siteBranchesReceivedActionCreator = stub();
-    siteLoadingActionCreator = stub();
-    siteInvalidActionCreator = stub();
     pushHistory = stub();
 
     fixture = proxyquire("../../../frontend/actions/dispatchActions", {
@@ -35,8 +32,6 @@ describe("dispatchActions", () => {
         siteUpdated: siteUpdatedActionCreator,
         siteDeleted: siteDeletedActionCreator,
         siteBranchesReceived: siteBranchesReceivedActionCreator,
-        siteInvalid: siteInvalidActionCreator,
-        siteLoading: siteLoadingActionCreator
       },
       "./routeActions": {
         pushHistory: pushHistory
@@ -50,12 +45,6 @@ describe("dispatchActions", () => {
   it("updateRouterToSitesUri", () => {
     fixture.updateRouterToSitesUri();
     expect(pushHistory.calledWith("/sites")).to.be.true;
-  });
-
-  it("updateRouterToSpecificSiteUri", () => {
-    const siteId = "7";
-    fixture.updateRouterToSpecificSiteUri(siteId);
-    expect(pushHistory.calledWith(`/sites/${siteId}`)).to.be.true;
   });
 
   it("dispatchSitesReceivedAction", () => {
@@ -96,20 +85,6 @@ describe("dispatchActions", () => {
     siteBranchesReceivedActionCreator.withArgs(siteId, branches).returns(action);
 
     fixture.dispatchSiteBranchesReceivedAction(siteId, branches);
-
-    expect(dispatch.calledWith(action)).to.be.true;
-  });
-
-  it('dispatchSiteInvalidAction', () => {
-    siteInvalidActionCreator.withArgs(site, false).returns(action);
-    fixture.dispatchSiteInvalidAction(site, false);
-
-    expect(dispatch.calledWith(action)).to.be.true;
-  });
-
-  it('dispatchSiteLoadingAction', () => {
-    siteLoadingActionCreator.withArgs(site, false).returns(action);
-    fixture.dispatchSiteLoadingAction(site, false);
 
     expect(dispatch.calledWith(action)).to.be.true;
   });

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -7,16 +7,15 @@ proxyquire.noCallThru();
 describe("siteActions", () => {
   let fixture;
 
-  let fetchBranches, deleteBranch, createRepo, fetchFile, getRepo;
+  let fetchBranches;
 
-  let fetchSites, addSite, updateSite, deleteSite, siteExists;
+  let fetchSites, addSite, updateSite, deleteSite;
 
   let httpErrorAlertAction, alertSuccess, alertError;
 
-  let updateRouterToSitesUri, updateRouterToSpecificSiteUri, dispatchSitesReceivedAction,
+  let updateRouterToSitesUri, dispatchSitesReceivedAction,
       dispatchSiteAddedAction, dispatchSiteUpdatedAction, dispatchSiteDeletedAction,
-      dispatchSiteBranchesReceivedAction, dispatchSiteInvalidAction,
-      dispatchSiteLoadingAction;
+      dispatchSiteBranchesReceivedAction;
 
   const siteId = "kuaw8fsru8hwugfw";
   const site = {
@@ -36,34 +35,25 @@ describe("siteActions", () => {
     addSite = stub();
     updateSite = stub();
     deleteSite = stub();
-    getRepo = stub();
     fetchBranches = stub();
-    deleteBranch = stub();
     alertSuccess = stub();
     alertError = stub();
-    siteExists = stub();
 
     updateRouterToSitesUri = stub();
-    updateRouterToSpecificSiteUri = stub();
     dispatchSitesReceivedAction = stub();
     dispatchSiteAddedAction = stub();
     dispatchSiteUpdatedAction = stub();
     dispatchSiteDeletedAction = stub();
     dispatchSiteBranchesReceivedAction = stub();
-    dispatchSiteInvalidAction = stub();
-    dispatchSiteLoadingAction = stub();
 
     fixture = proxyquire("../../../frontend/actions/siteActions", {
       "./dispatchActions": {
         updateRouterToSitesUri: updateRouterToSitesUri,
-        updateRouterToSpecificSiteUri: updateRouterToSpecificSiteUri,
         dispatchSitesReceivedAction: dispatchSitesReceivedAction,
         dispatchSiteAddedAction: dispatchSiteAddedAction,
         dispatchSiteUpdatedAction: dispatchSiteUpdatedAction,
         dispatchSiteDeletedAction: dispatchSiteDeletedAction,
         dispatchSiteBranchesReceivedAction: dispatchSiteBranchesReceivedAction,
-        dispatchSiteInvalidAction: dispatchSiteInvalidAction,
-        dispatchSiteLoadingAction: dispatchSiteLoadingAction
       },
       "./alertActions": {
         httpError: httpErrorAlertAction,
@@ -78,7 +68,6 @@ describe("siteActions", () => {
       },
       "../util/githubApi": {
         fetchBranches: fetchBranches,
-        getRepo: getRepo
       },
     }).default;
   });

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -13,8 +13,9 @@ describe("siteActions", () => {
 
   let httpErrorAlertAction, alertSuccess, alertError;
 
-  let updateRouterToSitesUri, dispatchSitesReceivedAction,
-      dispatchSiteAddedAction, dispatchSiteUpdatedAction, dispatchSiteDeletedAction,
+  let updateRouterToSitesUri, dispatchSitesFetchStartedAction,
+      dispatchSitesReceivedAction, dispatchSiteAddedAction,
+      dispatchSiteUpdatedAction, dispatchSiteDeletedAction,
       dispatchSiteBranchesReceivedAction;
 
   const siteId = "kuaw8fsru8hwugfw";
@@ -40,6 +41,7 @@ describe("siteActions", () => {
     alertError = stub();
 
     updateRouterToSitesUri = stub();
+    dispatchSitesFetchStartedAction = stub();
     dispatchSitesReceivedAction = stub();
     dispatchSiteAddedAction = stub();
     dispatchSiteUpdatedAction = stub();
@@ -49,6 +51,7 @@ describe("siteActions", () => {
     fixture = proxyquire("../../../frontend/actions/siteActions", {
       "./dispatchActions": {
         updateRouterToSitesUri: updateRouterToSitesUri,
+        dispatchSitesFetchStartedAction: dispatchSitesFetchStartedAction,
         dispatchSitesReceivedAction: dispatchSitesReceivedAction,
         dispatchSiteAddedAction: dispatchSiteAddedAction,
         dispatchSiteUpdatedAction: dispatchSiteUpdatedAction,
@@ -74,9 +77,6 @@ describe("siteActions", () => {
 
   describe("fetchSites", () => {
     it("triggers the fetching of sites and dispatches a sites received action to the store when successful", () => {
-      const action = {
-        hi: "you"
-      };
       const sites = {
         hi: "mom"
       };
@@ -86,6 +86,7 @@ describe("siteActions", () => {
       const actual = fixture.fetchSites();
 
       return actual.then(() => {
+        expect(dispatchSitesFetchStartedAction.called).to.be.true
         expect(dispatchSitesReceivedAction.calledWith(sites)).to.be.true;
       });
     });

--- a/test/frontend/components/siteList/siteList.test.js
+++ b/test/frontend/components/siteList/siteList.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import proxyquire from 'proxyquire';
+import LoadingIndicator from '../../../../frontend/components/loadingIndicator'
 
 proxyquire.noCallThru();
 
@@ -11,8 +12,9 @@ const LinkButton = () => <div></div>;
 const NO_SITE_TEXT = 'No sites yet.';
 
 // sites can be empty as the test is rendering empty divs for children.
-const STORE_WITH_SITES = {sites: [{}, {}, {}]};
-const STORE_WITH_NO_SITES = {sites: []};
+const STORE_WITH_SITES = { sites: { isLoading: false, data: [{}, {}, {}]} };
+const STORE_WITH_NO_SITES = { sites: { isLoading: false, data: []} };
+const STORE_LOADING_SITES = { sites: { isLoading: true } }
 
 describe('<SiteList />', () => {
   let Fixture;
@@ -24,6 +26,16 @@ describe('<SiteList />', () => {
       '../linkButton': LinkButton
     }).default;
   });
+
+  describe('when sites are being loaded', () => {
+    beforeEach(() => {
+      wrapper = shallow(<Fixture storeState={STORE_LOADING_SITES}/>)
+    })
+
+    it("renders a loading indicator", () => {
+      expect(wrapper.find(LoadingIndicator)).to.have.length(1)
+    })
+  })
 
   describe('when no sites are received as props', () => {
     beforeEach(() => {

--- a/test/frontend/reducers/sitesTest.js
+++ b/test/frontend/reducers/sitesTest.js
@@ -5,6 +5,7 @@ proxyquire.noCallThru();
 
 describe("sitesReducer", () => {
   let fixture;
+  const SITES_FETCH_STARTED = "🐶⚾️"
   const SITE_ADDED = "hey, new site!";
   const SITE_DELETED = "bye, site.";
   const SITE_UPDATED = "change the site, please";
@@ -14,6 +15,7 @@ describe("sitesReducer", () => {
   beforeEach(() => {
     fixture = proxyquire("../../../frontend/reducers/sites", {
       "../actions/actionCreators/siteActions": {
+        sitesFetchStartedType: SITES_FETCH_STARTED,
         sitesReceivedType: SITES_RECEIVED,
         siteAddedType: SITE_ADDED,
         siteUpdatedType: SITE_UPDATED,
@@ -25,58 +27,70 @@ describe("sitesReducer", () => {
     }).default;
   });
 
-  it("defaults to empty array and ignores other actions", () => {
+  it("defaults to an initial state and ignores other actions", () => {
     const actual = fixture(undefined, {
       type: "not what you're looking for",
       hello: "alijasfjir"
     });
 
-    expect(actual).to.deep.equal([]);
+    expect(actual).to.deep.equal({ isLoading: false });
   });
+
+  it("marks the state as loading when it gets a 'sites fetch started' action", () => {
+    const actual = fixture({ isLoading: false }, {
+      type: SITES_FETCH_STARTED,
+    })
+
+    expect(actual).to.deep.equal({ isLoading: true })
+  })
 
   it("replaces anything it has when it gets a 'sites received' action", () => {
     const sites = [{ hello: "world"}, { how: "are you?" }];
 
-    const actual = fixture([{ oldData: "to be lost" }], {
+    const actual = fixture({ isLoading: false, data: [{ oldData: "to be lost" }] }, {
       type: SITES_RECEIVED,
       sites: sites
     });
 
-    expect(actual).to.deep.equal(sites);
+    expect(actual).to.deep.equal({
+      isLoading: false,
+      data: sites,
+    });
   });
 
 
   it("ignores a malformed 'sites received' action", () => {
-    const sites = [{ hello: "world"}, { how: "are you?" }];
-
     const actual = fixture([{ oldData: "to be lost" }], {
       type: SITES_RECEIVED
     });
 
-    expect(actual).to.deep.equal([]);
+    expect(actual).to.deep.equal({
+      isLoading: false,
+      data: [],
+    });
   });
 
   it("adds a site if action has a site", () => {
     const existingSites = [{ existing: "siteToKeep" }];
     const site = { hereIs: "something" };
 
-    const actual = fixture(existingSites, {
+    const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_ADDED,
       site: site
     });
 
-    expect(actual).to.deep.equal(existingSites.concat(site));
+    expect(actual.data).to.deep.equal(existingSites.concat(site));
   });
 
   it("does not add a site if action has no site", () => {
     const existingSites = [{ existing: "siteToKeep" }];
     const site = { hereIs: "something" };
 
-    const actual = fixture(existingSites, {
+    const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_ADDED
     });
 
-    expect(actual).to.deep.equal(existingSites);
+    expect(actual.data).to.deep.equal(existingSites);
   });
 
   it("ignores when given an update action and the new site's id is not found", () => {
@@ -90,13 +104,13 @@ describe("sitesReducer", () => {
 
     const site = { id: "something", oldData: false };
 
-    const actual = fixture(existingSites, {
+    const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_UPDATED,
       siteId: "something",
       site: site
     });
 
-    expect(actual).to.deep.equal(existingSites);
+    expect(actual.data).to.deep.equal(existingSites);
   });
 
   it("updates existing site data when given an update action and the new site's id is found", () => {
@@ -114,13 +128,13 @@ describe("sitesReducer", () => {
 
     const newSite = { id: "siteToKeep", oldData: false, hi: "there" };
 
-    const actual = fixture(existingSites, {
+    const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_UPDATED,
       siteId: "siteToKeep",
       site: newSite
     });
 
-    expect(actual).to.deep.equal([ newSite, siteTwo ]);
+    expect(actual.data).to.deep.equal([ newSite, siteTwo ]);
   });
 
   it("ignores delete request if site id is not found", () => {
@@ -136,12 +150,12 @@ describe("sitesReducer", () => {
 
     const existingSites = [ siteOne, siteTwo ];
 
-    const actual = fixture(existingSites, {
+    const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_DELETED,
       siteId: "i'm not here."
     });
 
-    expect(actual).to.deep.equal(existingSites);
+    expect(actual.data).to.deep.equal(existingSites);
   });
 
   it("deletes site if site id is found", () => {
@@ -159,11 +173,11 @@ describe("sitesReducer", () => {
 
     const existingSites = [ siteOne, siteTwo ];
 
-    const actual = fixture(existingSites, {
+    const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_DELETED,
       siteId: siteToLoseId
     });
 
-    expect(actual).to.deep.equal([ siteOne ]);
+    expect(actual.data).to.deep.equal([ siteOne ]);
   });
 });


### PR DESCRIPTION
This branch has 2 commits. The first removes some dead code that was previously used to manage sites in the frontend. This was mostly unused action and reducer code.

The other commit adds a loading state to the sites list. When a site fetch starts, the sites state is marked as loading and the sites list displays a loading indicator. When the fetch is complete, the sites list is displayed. This second commit is WIP at this time.