### PR TITLE
Fix order of build array

### DIFF
--- a/api/controllers/build.js
+++ b/api/controllers/build.js
@@ -24,10 +24,7 @@ module.exports = {
       site = model
       return siteAuthorizer.findOne(req.user, site)
     }).then(() => {
-      return Build.findAll({
-        where: { site: site.id },
-        order: [["createdAt", "DESC"]],
-      })
+      return Build.findAll({ where: { site: site.id } })
     }).then(builds => {
       return buildSerializer.serialize(builds)
     }).then(buildsJSON => {

--- a/api/serializers/build.js
+++ b/api/serializers/build.js
@@ -3,7 +3,11 @@ const { Build, User, Site } = require("../models")
 const serialize = (serializable) => {
   if (serializable.length !== undefined) {
     const buildIds = serializable.map(build => build.id)
-    const query = Build.findAll({ where: { id: buildIds }, include: [ User, Site ] })
+    const query = Build.findAll({
+      where: { id: buildIds },
+      order: [["createdAt", "DESC"]],
+      include: [ User, Site ],
+    })
 
     return query.then(builds => {
       return builds.map(build => serializeObject(build))


### PR DESCRIPTION
The build array that was rendered by the build API was showing builds in an incorrect order. This was confusing because the builds query set the order in the correct manner.

It turned out the issue was that the build serializer was running another query that did not specify the order. This commit moves the code to set the order into the query in the build serializer.

Ref #898