### PR TITLE
Remove beta notice from top banner

### DIFF
--- a/frontend/components/disclaimer.js
+++ b/frontend/components/disclaimer.js
@@ -4,10 +4,13 @@ const Disclaimer = () =>
   <div className="usa-disclaimer">
     <div className="usa-grid">
       <span className="usa-disclaimer-official">
-        <img className="usa-flag_icon" alt="US flag signifying that this is a United States Federal Government website" src="/images/uswds/us_flag_small.png" />
+        <img
+          className="usa-flag_icon"
+          alt="US flag signifying that this is a United States Federal Government website"
+          src="/images/uswds/us_flag_small.png"
+        />
         An official website of the United States Government
       </span>
-      <span className="usa-disclaimer-stage">This site is currently in beta. <a href="https://18f.gsa.gov/dashboard/stages/#beta">Learn more.</a></span>
     </div>
   </div>;
 


### PR DESCRIPTION
(replaces #962)

Removes the beta notice from the top site banner.