### PR TITLE
Coalesce env vars that depend on the apps hostname

### DIFF
--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -1,11 +1,64 @@
-const AWS = require('aws-sdk')
-const logger = require("winston")
-const url = require("url")
-const config = require("../../config")
-const buildConfig = config.build
-const s3Config = config.s3
+const AWS = require('aws-sdk');
+const logger = require('winston');
+const url = require('url');
+const config = require('../../config');
 
-const buildContainerEnvironment = (build) => ({
+const buildConfig = config.build;
+const s3Config = config.s3;
+
+const defaultBranch = build => build.branch === build.Site.defaultBranch;
+const demoBranch = build => build.branch === build.Site.demoBranch;
+
+const siteConfig = (build) => {
+  if (defaultBranch(build) || demoBranch(build)) {
+    return build.Site.config;
+  }
+  return build.Site.previewConfig;
+};
+
+const pathForBuild = (build) => {
+  if (defaultBranch(build)) {
+    return `site/${build.Site.owner}/${build.Site.repository}`;
+  } else if (demoBranch(build)) {
+    return `demo/${build.Site.owner}/${build.Site.repository}`;
+  }
+  return `preview/${build.Site.owner}/${build.Site.repository}/${build.branch}`;
+};
+
+const baseURLForCustomDomain = (rawDomain) => {
+  let domain = rawDomain;
+  if (!domain.match(/https?:\/\//)) {
+    domain = `https://${domain}`;
+  }
+  return url.parse(domain).path.replace(/\/$/, '');
+};
+
+const baseURLForBuild = (build) => {
+  if (defaultBranch(build) && build.Site.domain) {
+    return baseURLForCustomDomain(build.Site.domain);
+  } else if (demoBranch(build) && build.Site.demoDomain) {
+    return baseURLForCustomDomain(build.Site.demoDomain);
+  }
+  return `/${pathForBuild(build)}`;
+};
+
+const statusCallbackURL = build => [
+  url.resolve(config.app.hostname, '/v0/build'),
+  build.id,
+  'status',
+  build.token,
+].join('/');
+
+const buildLogCallbackURL = build => [
+  url.resolve(config.app.hostname, '/v0/build'),
+  build.id,
+  'log',
+  build.token,
+].join('/');
+
+const sourceForBuild = build => build.source || {};
+
+const buildContainerEnvironment = build => ({
   AWS_DEFAULT_REGION: s3Config.region,
   AWS_ACCESS_KEY_ID: s3Config.accessKeyId,
   AWS_SECRET_ACCESS_KEY: s3Config.secretAccessKey,
@@ -23,106 +76,39 @@ const buildContainerEnvironment = (build) => ({
   GENERATOR: build.Site.engine,
   SOURCE_REPO: sourceForBuild(build).repository,
   SOURCE_OWNER: sourceForBuild(build).owner,
-})
+});
 
-const siteConfig = (build) => {
-  if (defaultBranch(build) || demoBranch(build)) {
-    return build.Site.config
-  } else {
-    return build.Site.previewConfig
-  }
-}
-
-const statusCallbackURL = (build) => {
-  return [
-    url.resolve(config.app.hostname, "/v0/build"),
-    build.id,
-    "status",
-    build.token,
-  ].join("/")
-}
-
-const buildLogCallbackURL = (build) => {
-  return [
-    url.resolve(config.app.hostname, "/v0/build"),
-    build.id,
-    "log",
-    build.token,
-  ].join("/")
-}
-
-const defaultBranch = (build) => {
-  return build.branch === build.Site.defaultBranch
-}
-
-const demoBranch = (build) => {
-  return build.branch === build.Site.demoBranch
-}
-
-const pathForBuild = (build) => {
-  if (defaultBranch(build)) {
-    return `site/${build.Site.owner}/${build.Site.repository}`
-  } else if (demoBranch(build)) {
-    return `demo/${build.Site.owner}/${build.Site.repository}`
-  } else {
-    return `preview/${build.Site.owner}/${build.Site.repository}/${build.branch}`
-  }
-}
-
-const baseURLForBuild = (build) => {
-  if (defaultBranch(build) && build.Site.domain) {
-    return baseURLForCustomDomain(build.Site.domain)
-  } else if (demoBranch(build) && build.Site.demoDomain) {
-    return baseURLForCustomDomain(build.Site.demoDomain)
-  } else {
-    return "/" + pathForBuild(build)
-  }
-}
-
-const baseURLForCustomDomain = (domain) => {
-  if (!domain.match(/https?\:\/\//)) {
-    domain = "https://" + domain
-  }
-  return url.parse(domain).path.replace(/\/$/, "")
-}
-
-const sourceForBuild = (build) => {
-  return build.source || {}
-}
-
-const sqsConfig = config.sqs
+const sqsConfig = config.sqs;
 const SQS = {
   sqsClient: new AWS.SQS({
     accessKeyId: sqsConfig.accessKeyId,
     secretAccessKey: sqsConfig.secretAccessKey,
     region: sqsConfig.region,
   }),
-}
+};
 
 SQS.messageBodyForBuild = (build) => {
-  var environment = buildContainerEnvironment(build)
+  const environment = buildContainerEnvironment(build);
   return {
-    environment: Object.keys(environment).map(key => {
-      return {
-        name: key,
-        value: environment[key]
-      }
-    }),
-    name: buildConfig.containerName
-  }
-}
+    environment: Object.keys(environment).map(key => ({
+      name: key,
+      value: environment[key],
+    })),
+    name: buildConfig.containerName,
+  };
+};
 
-SQS.sendBuildMessage = build => {
-  var params = {
+SQS.sendBuildMessage = (build) => {
+  const params = {
     QueueUrl: sqsConfig.queue,
-    MessageBody: JSON.stringify(SQS.messageBodyForBuild(build))
-  }
-  SQS.sqsClient.sendMessage(params, function(err, data) {
+    MessageBody: JSON.stringify(SQS.messageBodyForBuild(build)),
+  };
+  SQS.sqsClient.sendMessage(params, (err) => {
     if (err) {
-      logger.error("There was an error, adding the job to SQS: ", err);
+      logger.error('There was an error, adding the job to SQS: ', err);
       build.completeJob(err);
     }
-  })
-}
+  });
+};
 
-module.exports = SQS
+module.exports = SQS;

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -9,8 +9,8 @@ const buildContainerEnvironment = (build) => ({
   AWS_DEFAULT_REGION: s3Config.region,
   AWS_ACCESS_KEY_ID: s3Config.accessKeyId,
   AWS_SECRET_ACCESS_KEY: s3Config.secretAccessKey,
-  STATUS_CALLBACK: buildConfig.statusCallback.replace(":build_id", build.id).replace(":token", build.token),
-  LOG_CALLBACK: buildConfig.logCallback.replace(":build_id", build.id).replace(":token", build.token),
+  STATUS_CALLBACK: statusCallbackURL(build),
+  LOG_CALLBACK: buildLogCallbackURL(build),
   BUCKET: s3Config.bucket,
   BASEURL: baseURLForBuild(build),
   CACHE_CONTROL: buildConfig.cacheControl,
@@ -31,6 +31,24 @@ const siteConfig = (build) => {
   } else {
     return build.Site.previewConfig
   }
+}
+
+const statusCallbackURL = (build) => {
+  return [
+    url.resolve(config.app.hostname, "/v0/build"),
+    build.id,
+    "status",
+    build.token,
+  ].join("/")
+}
+
+const buildLogCallbackURL = (build) => {
+  return [
+    url.resolve(config.app.hostname, "/v0/build"),
+    build.id,
+    "log",
+    build.token,
+  ].join("/")
 }
 
 const defaultBranch = (build) => {

--- a/config/build.js
+++ b/config/build.js
@@ -1,9 +1,10 @@
 /*
  * Settings the build process
  */
-var envFn = require('../services/environment.js');
-var env = envFn();
+const envFn = require('../services/environment.js');
+
+const env = envFn();
 
 module.exports = {
   cacheControl: env.FEDERALIST_CACHE_CONTROL || 'max-age=60',
-}
+};

--- a/config/build.js
+++ b/config/build.js
@@ -6,6 +6,4 @@ var env = envFn();
 
 module.exports = {
   cacheControl: env.FEDERALIST_CACHE_CONTROL || 'max-age=60',
-  statusCallback: env.FEDERALIST_BUILD_STATUS_CALLBACK || 'http://localhost:1337/v0/build/:build_id/status/:token',
-  logCallback: env.FEDERALIST_BUILD_LOG_CALLBACK || 'http://localhost:1337/v0/build/:build_id/log/:token',
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -19,8 +19,4 @@ env:
   LOG_LEVEL: info
   NPM_CONFIG_PRODUCTION: true
   NODE_MODULES_CACHE: false
-  APP_NAME: federalist
-  APP_DOMAIN: fr.cloud.gov
-  FEDERALIST_BUILD_STATUS_CALLBACK: https://federalist.18f.gov/v0/build/:build_id/status/:token
-  FEDERALIST_BUILD_LOG_CALLBACK: https://federalist.18f.gov/v0/build/:build_id/log/:token
   FEDERALIST_PREVIEW_HOSTNAME: https://federalist-proxy.app.cloud.gov

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -19,8 +19,4 @@ env:
   LOG_LEVEL: verbose
   NPM_CONFIG_PRODUCTION: true
   NODE_MODULES_CACHE: false
-  APP_NAME: federalist-staging
-  APP_DOMAIN: fr.cloud.gov
-  FEDERALIST_BUILD_STATUS_CALLBACK: https://federalist-staging.fr.cloud.gov/v0/build/:build_id/status/:token
-  FEDERALIST_BUILD_LOG_CALLBACK: https://federalist-staging.fr.cloud.gov/v0/build/:build_id/log/:token
   FEDERALIST_PREVIEW_HOSTNAME: https://federalist-proxy-staging.app.cloud.gov


### PR DESCRIPTION
There are a number of env vars whose values are function of the app's hostname. Traditionally, these vars have been added to the env as such:

```
FEDERALIST_BUILD_STATUS_CALLBACK='https://federalist-staging.fr.cloud.gov/v0/build/:build_id/status/:token'
```

Since the only variable in these env vars is Federalist's hostname, it makes sense to remove them and use the hostname env var to build them at runtime. This commit does the work to that end.

- Remove unused `APP_NAME` and `APP_DOMAIN` vars
- Remove build container callback vars and build URLs inline when creating message body