### PR TITLE
Add published branches loading state to the frontend

### DIFF
--- a/frontend/actions/actionCreators/publishedBranchActions.js
+++ b/frontend/actions/actionCreators/publishedBranchActions.js
@@ -1,4 +1,9 @@
+const publishedBranchesFetchStartedType = "SITE_PUBLISHED_BRANCHES_FETCH_STARTED"
 const publishedBranchesReceivedType = "SITE_PUBLISHED_BRANCHES_RECEIVED"
+
+const publishedBranchesFetchStarted = () => ({
+  type: publishedBranchesFetchStartedType,
+})
 
 const publishedBranchesReceived = branches => ({
   type: publishedBranchesReceivedType,
@@ -6,5 +11,6 @@ const publishedBranchesReceived = branches => ({
 });
 
 export {
+  publishedBranchesFetchStartedType, publishedBranchesFetchStarted,
   publishedBranchesReceivedType, publishedBranchesReceived,
 }

--- a/frontend/actions/publishedBranchActions.js
+++ b/frontend/actions/publishedBranchActions.js
@@ -2,8 +2,13 @@ import api from '../util/federalistApi';
 import { dispatch } from '../store';
 
 import {
+  publishedBranchesFetchStarted as createPublishedBranchesFetchStartedAction,
   publishedBranchesReceived as createPublishedBranchesReceivedAction,
 } from "./actionCreators/publishedBranchActions";
+
+const dispatchPublishedBranchesFetchStartedAction = () => {
+  dispatch(createPublishedBranchesFetchStartedAction())
+}
 
 const dispatchPublishedBranchesReceivedAction = branches => {
   dispatch(createPublishedBranchesReceivedAction(branches))
@@ -11,6 +16,7 @@ const dispatchPublishedBranchesReceivedAction = branches => {
 
 export default {
   fetchPublishedBranches(site) {
+    dispatchPublishedBranchesFetchStartedAction()
     return api.fetchPublishedBranches(site)
       .then(dispatchPublishedBranchesReceivedAction)
   },

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from 'react-router';
 import publishedBranchActions from "../../actions/publishedBranchActions";
+import LoadingIndicator from "../loadingIndicator"
 
 class SitePublishedBranchesTable extends React.Component {
   componentDidMount() {
@@ -8,25 +9,27 @@ class SitePublishedBranchesTable extends React.Component {
   }
 
   publishedBranches() {
-    if (!this.props.publishedBranches) {
+    if (this.props.publishedBranches.isLoading || !this.props.publishedBranches.data) {
       return []
+    } else {
+      return this.props.publishedBranches.data
     }
-    return this.props.publishedBranches.filter(branch => {
-      return branch.site.id === parseInt(this.props.params.id)
-    })
   }
 
   render() {
-    if (this.publishedBranches().length > 0) {
-      return this.renderBuildLogsTable()
-    } else {
+    const branches = this.publishedBranches()
+    if (this.props.publishedBranches.isLoading) {
       return this.renderLoadingState()
+    } else if (!branches.length) {
+      return this.renderEmptyState()
+    } else {
+      return this.renderPublishedBranchesTable()
     }
   }
 
-  renderBuildLogsTable() {
+  renderPublishedBranchesTable() {
     return (
-      <table className="usa-table-borderless build-log-table">
+      <table className="usa-table-borderless published-branch-table">
         <thead>
           <tr>
             <th>Branch</th>
@@ -62,7 +65,14 @@ class SitePublishedBranchesTable extends React.Component {
   }
 
   renderLoadingState() {
-    return <p>No published branch data available</p>
+    return <LoadingIndicator/>
+  }
+
+  renderEmptyState() {
+    return <p>
+      No branches have been published.
+      Please wait for build to complete or check logs for error message.
+    </p>
   }
 }
 

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -66,9 +66,7 @@ class SiteContainer extends React.Component {
     const site = this.getCurrentSite(storeState.sites, params.id)
     const builds = storeState.builds
     const buildLogs = storeState.buildLogs
-    const publishedBranches = storeState.publishedBranches.filter(branch => {
-      return branch.site.id === site.id
-    })
+    const publishedBranches = storeState.publishedBranches
     const publishedFiles = storeState.publishedFiles
     const childConfigs = { site, builds, buildLogs, publishedBranches, publishedFiles }
 

--- a/frontend/reducers/publishedBranches.js
+++ b/frontend/reducers/publishedBranches.js
@@ -1,11 +1,17 @@
 import {
+  publishedBranchesFetchStartedType as PUBLISHED_BRANCHES_FETCH_STARTED,
   publishedBranchesReceivedType as PUBLISHED_BRANCHES_RECEIVED,
 } from "../actions/actionCreators/publishedBranchActions";
 
-export default function publishedBranches(state = [], action) {
+const initialState = { isLoading: false }
+
+export default function publishedBranches(state = initialState, action) {
   switch (action.type) {
+
+  case PUBLISHED_BRANCHES_FETCH_STARTED:
+    return { isLoading: true }
   case PUBLISHED_BRANCHES_RECEIVED:
-    return action.branches;
+    return { isLoading: false, data: action.branches };
   default:
     return state;
   }

--- a/test/frontend/actions/actionCreators/publishedBranchActionsTest.js
+++ b/test/frontend/actions/actionCreators/publishedBranchActionsTest.js
@@ -1,9 +1,24 @@
 import { expect } from "chai"
 import {
+  publishedBranchesFetchStarted, publishedBranchesFetchStartedType,
   publishedBranchesReceived, publishedBranchesReceivedType,
 } from "../../../../frontend/actions/actionCreators/publishedBranchActions";
 
 describe("publishedBranchActions actionCreators", () => {
+  describe("published branches fetch started", () => {
+    it("constructs properly", () => {
+      const actual = publishedBranchesFetchStarted()
+
+      expect(actual).to.deep.equal({
+        type: publishedBranchesFetchStartedType,
+      })
+    })
+
+    it("exports its type", () => {
+      expect(publishedBranchesFetchStartedType).to.equal("SITE_PUBLISHED_BRANCHES_FETCH_STARTED")
+    })
+  })
+
   describe("published branches received", () => {
     it("constructs properly", () => {
       const branches = ["Branch 1", "Branch 2"]

--- a/test/frontend/actions/publishedBranchActionsTest.js
+++ b/test/frontend/actions/publishedBranchActionsTest.js
@@ -7,17 +7,20 @@ proxyquire.noCallThru()
 describe("publishedBranchActions", () => {
   let fixture
   let dispatch
+  let publishedBranchesFetchStartedActionCreator
   let publishedBranchesReceivedActionCreator
   let fetchPublishedBranches
 
   beforeEach(() => {
     dispatch = spy()
+    publishedBranchesFetchStartedActionCreator = stub()
     publishedBranchesReceivedActionCreator = stub()
 
     fetchPublishedBranches = stub()
 
     fixture = proxyquire("../../../frontend/actions/publishedBranchActions", {
       "./actionCreators/publishedBranchActions": {
+        publishedBranchesFetchStarted: publishedBranchesFetchStartedActionCreator,
         publishedBranchesReceived: publishedBranchesReceivedActionCreator,
       },
       "../util/federalistApi": {
@@ -32,15 +35,18 @@ describe("publishedBranchActions", () => {
   it("fetchPublishedBranches", done => {
     const branches = ["Branch 1", "Branch 2"]
     const publishedBranchesPromise = Promise.resolve(branches)
-    const action = { action: "action" }
+    const startedAction = { action: "🚦🏎" }
+    const receivedAction = { action: "🏁" }
     fetchPublishedBranches.withArgs().returns(publishedBranchesPromise)
-    publishedBranchesReceivedActionCreator.withArgs(branches).returns(action)
+    publishedBranchesFetchStartedActionCreator.withArgs().returns(startedAction)
+    publishedBranchesReceivedActionCreator.withArgs(branches).returns(receivedAction)
 
     const actual = fixture.fetchPublishedBranches()
 
     actual.then(() => {
-      expect(dispatch.calledOnce).to.be.true
-      expect(dispatch.calledWith(action)).to.be.true
+      expect(dispatch.calledTwice).to.be.true
+      expect(dispatch.calledWith(startedAction)).to.be.true
+      expect(dispatch.calledWith(receivedAction)).to.be.true
       done()
     })
   })

--- a/test/frontend/components/site/sitePublishedBranchesTable.test.js
+++ b/test/frontend/components/site/sitePublishedBranchesTable.test.js
@@ -1,16 +1,20 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import LoadingIndicator from '../../../../frontend/components/loadingIndicator';
 import SitePublishedBranchesTable from '../../../../frontend/components/site/sitePublishedBranchesTable';
 
 describe("<SitePublishedBranchesTable/>", () => {
-  it("should render a table with branches for the given site", () => {
+  it("should render a table with branches from the state", () => {
     const props = {
       params: { id: 1 },
-      publishedBranches: [
-        { name: "branch-a", viewLink: "www.example.gov/branch-a", site: { id: 1 } },
-        { name: "branch-b", viewLink: "www.example.gov/branch-b", site: { id: 1 } },
-      ]
+      publishedBranches: {
+        isLoading: false,
+        data: [
+          { name: "branch-a", viewLink: "www.example.gov/branch-a", site: { id: 1 } },
+          { name: "branch-b", viewLink: "www.example.gov/branch-b", site: { id: 1 } },
+        ],
+      },
     }
 
     const wrapper = shallow(<SitePublishedBranchesTable {...props}/>)
@@ -19,30 +23,28 @@ describe("<SitePublishedBranchesTable/>", () => {
     expect(wrapper.find("table").contains("branch-b")).to.be.true
   })
 
-  it("shoud not render branches for another site", () => {
+  it("should render a loading state if branch data is loading", () => {
     const props = {
       params: { id: 1 },
-      publishedBranches: [
-        { name: "branch-a", viewLink: "www.example.gov/branch-a", site: { id: 1 } },
-        { name: "branch-b", viewLink: "www.example.gov/branch-b", site: { id: 2 } },
-      ]
+      publishedBranches: { isLoading: true }
     }
 
     const wrapper = shallow(<SitePublishedBranchesTable {...props}/>)
-    expect(wrapper.find("table")).to.have.length(1)
-    expect(wrapper.find("table").contains("branch-a")).to.be.true
-    expect(wrapper.find("table").contains("branch-b")).to.be.false
+    expect(wrapper.find("table")).to.have.length(0)
+    expect(wrapper.find(LoadingIndicator)).to.have.length(1)
   })
 
-  it("should render a loading state if there are no published branches", () => {
+  it("should render an empty state if there are no published branches", () => {
     const props = {
       params: { id: 1 },
-      publishedBranches: []
+      publishedBranches: { isLoading: false, data: [] }
     }
 
     const wrapper = shallow(<SitePublishedBranchesTable {...props}/>)
     expect(wrapper.find("table")).to.have.length(0)
     expect(wrapper.find("p")).to.have.length(1)
-    expect(wrapper.find("p").contains("No published branch data available")).to.be.true
+    expect(wrapper.find("p").contains(
+      "No branches have been published. Please wait for build to complete or check logs for error message."
+    )).to.be.true
   })
 })

--- a/test/frontend/reducers/publishedBranchesTest.js
+++ b/test/frontend/reducers/publishedBranchesTest.js
@@ -5,17 +5,19 @@ proxyquire.noCallThru();
 
 describe("publishedBranchesReducer", () => {
   let fixture
+  const PUBLISHED_BRANCHES_FETCH_STARTED = "🚦🏎"
   const PUBLISHED_BRANCHES_RECEIVED = "published branches received"
 
   beforeEach(() => {
     fixture = proxyquire("../../../frontend/reducers/publishedBranches", {
       "../actions/actionCreators/publishedBranchActions": {
+        publishedBranchesFetchStartedType: PUBLISHED_BRANCHES_FETCH_STARTED,
         publishedBranchesReceivedType: PUBLISHED_BRANCHES_RECEIVED,
       }
     }).default
   })
 
-  it("ignores other actions and returns an empty array", () => {
+  it("ignores other actions and returns an initial state", () => {
     const BRANCHES = ["Branch 1", "Branch 2"]
 
     const actual = fixture(undefined, {
@@ -23,28 +25,35 @@ describe("publishedBranchesReducer", () => {
       type: "the wrong type",
     })
 
-    expect(actual).to.deep.equal([])
+    expect(actual).to.deep.equal({ isLoading: false })
+  })
+
+  it("marks the state as loading when a fetch starts", () => {
+    const actual = fixture({ isLoading: false }, {
+      type: PUBLISHED_BRANCHES_FETCH_STARTED
+    })
+
+    expect(actual).to.deep.equal({ isLoading: true })
   })
 
   it("records the branches received in the action", () => {
     const BRANCHES = ["Branch 1", "Branch 2"]
 
-    const actual = fixture([], {
+    const actual = fixture({ isLoading: true }, {
       type: PUBLISHED_BRANCHES_RECEIVED,
       branches: BRANCHES,
     })
 
-    expect(actual).to.deep.equal(BRANCHES)
+    expect(actual).to.deep.equal({ isLoading: false, data: BRANCHES })
   })
 
-  it("overrides the branches received in the action", () => {
+  it("drops the current branches when a new fetch starts", () => {
     const BRANCHES = ["Branch 1", "Branch 2"]
 
-    const actual = fixture(["Branch 3"], {
-      type: PUBLISHED_BRANCHES_RECEIVED,
-      branches: BRANCHES,
+    const actual = fixture({ isLoading: false, data: ["Branch 3"] }, {
+      type: PUBLISHED_BRANCHES_FETCH_STARTED,
     })
 
-    expect(actual).to.deep.equal(BRANCHES)
+    expect(actual).to.deep.equal({ isLoading: true })
   })
 })


### PR DESCRIPTION
This commit changes the published branches redux state so it has an `isLoading` prop and `data` prop. This allows us to know if published branches are being loaded. The changes to the state are used to add a loading indicator to the published branch list if published branches are being downloaded.