### PR TITLE
Push build status back to GitHub

### DIFF
--- a/api/controllers/build.js
+++ b/api/controllers/build.js
@@ -39,6 +39,7 @@ module.exports = {
       branch: req.body["branch"],
       site: req.body["site"],
       user: req.user.id,
+      commitSha: req.body["commitSha"],
     }
     authorizer.create(req.user, params).then(() => {
       return Build.create(params)

--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -2,6 +2,7 @@ const crypto = require('crypto')
 const logger = require("winston")
 const config = require("../../config")
 const buildSerializer = require("../serializers/build")
+const GithubBuildStatusReporter = require("../services/GithubBuildStatusReporter")
 const { Build, User, Site } = require("../models")
 
 module.exports = {
@@ -14,7 +15,9 @@ module.exports = {
       if (!build) {
         res.ok("No new commits found. No build scheduled.")
       } else {
-        return buildSerializer.serialize(build)
+        return GithubBuildStatusReporter.reportBuildStatus(build).then(() =>{
+          return buildSerializer.serialize(build)
+        })
       }
     }).then(buildJSON => {
       if (buildJSON) {

--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -68,6 +68,7 @@ const createBuildForWebhookRequest = (request) => {
   }).then(() => {
     return Build.create({
       branch: request.body.ref.replace('refs/heads/', ''),
+      commitSha: request.body.after,
       site: buildParams.site.id,
       user: buildParams.user.id,
     })

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -33,26 +33,10 @@ const beforeValidate = (build) => {
 
 const completeJob = function(err) {
   const completedAt = new Date()
-  const { Site } = this.sequelize.models
 
-  if (err) {
-    return this.update({
-      state: "error",
-      error: completeJobErrorMessage(err),
-      completedAt: completedAt,
-    })
-  } else {
-    return this.update({
-      state: "success",
-      error: "",
-      completedAt: completedAt,
-    }).then(build => {
-      return Site.update(
-        { publishedAt: completedAt },
-        { where: { id: this.site } }
-      ).then(() => build)
-    })
-  }
+  return completeJobStateUpdate(err, this, completedAt).then(build => {
+    return completeJobSiteUpdate(build, completedAt).then(() => build)
+  })
 }
 
 const completeJobErrorMessage = (err) => {
@@ -63,6 +47,35 @@ const completeJobErrorMessage = (err) => {
     message = "An unknown error occured"
   }
   return sanitizeCompleteJobErrorMessage(message)
+}
+
+const completeJobSiteUpdate = (build, completedAt) => {
+  const { Site } = build.sequelize.models
+
+  if (build.state === "success") {
+    return Site.update(
+      { publishedAt: completedAt },
+      { where: { id: build.site } }
+    )
+  } else {
+    return Promise.resolve()
+  }
+}
+
+const completeJobStateUpdate = (err, build, completedAt) => {
+  if (err) {
+    return build.update({
+      state: "error",
+      error: completeJobErrorMessage(err),
+      completedAt: completedAt,
+    })
+  } else {
+    return build.update({
+      state: "success",
+      error: "",
+      completedAt: completedAt,
+    })
+  }
 }
 
 const generateToken = () => {

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -95,6 +95,9 @@ module.exports = (sequelize, DataTypes) => {
     branch: {
       type: DataTypes.STRING,
     },
+    commitSha: {
+      type: DataTypes.STRING,
+    },
     completedAt: {
       type: DataTypes.DATE,
     },

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -16,6 +16,7 @@ const toJSON = function() {
 
   delete object.githubAccessToken
   delete object.githubUserId
+  delete object.signedInAt
 
   object.createdAt = object.createdAt.toISOString()
   object.updatedAt = object.updatedAt.toISOString()
@@ -42,6 +43,9 @@ module.exports = (sequelize, DataTypes) => {
     },
     githubUserId: {
       type: DataTypes.STRING,
+    },
+    signedInAt: {
+      type: DataTypes.DATE,
     },
     username: {
       type: DataTypes.STRING,

--- a/api/services/GithubBuildStatusReporter.js
+++ b/api/services/GithubBuildStatusReporter.js
@@ -1,0 +1,104 @@
+const Github = require("github")
+const logger = require("winston")
+const url = require("url")
+const config = require("../../config")
+const { Build, Site, User } = require("../models")
+
+const reportBuildStatus = (build) => {
+  let site
+
+  return new Promise((resolve, reject) => {
+    if (!build || !build.commitSha) {
+      reject(new Error("Build or commit sha undefined. Unable to report build status"))
+    } else {
+      resolve()
+    }
+  }).then(() => {
+    return Site.findById(build.site)
+  }).then(model => {
+    if (!model) {
+      throw new Error("Unable to find a site for the given build")
+    }
+    site = model
+    return loadBuildUserAccessToken(build)
+  }).then(accessToken => {
+    githubClient = authenticateGithubClient(accessToken)
+
+    const options = {
+      user: site.owner,
+      repo: site.repository,
+      sha: build.commitSha,
+      context: "federalist/build"
+    }
+
+    if (build.state === "processing") {
+      options.state = "pending"
+      options.target_url = url.resolve(config.app.hostname, `/sites/${site.id}/builds/${build.id}/logs`)
+      options.description = "The build is running."
+    } else if (build.state === "success") {
+      options.state = "success"
+      options.target_url = site.viewLinkForBranch(build.branch)
+      options.description = "The build is complete!"
+    } else if (build.state === "error") {
+      options.state = "error"
+      options.target_url = url.resolve(config.app.hostname, `/sites/${site.id}/builds/${build.id}/logs`)
+      options.description = "The build has encountered an error."
+    }
+    return sendCreateGithubStatusRequest(githubClient, options)
+  }).catch(error => {
+    logger.error("Error reporting build status to GitHub: ", error)
+  })
+}
+
+const authenticateGithubClient = (accessToken) => {
+  let client = new Github({ version: "3.0.0" })
+  client.authenticate({
+    type: 'oauth',
+    token: accessToken
+  })
+  return client
+}
+
+const loadBuildUserAccessToken = (build) => {
+  return Build.findById(build.id, { include: [ Site, User ] }).then(build => {
+    const user = build.User
+
+    if (user.githubAccessToken) {
+      return user.githubAccessToken
+    } else {
+      return loadSiteUserAccessToken(build.Site)
+    }
+  })
+}
+
+const loadSiteUserAccessToken = (site) => {
+  return site.getUsers({
+    where: {
+      githubAccessToken: { $ne: null },
+      signedInAt: { $ne: null },
+    },
+    order: [[ "signedInAt", "DESC" ]],
+    limit: 1,
+  }).then(users => {
+    const user = users[0]
+    if (user && user.githubAccessToken) {
+      return user.githubAccessToken
+    } else {
+      throw new Error("Unable to find valid access token to report build status")
+    }
+  })
+}
+
+const sendCreateGithubStatusRequest = (githubClient, options) => {
+  return new Promise((resolve, reject) => {
+    githubClient.statuses.create(options, (err, res) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(res)
+      }
+    })
+  })
+}
+
+module.exports = { reportBuildStatus }

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -20,7 +20,8 @@ const githubVerifyCallback = (accessToken, refreshToken, profile, callback) => {
     if (!user) throw new Error(`Unable to find or create user ${profile.username}`);
     return user.update({
       githubAccessToken: accessToken,
-      githubUserId: profile.id
+      githubUserId: profile.id,
+      signedInAt: new Date(),
     })
   }).then(() => {
     callback(null, user)

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -64,6 +64,7 @@ export default {
       data: {
         site: build.site.id || build.site,
         branch: build.branch,
+        commitSha: build.commitSha,
       },
     });
   },

--- a/migrations/20170511173355-add-signed-in-at-to-user.js
+++ b/migrations/20170511173355-add-signed-in-at-to-user.js
@@ -1,0 +1,10 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  db.addColumn("user", "signedInAt", { type: "timestamp" }, callback)
+};
+
+exports.down = function(db, callback) {
+  db.removeColumn("user", "signedInAt", callback)
+};

--- a/migrations/20170511175918-add-commit-sha-to-build.js
+++ b/migrations/20170511175918-add-commit-sha-to-build.js
@@ -1,0 +1,10 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  db.addColumn("build", "commitSha", { type: "string" }, callback)
+};
+
+exports.down = function(db, callback) {
+  db.removeColumn("build", "commitSha", callback)
+};

--- a/public/swagger/Build.json
+++ b/public/swagger/Build.json
@@ -15,6 +15,9 @@
     "branch": {
       "type": ["string", "null"]
     },
+    "commitSha": {
+      "type": "string"
+    },
     "createdAt": {
       "type": "string"
     },

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -16,6 +16,7 @@ describe("Build API", () => {
     }
     expect(build.error == response.error).to.be.ok
     expect(build.branch == response.branch).to.be.ok
+    expect(build.commitSha == response.commitSha).to.be.ok
     expect(response.site.id).to.equal(build.site || build.Site.id)
     expect(response.user.id).to.equal(build.user || build.User.id)
     expect(response.buildLogs).to.be.undefined
@@ -56,7 +57,8 @@ describe("Build API", () => {
           .post(`/v0/build/`)
           .send({
             site: site.id,
-            branch: "my-branch"
+            branch: "my-branch",
+            commitSha: "test-commit-sha",
           })
           .set("Cookie", promisedValues.cookie)
           .expect(200)
@@ -67,6 +69,7 @@ describe("Build API", () => {
             site: site.id,
             user: user.id,
             branch: "my-branch",
+            commitSha: "test-commit-sha",
           }
         })
       }).then(build => {
@@ -84,7 +87,8 @@ describe("Build API", () => {
           .post(`/v0/build/`)
           .send({
             site: site.id,
-            branch: "my-branch"
+            branch: "my-branch",
+            commitSha: "test-commit-sha",
           })
           .set("Cookie", cookie)
           .expect(403)
@@ -113,7 +117,8 @@ describe("Build API", () => {
         error: "message",
         state: "error",
         branch: "18f-pages",
-        completedAt: new Date()
+        completedAt: new Date(),
+        commitSha: "json-test-commit-sha",
       }
 
       factory.build(buildAttributes).then(model => {

--- a/test/api/requests/webhook.test.js
+++ b/test/api/requests/webhook.test.js
@@ -1,9 +1,11 @@
 const crypto = require('crypto')
 const expect = require("chai").expect
+const nock = require("nock")
 const request = require("supertest-as-promised")
 const app = require("../../../app")
 const config = require("../../../config")
 const factory = require("../support/factory")
+const githubAPINocks = require("../support/githubAPINocks")
 const { Build, Site, User } = require("../../../api/models")
 
 
@@ -29,6 +31,11 @@ describe("Webhook API", () => {
   })
 
   describe("POST /webhook/github", () => {
+    beforeEach(() => {
+      nock.cleanAll()
+      githubAPINocks.status()
+    })
+
     it("should create a new site build for the sender", done => {
       let site, user, payload
 
@@ -122,6 +129,32 @@ describe("Webhook API", () => {
           .expect(200)
       }).then(response => {
         expect(response.body.site.id).to.equal(site.id)
+        done()
+      }).catch(done)
+    })
+
+    it("should report the status of the new build to GitHub", done => {
+      nock.cleanAll()
+      const statusNock = githubAPINocks.status({ state: "pending" })
+
+      const user = factory.user()
+      const site = factory.site({ users: Promise.all([user]) })
+      Promise.props({ user, site }).then(({ user, site }) => {
+        const payload = buildWebhookPayload(user, site)
+        payload.repository.full_name = `${site.owner.toUpperCase()}/${site.repository.toUpperCase()}`
+        const signature = signWebhookPayload(payload)
+
+        return request(app)
+          .post("/webhook/github")
+          .send(payload)
+          .set({
+            "X-GitHub-Event": "push",
+            "X-Hub-Signature": signature,
+            "X-GitHub-Delivery": "123abc"
+          })
+          .expect(200)
+      }).then(() => {
+        expect(statusNock.isDone()).to.be.true
         done()
       }).catch(done)
     })

--- a/test/api/support/factory/user.js
+++ b/test/api/support/factory/user.js
@@ -13,7 +13,8 @@ const _attributes = (overrides) => {
     email: `${username}@example.com`,
     username: username,
     githubAccessToken: "fake-access-token",
-    githubUserId: 12345
+    githubUserId: 12345,
+    signedInAt: new Date(),
   }, overrides)
 }
 

--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -132,6 +132,33 @@ const repo = ({ accessToken, owner, repo, response } = {}) => {
   return webhookNock.reply(...response)
 }
 
+const status = ({ accessToken, owner, repo, sha, state, targetURL } = {}) => {
+  let path
+  if (owner && repo && sha) {
+    path = `/repos/${owner}/${repo}/statuses/${sha}`
+  } else {
+    path = /\/repos\/.+\/.+\/statuses\/.+/
+  }
+
+  let statusNock = nock("https://api.github.com").post(path, body => {
+    if (state && body.state != state) {
+      return false
+    }
+    if (targetURL && body.target_url !== targetURL) {
+      return false
+    }
+    return true
+  })
+
+  if (accessToken) {
+    statusNock = statusNock.query({ access_token: accessToken })
+  } else {
+    statusNock = statusNock.query(true)
+  }
+
+  return statusNock.reply(201, { id: 1 })
+}
+
 const user = ({ accessToken, githubUserID, username, email } = {}) => {
   accessToken = accessToken || "access-token-123abc"
 
@@ -194,6 +221,7 @@ module.exports = {
   createRepoForUser,
   githubAuth,
   repo,
+  status,
   user,
   userOrganizations,
   webhook,

--- a/test/api/unit/services/GithubBuildStatusReporter.test.js
+++ b/test/api/unit/services/GithubBuildStatusReporter.test.js
@@ -1,0 +1,218 @@
+const crypto = require("crypto")
+const expect = require("chai").expect
+const nock = require("nock")
+const factory = require("../../support/factory")
+const githubAPINocks = require("../../support/githubAPINocks")
+const { Build, User } = require("../../../../api/models")
+
+const GithubBuildStatusReporter = require("../../../../api/services/GithubBuildStatusReporter")
+
+describe("GithubBuildStatusReporter", () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe("reportBuildStatus(build)", () => {
+    context("with a build in the processing state", () => {
+      it("should report that the status is 'pending'", done => {
+        let statusNock
+
+        factory.build({
+          state: "processing",
+          site: factory.site({ owner: "test-owner", repository: "test-repo" }),
+          commitSha: "456def",
+        }).then(build => {
+          statusNock = githubAPINocks.status({
+            owner: "test-owner",
+            repo: "test-repo",
+            repository: "test-repo",
+            sha: "456def",
+            state: "pending",
+          })
+
+          return GithubBuildStatusReporter.reportBuildStatus(build)
+        }).then(() => {
+          expect(statusNock.isDone()).to.be.true
+          done()
+        }).catch(done)
+      })
+
+      it("should set the target uri to the build logs", done => {
+        let statusNock
+
+        factory.build({
+          state: "processing",
+          site: factory.site({ owner: "test-owner", repository: "test-repo" }),
+          commitSha: "456def",
+        }).then(build => {
+          statusNock = githubAPINocks.status({
+            owner: "test-owner",
+            repo: "test-repo",
+            sha: "456def",
+            targetURL: `http://localhost:1337/sites/${build.site}/builds/${build.id}/logs`,
+          })
+
+          return GithubBuildStatusReporter.reportBuildStatus(build)
+        }).then(() => {
+          expect(statusNock.isDone()).to.be.true
+          done()
+        }).catch(done)
+      })
+    })
+
+    context("with a build in the success state", () => {
+      it("should report that the status is 'success'", done => {
+        let statusNock
+
+        factory.build({
+          state: "success",
+          site: factory.site({ owner: "test-owner", repository: "test-repo" }),
+          commitSha: "456def",
+        }).then(build => {
+          statusNock = githubAPINocks.status({
+            owner: "test-owner",
+            repo: "test-repo",
+            sha: "456def",
+            state: "success",
+          })
+
+          return GithubBuildStatusReporter.reportBuildStatus(build)
+        }).then(() => {
+          expect(statusNock.isDone()).to.be.true
+          done()
+        }).catch(done)
+      })
+
+      it("should set the target uri to the preview link", done => {
+        let statusNock
+
+        factory.build({
+          state: "success",
+          site: factory.site({ owner: "test-owner", repository: "test-repo" }),
+          commitSha: "456def",
+          branch: "preview-branch"
+        }).then(build => {
+          statusNock = githubAPINocks.status({
+            owner: "test-owner",
+            repo: "test-repo",
+            sha: "456def",
+            targetURL: `http://localhost:1337/preview/test-owner/test-repo/preview-branch`,
+          })
+
+          return GithubBuildStatusReporter.reportBuildStatus(build)
+        }).then(() => {
+          expect(statusNock.isDone()).to.be.true
+          done()
+        }).catch(done)
+      })
+    })
+
+    context("with a build in the error state", () => {
+      it("should report that the status is 'error'", done => {
+        let statusNock
+
+        factory.build({
+          state: "error",
+          site: factory.site({ owner: "test-owner", repository: "test-repo" }),
+          commitSha: "456def",
+        }).then(build => {
+          statusNock = githubAPINocks.status({
+            owner: "test-owner",
+            repo: "test-repo",
+            sha: "456def",
+            state: "error",
+          })
+
+          return GithubBuildStatusReporter.reportBuildStatus(build)
+        }).then(() => {
+          expect(statusNock.isDone()).to.be.true
+          done()
+        }).catch(done)
+      })
+
+      it("should set the target uri to the build logs", done => {
+        let statusNock
+
+        factory.build({
+          state: "error",
+          site: factory.site({ owner: "test-owner", repository: "test-repo" }),
+          commitSha: "456def",
+        }).then(build => {
+          statusNock = githubAPINocks.status({
+            owner: "test-owner",
+            repo: "test-repo",
+            sha: "456def",
+            targetURL: `http://localhost:1337/sites/${build.site}/builds/${build.id}/logs`,
+          })
+
+          return GithubBuildStatusReporter.reportBuildStatus(build)
+        }).then(() => {
+          expect(statusNock.isDone()).to.be.true
+          done()
+        }).catch(done)
+      })
+    })
+
+    context("with a build by a Federalist user", () => {
+      it("should use the GitHub access token of the build's user", done => {
+        let statusNock
+
+        factory.build({
+          state: "error",
+          user: factory.user({ githubAccessToken: "federalist-user-access-token" }),
+          site: factory.site({ owner: "test-owner", repository: "test-repo" }),
+          commitSha: "456def",
+        }).then(build => {
+          statusNock = githubAPINocks.status({
+            owner: "test-owner",
+            repo: "test-repo",
+            sha: "456def",
+            accessToken: "federalist-user-access-token",
+          })
+
+          return GithubBuildStatusReporter.reportBuildStatus(build)
+        }).then(() => {
+          expect(statusNock.isDone()).to.be.true
+          done()
+        }).catch(done)
+      })
+    })
+
+    context("with a build by a user outside Federalist", () => {
+      it("should use the access token of the site's most recently signed in user", done => {
+        let statusNock
+
+        const federalistUser = factory.user({
+          githubAccessToken: "fallback-access-token",
+          signedInAt: new Date(),
+        })
+        const githubUserName = `github-user-${crypto.randomBytes(8).toString("hex")}`
+        const githubUser = User.create({ username: githubUserName })
+        const site = factory.site({
+          owner: "test-owner",
+          repository: "test-repo",
+          users: Promise.all([ federalistUser, githubUser ])
+        })
+
+        factory.build({
+          state: "processing",
+          user: githubUser,
+          site,
+          commitSha: "456def",
+        }).then(build => {
+          statusNock = githubAPINocks.status({
+            owner: "test-owner",
+            repo: "test-repo",
+            sha: "456def",
+            accessToken: "fallback-access-token",
+          })
+
+          return GithubBuildStatusReporter.reportBuildStatus(build)
+        }).then(() => {
+          expect(statusNock.isDone()).to.be.true
+          done()
+        }).catch(done)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This commit adds a new service, the `GithubBuildStatusReporter`. This takes a build and uses the [GitHub status API](https://developer.github.com/v3/repos/statuses/) to push the build status back to GitHub. If the build is processing or errored, it also pushes a link to the build logs. If the build has completed successfully, it pushes a link to the preview link for the build.

Adding this required 2 changes:

First, I needed to add a `signedInAt` attribute to users. This lets us fetch users in the order they last signed in. This way, if the committing user is not a Federalist user, and we don't have an access token for them, we can instead use the access token of the last user to sign in, since that access token is likely to be the freshest.

Second, I added a `commitSha` attribute to the Build model. This was because the GitHub status API requires a commit sha in the request to tie builds to commits. I'm questioning this decision now, since it binds builds to commits, when the reality is that builds refer to branches, building the most recent commit on the branch. I may change this so it uses the most recent commit sha on the given branch.