### PR TITLE
[HOLD] Move demo builds to demo/<org>/<repo>

### DIFF
--- a/api/controllers/published-branch.js
+++ b/api/controllers/published-branch.js
@@ -22,6 +22,10 @@ module.exports = {
     }).then(() => {
       return S3PublishedFileLister.listPublishedPreviews(site)
     }).then(branchNames => {
+      if (site.demoBranch) {
+        branchNames = branchNames.filter(branchName => branchName != site.demoBranch)
+        branchNames = [site.demoBranch].concat(branchNames)
+      }
       branchNames = [site.defaultBranch].concat(branchNames)
       return PublishedBranchSerializer.serialize(site, branchNames)
     }).then(branches => {

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -119,7 +119,7 @@ module.exports = {
         branch: site.defaultBranch,
       })
     }).then(() => {
-      if (site.demoDomain && site.demoBranch) {
+      if (site.demoBranch) {
         return Build.create({
           user: req.user.id,
           site: siteId,

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -45,6 +45,9 @@ const toJSON = function() {
   const s3Config = config.s3
   object.siteRoot = `http://${s3Config.bucket}.s3-website-${s3Config.region}.amazonaws.com`
   object.viewLink = object.domain || [object.siteRoot, 'site', object.owner, object.repository].join('/')
+  if (object.demoBranch) {
+    object.demoViewLink = object.demoDomain || [object.siteRoot, 'demo', object.owner, object.repository].join('/')
+  }
 
   Object.keys(object).forEach(key => {
     if (object[key] === null) {
@@ -64,6 +67,8 @@ const viewLinkForBranch = function(branch) {
     return `${s3Root}/site/${this.owner}/${this.repository}`
   } else if (branch === this.demoBranch && this.demoDomain) {
     return this.demoDomain
+  } else if (branch === this.demoBranch) {
+    return `${s3Root}/demo/${this.owner}/${this.repository}`
   } else {
     return url.resolve(config.app.hostname, `/preview/${this.owner}/${this.repository}/${branch}`)
   }

--- a/api/services/S3PublishedFileLister.js
+++ b/api/services/S3PublishedFileLister.js
@@ -17,6 +17,8 @@ const listPublishedFilesForBranch = (site, branch) => {
   let filepath
   if (site.defaultBranch === branch) {
     filepath = `site/${site.owner}/${site.repository}`
+  } else if (site.demoBranch === branch) {
+    filepath = `demo/${site.owner}/${site.repository}`
   } else {
     filepath = `preview/${site.owner}/${site.repository}/${branch}`
   }

--- a/api/services/S3SiteRemover.js
+++ b/api/services/S3SiteRemover.js
@@ -11,9 +11,10 @@ const s3Client = new AWS.S3({
 const removeSite = site => {
   return Promise.all([
     getObjectsWithPrefix(`site/${site.owner}/${site.repository}`),
+    getObjectsWithPrefix(`demo/${site.owner}/${site.repository}`),
     getObjectsWithPrefix(`preview/${site.owner}/${site.repository}`),
   ]).then(objects => {
-    objects = objects[0].concat(objects[1])
+    objects = [].concat.apply([], objects)
     return deleteObjects(objects)
   })
 }

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -26,7 +26,7 @@ const buildContainerEnvironment = (build) => ({
 })
 
 const siteConfig = (build) => {
-  if (defaultBranch(build)) {
+  if (defaultBranch(build) || demoBranch(build)) {
     return build.Site.config
   } else {
     return build.Site.previewConfig
@@ -44,6 +44,8 @@ const demoBranch = (build) => {
 const pathForBuild = (build) => {
   if (defaultBranch(build)) {
     return `site/${build.Site.owner}/${build.Site.repository}`
+  } else if (demoBranch(build)) {
+    return `demo/${build.Site.owner}/${build.Site.repository}`
   } else {
     return `preview/${build.Site.owner}/${build.Site.repository}/${build.branch}`
   }

--- a/frontend/components/site/siteGithubBranchesTable.js
+++ b/frontend/components/site/siteGithubBranchesTable.js
@@ -47,8 +47,8 @@ const branchRow = ({ branch, site }) => (
 const previewURL = ({ branch, site }) => {
   if (branch.name === site.defaultBranch) {
     return site.viewLink
-  } else if (branch.name === site.demoBranch && site.demoDomain) {
-    return site.demoDomain
+  } else if (branch.name === site.demoBranch) {
+    return site.demoViewLink
   } else {
     return `/preview/${site.owner}/${site.repository}/${branch.name}/`
   }

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -19,6 +19,9 @@
     "demoDomain": {
       "type": "string"
     },
+    "demoViewLink": {
+      "type": "string"
+    },
     "config": {
       "type": "string"
     },

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -43,10 +43,10 @@ describe("Site model", () => {
     })
 
     context("for the demo branch", () => {
-      it("should return a federalist preview link if there is no demo domain", done => {
+      it("should return an s3 demo link if there is no demo domain", done => {
         factory.site({ demoBranch: "demo-branch" }).then(site => {
           const viewLink = site.viewLinkForBranch("demo-branch")
-          expect(viewLink).to.equal(`http://localhost:1337/preview/${site.owner}/${site.repository}/demo-branch`)
+          expect(viewLink).to.equal(`${s3BaseURL}/demo/${site.owner}/${site.repository}`)
           done()
         }).catch(done)
       })

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -191,7 +191,7 @@ describe("SQS", () => {
           return Build.findById(build.id, { include: [Site, User] })
         }).then(build => {
           const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "BASEURL")).to.equal("/preview/owner/repo/demo")
+          expect(messageEnv(message, "BASEURL")).to.equal("/demo/owner/repo")
           done()
         }).catch(done)
       })
@@ -223,14 +223,14 @@ describe("SQS", () => {
         }).catch(done)
       })
 
-      it("should set SITE_PREFIX in the message to 'preview/:owner/:repo/:branch'", done => {
+      it("should set SITE_PREFIX in the message to 'demo/:owner/:repo'", done => {
         factory.site({ demoDomain: "", owner: "owner", repository: "repo", demoBranch: "demo" }).then(site => {
           return factory.build({ site: site, branch: "demo" })
         }).then(build => {
           return Build.findById(build.id, { include: [Site, User] })
         }).then(build => {
           const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "SITE_PREFIX")).to.equal("preview/owner/repo/demo")
+          expect(messageEnv(message, "SITE_PREFIX")).to.equal("demo/owner/repo")
           done()
         }).catch(done)
       })
@@ -303,6 +303,22 @@ describe("SQS", () => {
         previewConfig: "plugins_dir: _preview_plugins",
       }).then(site => {
         return factory.build({ site, branch: "master" })
+      }).then(build => {
+        return Build.findById(build.id, { include: [Site, User] })
+      }).then(build => {
+        const message = SQS.messageBodyForBuild(build)
+        expect(messageEnv(message, "CONFIG")).to.equal("plugins_dir: _plugins")
+        done()
+      }).catch(done)
+    })
+
+    it("should set CONFIG in the message to the YAML config for the site on a demo branch", done => {
+      factory.site({
+        demoBranch: "demo",
+        config: "plugins_dir: _plugins",
+        previewConfig: "plugins_dir: _preview_plugins",
+      }).then(site => {
+        return factory.build({ site, branch: "demo" })
       }).then(build => {
         return Build.findById(build.id, { include: [Site, User] })
       }).then(build => {

--- a/test/frontend/components/site/siteGithubBranchesTable.test.js
+++ b/test/frontend/components/site/siteGithubBranchesTable.test.js
@@ -59,14 +59,14 @@ describe("<SiteGithubBranchesTable/>", () => {
     ]
     props.site ={
       demoBranch: "demo",
-      demoDomain: "demo.example.com",
+      demoViewLink: "demo.example.com",
     };
 
     const wrapper = shallow(<SiteGithubBranchesTable {...props}/>);
     const link = wrapper.find("a");
 
     expect(link.contains("View")).to.be.true;
-    expect(link.prop("href")).to.equal(props.site.demoDomain);
+    expect(link.prop("href")).to.equal(props.site.demoViewLink);
   })
 
   it("renders the the preview URL for preview branches", () => {


### PR DESCRIPTION
This commit changes the backend so that demo builds have their own folder in the S3 bucket. This will be helpful for pending changes that will redirect preview requests to the Federalist Proxy, since at that point preview and demo URLs will need to handle trailing slashes in a different manner.

Changes include:

- Change site model `viewLinkForBranch` to return new URL format for demo branches
- Change the SQS service to configure demo builds to build at `demo/<org>/<repo>
- Change the published branch API to render demo URLs for demo branches
- Change the published file API to look for demo branch files in the demo branch folder
- Change the S3 site remover to delete files from the demo branch folder
- Add `demoViewLink` prop to site API response
- Change the `SiteGitHubBranchTable` component to use the `demoViewLink` for demo branches