### PR TITLE
Run linter on CI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,4 @@
 {
-  "extends": "airbnb/legacy",
-  "rules": {
-    "comma-dangle": ["error", "always-multiline"],
-    "no-inner-declarations": ["error", "functions"],
-    "quotes": ["error", "double", { "allowTemplateLiterals": true }],
-    "semi": ["error", "never"],
-  },
+  "extends": "airbnb",
   "parser": "babel-eslint",
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
   - rvm install ruby-1.9.3-p551
 before_script:
   - "psql -c 'create database travis_ci_test;' -U postgres"
+script:
+  - npm test
+  - scripts/lint-travis.sh
 env:
   global:
   - CF_API="https://api.fr.cloud.gov"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "license": "Public Domain",
   "devDependencies": {
     "autoprefixer": "^6.5.1",
-    "babel-eslint": "^7.2.2",
+    "babel-eslint": "^7.2.3",
     "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",

--- a/scripts/lint-travis.sh
+++ b/scripts/lint-travis.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  exit 0
+fi;
+
+CHANGED_FILES_LIST=`git diff-index --name-only $TRAVIS_BRANCH | grep -E '.js$|.jsx$' | tr '\n' ' '`
+
+FAILURES=0
+
+for FILE in $CHANGED_FILES_LIST; do
+  `npm bin`/eslint $FILE
+  if [ "$?" != 0 ]; then
+    FAILURES=$(($FAILURES+1))
+  fi
+done
+
+echo "ESLint found $FAILURES file(s) with errors"
+
+exit $FAILURES


### PR DESCRIPTION
This commit tells Travis to run ESLint on all changed files when a build runs for a PR. It will fail the build if the linter finds any errors.