### PR TITLE
Add small margin-top to usa-disclaimer-official

### DIFF
--- a/public/styles/sass/_header.scss
+++ b/public/styles/sass/_header.scss
@@ -107,3 +107,7 @@ $logo-height: 29px;
 .header .usa-button {
   margin-top: 0;
 }
+
+.usa-disclaimer-official {
+  margin-top: 3px;
+}

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -442,6 +442,9 @@ nav li a:visited {
 .header .usa-button {
   margin-top: 0; }
 
+.usa-disclaimer-official {
+  margin-top: 3px; }
+
 .hero {
   background-color: #618ec8;
   background-image: url("/images/essay-blue.png");


### PR DESCRIPTION
This PR adds a `margin-top: 3px` to the `.usa-disclaimer-official` class so that the top of that little banner doesn't touch the top of the browser viewport.

Before:
<img width="403" alt="screen shot 2017-05-23 at 2 59 57 pm" src="https://cloud.githubusercontent.com/assets/697848/26373821/ac950d4c-3fc8-11e7-9112-028978ab3bff.png">

After:
<img width="415" alt="screen shot 2017-05-23 at 2 59 49 pm" src="https://cloud.githubusercontent.com/assets/697848/26373817/a85dffe0-3fc8-11e7-9eef-f2b18cab1375.png">
