### PR TITLE
Fix issue where Federalist was creating org sites instead of user sites

### DIFF
--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -1,184 +1,162 @@
-const Github = require("github")
-const config = require("../../config")
-const { User } = require("../models")
+const Github = require('github');
+const config = require('../../config');
+const { User } = require('../models');
 
-const createRepoForOrg = (github, options) => {
-  return new Promise((resolve, reject) => {
-    github.repos.createFromOrg(options, (err, res) => {
-      if (err) {
-        err.status = err.code
-        reject(err)
-      } else {
-        resolve(res)
-      }
-    })
-  })
-}
+const createRepoForOrg = (github, options) => new Promise((resolve, reject) => {
+  github.repos.createFromOrg(options, (err, res) => {
+    if (err) {
+      reject(Object.assign(err, { status: err.code }));
+    } else {
+      resolve(res);
+    }
+  });
+});
 
-const createRepoForUser = (github, options) => {
-  return new Promise((resolve, reject) => {
-    github.repos.create(options, (err, res) => {
-      if (err) {
-        err.status = err.code
-        reject(err)
-      } else {
-        resolve(res)
-      }
-    })
-  })
-}
+const createRepoForUser = (github, options) => new Promise((resolve, reject) => {
+  github.repos.create(options, (err, res) => {
+    if (err) {
+      reject(Object.assign(err, { status: err.code }));
+    } else {
+      resolve(res);
+    }
+  });
+});
 
-const createWebhook = (github, options) => {
-  return new Promise((resolve, reject) => {
-    github.repos.createHook(options, (err, res) => {
-      if (err) {
-        err.status = err.code
-        reject(err)
-      } else {
-        resolve(res)
-      }
-    })
-  })
-}
+const createWebhook = (github, options) => new Promise((resolve, reject) => {
+  github.repos.createHook(options, (err, res) => {
+    if (err) {
+      reject(Object.assign(err, { status: err.code }));
+    } else {
+      resolve(res);
+    }
+  });
+});
 
-const getOrganizations = (github) => {
-  return new Promise((resolve, reject) => {
-    github.user.getOrgs({}, (err, organizations) => {
-      if (err) {
-        err.status = err.code
-        reject(err)
-      } else {
-        resolve(organizations)
-      }
-    })
-  })
-}
+const getOrganizations = github => new Promise((resolve, reject) => {
+  github.user.getOrgs({}, (err, organizations) => {
+    if (err) {
+      reject(Object.assign(err, { status: err.code }));
+    } else {
+      resolve(organizations);
+    }
+  });
+});
 
-const getRepository = (github, options) => {
-  return new Promise((resolve, reject) => {
-    github.repos.get(options, (err, repo) => {
-      if (err) {
-        err.status = err.code
-        reject(err)
-      } else {
-        resolve(repo)
-      }
-    })
-  })
-}
+const getRepository = (github, options) => new Promise((resolve, reject) => {
+  github.repos.get(options, (err, repo) => {
+    if (err) {
+      reject(Object.assign(err, { status: err.code }));
+    } else {
+      resolve(repo);
+    }
+  });
+});
 
-const githubClient = (accessToken) => {
-  return new Promise((resolve, reject) => {
-    let client = new Github({ version: "3.0.0" })
-    client.authenticate({
-      type: 'oauth',
-      token: accessToken
-    })
-    resolve(client)
-  })
-}
+const githubClient = accessToken => new Promise((resolve) => {
+  const client = new Github({ version: '3.0.0' });
+  client.authenticate({
+    type: 'oauth',
+    token: accessToken,
+  });
+  resolve(client);
+});
 
-const handleCreateRepoError = (error) => {
-  const REPO_EXISTS_MESSAGE = "name already exists on this account"
+const parseGithubErrorMessage = (error) => {
+  let githubError = 'Encounted an unexpected GitHub error';
 
-  const githubError = parseGithubErrorMessage(error)
-
-  if (githubError === REPO_EXISTS_MESSAGE) {
-    error.status = 400
-    error.message = "A repo with that name already exists."
-  } else if (githubError && error.code === 403) {
-    error.status = 400
-    error.message = githubError
+  try {
+    githubError = JSON.parse(error.message).errors[0].message;
+  } catch (e) {
+    try {
+      githubError = JSON.parse(error.message).message;
+    } catch (e2) { /* noop */ }
   }
 
-  throw error
-}
+  return githubError;
+};
 
-const handleWebhookError = (error) => {
-  const HOOK_EXISTS_MESSAGE = "Hook already exists on this repository"
-  const NO_ACCESS_MESSAGE = "Not Found"
-  const NO_ADMIN_ACCESS_ERROR_MESSAGE = "You do not have admin access to this repository"
+const handleCreateRepoError = (err) => {
+  const error = err;
 
-  const githubError = parseGithubErrorMessage(error)
+  const REPO_EXISTS_MESSAGE = 'name already exists on this account';
+
+  const githubError = parseGithubErrorMessage(error);
+
+  if (githubError === REPO_EXISTS_MESSAGE) {
+    error.status = 400;
+    error.message = 'A repo with that name already exists.';
+  } else if (githubError && error.code === 403) {
+    error.status = 400;
+    error.message = githubError;
+  }
+
+  throw error;
+};
+
+const handleWebhookError = (err) => {
+  const error = err;
+
+  const HOOK_EXISTS_MESSAGE = 'Hook already exists on this repository';
+  const NO_ACCESS_MESSAGE = 'Not Found';
+  const NO_ADMIN_ACCESS_ERROR_MESSAGE = 'You do not have admin access to this repository';
+
+  const githubError = parseGithubErrorMessage(error);
 
   if (githubError === HOOK_EXISTS_MESSAGE) {
     // noop
-    return
   } else if (githubError === NO_ACCESS_MESSAGE) {
-    const error = new Error(NO_ADMIN_ACCESS_ERROR_MESSAGE)
-    error.status = 400
-    throw error
+    const adminAccessError = new Error(NO_ADMIN_ACCESS_ERROR_MESSAGE);
+    adminAccessError.status = 400;
+    throw adminAccessError;
   } else {
-    throw error
+    throw error;
   }
-}
-
-const parseGithubErrorMessage = (error) => {
-  let githubError = "Encounted an unexpected GitHub error"
-
-  try {
-    githubError = JSON.parse(error.message).errors[0].message
-  } catch(e) {
-    try {
-      githubError = JSON.parse(error.message).message
-    } catch(e) {}
-  }
-
-  return githubError
-}
+};
 
 module.exports = {
-  checkPermissions: (user, owner, repository) => {
-    return githubClient(user.githubAccessToken).then(github => {
-      return getRepository(github, {
-        user: owner,
-        repo: repository,
-      })
-    }).then(repository => {
-      return repository.permissions
-    })
-  },
+  checkPermissions: (user, owner, repository) =>
+    githubClient(user.githubAccessToken)
+      .then(github => getRepository(github, { user: owner, repo: repository }))
+      .then(fetchedRepository => fetchedRepository.permissions),
 
-  createRepo: (user, owner, repository) => {
-    return githubClient(user.githubAccessToken).then(github => {
-      if (user.username.toLowerCase() === owner.toLowerCase()) {
-        return createRepoForUser(github, {
-          name: repository,
-        })
-      } else {
+  createRepo: (user, owner, repository) =>
+    githubClient(user.githubAccessToken)
+      .then((github) => {
+        if (user.username.toLowerCase() === owner.toLowerCase()) {
+          return createRepoForUser(github, {
+            name: repository,
+          });
+        }
+
         return createRepoForOrg(github, {
           name: repository,
           org: owner,
-        })
-      }
-    }).catch(err => {
-      handleCreateRepoError(err)
-    })
-  },
+        });
+      })
+      .catch(handleCreateRepoError),
 
-  getRepository: (user, owner, repository) => {
-    return githubClient(user.githubAccessToken).then(github => {
-      return getRepository(github, {
+  getRepository: (user, owner, repository) =>
+    githubClient(user.githubAccessToken)
+      .then(github => getRepository(github, {
         user: owner,
         repo: repository,
-      })
-    }).catch(err => {
-      if (err.status === 404) {
-        return null
-      } else {
-        throw err
-      }
-    })
-  },
+      }))
+      .catch((err) => {
+        if (err.status === 404) {
+          return null;
+        }
+        throw err;
+      }),
 
   setWebhook: (site, user) => {
-    const userId = user.id || user
+    const userId = user.id || user;
 
-    return User.findById(userId).then(model => {
-      user = model
-      return githubClient(user.githubAccessToken)
-    }).then(github => {
-      return createWebhook(github, {
+    return User.findById(userId)
+      .then((model) => {
+        const fetchedFederalistUser = model;
+        return githubClient(fetchedFederalistUser.githubAccessToken);
+      })
+      .then(github => createWebhook(github, {
         user: site.owner,
         repo: site.repository,
         name: 'web',
@@ -186,27 +164,25 @@ module.exports = {
         config: {
           url: config.webhook.endpoint,
           secret: config.webhook.secret,
-          content_type: 'json'
-        }
-      })
-    }).catch(err => {
-      handleWebhookError(err)
-    })
+          content_type: 'json',
+        },
+      }))
+      .catch(handleWebhookError);
   },
 
   validateUser: (accessToken) => {
-    var approvedOrgs = config.passport.github.organizations || []
+    const approvedOrgs = config.passport.github.organizations || [];
 
-    return githubClient(accessToken).then(github => {
-      return getOrganizations(github)
-    }).then(organizations => {
-      const approvedOrg = organizations.find(organization => {
-        return approvedOrgs.indexOf(organization.id) >= 0
-      })
+    return githubClient(accessToken)
+      .then(github => getOrganizations(github))
+      .then((organizations) => {
+        const approvedOrg = organizations.find(organization =>
+          approvedOrgs.indexOf(organization.id) >= 0
+        );
 
-      if (!approvedOrg) {
-        throw new Error("Unauthorized")
-      }
-    })
+        if (!approvedOrg) {
+          throw new Error('Unauthorized');
+        }
+      });
   },
-}
+};

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -114,6 +114,8 @@ const handleWebhookError = (error) => {
 }
 
 const parseGithubErrorMessage = (error) => {
+  let githubError = "Encounted an unexpected GitHub error"
+
   try {
     githubError = JSON.parse(error.message).errors[0].message
   } catch(e) {
@@ -139,7 +141,7 @@ module.exports = {
 
   createRepo: (user, owner, repository) => {
     return githubClient(user.githubAccessToken).then(github => {
-      if (user.username === owner) {
+      if (user.username.toLowerCase() === owner.toLowerCase()) {
         return createRepoForUser(github, {
           name: repository,
         })

--- a/test/api/unit/services/GitHub.test.js
+++ b/test/api/unit/services/GitHub.test.js
@@ -1,255 +1,267 @@
-const expect = require("chai").expect
-const config = require("../../../../config")
-const factory = require("../../support/factory")
-const GitHub = require("../../../../api/services/GitHub")
-const githubAPINocks = require("../../support/githubAPINocks")
+const expect = require('chai').expect;
+const config = require('../../../../config');
+const factory = require('../../support/factory');
+const GitHub = require('../../../../api/services/GitHub');
+const githubAPINocks = require('../../support/githubAPINocks');
 
-describe("GitHub", () => {
-  describe(".getRepository(user, owner, repository)", () => {
-    it("should resolve with the repository data if the repo exists", done => {
-      factory.user().then(user => {
+describe('GitHub', () => {
+  describe('.getRepository(user, owner, repository)', () => {
+    it('should resolve with the repository data if the repo exists', (done) => {
+      factory.user().then((user) => {
         githubAPINocks.repo({
           accessToken: user.accessToken,
-          owner: "repo-owner",
-          repo: "repo-name",
+          owner: 'repo-owner',
+          repo: 'repo-name',
           response: [200, {
-            "name": "repo-name",
-            "owner": {
-              "login": "repo-owner",
+            name: 'repo-name',
+            owner: {
+              login: 'repo-owner',
             },
-            "meta": {},
+            meta: {},
           }],
-        })
+        });
 
-        return GitHub.getRepository(user, "repo-owner", "repo-name")
-      }).then(data => {
+        return GitHub.getRepository(user, 'repo-owner', 'repo-name');
+      }).then((data) => {
         expect(data).to.deep.equal({
-          "name": "repo-name",
-          "owner": {
-            "login": "repo-owner",
+          name: 'repo-name',
+          owner: {
+            login: 'repo-owner',
           },
-          "meta": {},
-        })
-        done()
-      }).catch(done)
-    })
+          meta: {},
+        });
+        done();
+      }).catch(done);
+    });
 
-    it("should resolve with null if the repo does not exist", done => {
-      factory.user().then(user => {
+    it('should resolve with null if the repo does not exist', (done) => {
+      factory.user().then((user) => {
         githubAPINocks.repo({
           accessToken: user.accessToken,
-          owner: "repo-owner",
-          repo: "repo-name",
+          owner: 'repo-owner',
+          repo: 'repo-name',
           response: [404, {
-            "message": "Not Found",
-            "documentation_url": "https://developer.github.com/v3",
+            message: 'Not Found',
+            documentation_url: 'https://developer.github.com/v3',
           }],
-        })
+        });
 
-        return GitHub.getRepository(user, "repo-owner", "repo-name")
-      }).then(result => {
-        expect(result).to.be.null
-        done()
-      }).catch(done)
-    })
-  })
+        return GitHub.getRepository(user, 'repo-owner', 'repo-name');
+      }).then((result) => {
+        expect(result).to.be.null;
+        done();
+      }).catch(done);
+    });
+  });
 
-  describe(".createRepository(user, owner, repository)", () => {
-    it("should create a repository for the user if the user is the owner", done => {
-      let createRepoNock
+  describe('.createRepository(user, owner, repository)', () => {
+    it('should create a repository for the user if the user is the owner', (done) => {
+      let createRepoNock;
 
-      factory.user().then(user => {
+      factory.user().then((user) => {
         createRepoNock = githubAPINocks.createRepoForUser({
           accessToken: user.accessToken,
-          repo: "repo-name",
-        })
+          repo: 'repo-name',
+        });
 
-        return GitHub.createRepo(user, user.username, "repo-name")
+        return GitHub.createRepo(user, user.username, 'repo-name');
       }).then(() => {
-        expect(createRepoNock.isDone()).to.equal(true)
-        done()
-      }).catch(done)
-    })
+        expect(createRepoNock.isDone()).to.equal(true);
+        done();
+      }).catch(done);
+    });
 
-    it("should create a repository for an org if the user is not the owner", done => {
-      let createRepoNock
+    it('should create a repository for an org if the user is not the owner', (done) => {
+      let createRepoNock;
 
-      factory.user().then(user => {
+      factory.user().then((user) => {
         createRepoNock = githubAPINocks.createRepoForOrg({
           accessToken: user.accessToken,
-          org: "org-name",
-          repo: "repo-name",
-        })
+          org: 'org-name',
+          repo: 'repo-name',
+        });
 
-        return GitHub.createRepo(user, "org-name", "repo-name")
+        return GitHub.createRepo(user, 'org-name', 'repo-name');
       }).then(() => {
-        expect(createRepoNock.isDone()).to.equal(true)
-        done()
-      }).catch(done)
-    })
+        expect(createRepoNock.isDone()).to.equal(true);
+        done();
+      }).catch(done);
+    });
 
-    it("should create a user repository even if the case for the owner and username don't match", done => {
-      let createRepoNock
+    it('should create a user repository even if the case for the owner and username don\'t match', (done) => {
+      let createRepoNock;
 
-      factory.user().then(user => {
+      factory.user().then((user) => {
         createRepoNock = githubAPINocks.createRepoForUser({
           accessToken: user.accessToken,
-          repo: "repo-name",
-        })
+          repo: 'repo-name',
+        });
 
-        return GitHub.createRepo(user, user.username.toUpperCase(), "repo-name")
+        return GitHub.createRepo(user, user.username.toUpperCase(), 'repo-name');
       }).then(() => {
-        expect(createRepoNock.isDone()).to.equal(true)
-        done()
-      }).catch(done)
-    })
+        expect(createRepoNock.isDone()).to.equal(true);
+        done();
+      }).catch(done);
+    });
 
-    it("should reject if the user is not authorized to create a repository", done => {
-      factory.user().then(user => {
+    it('should reject if the user is not authorized to create a repository', (done) => {
+      factory.user().then((user) => {
         githubAPINocks.createRepoForOrg({
           accessToken: user.accessToken,
-          org: "org-name",
-          repo: "repo-name",
+          org: 'org-name',
+          repo: 'repo-name',
           response: [403, {
-            message: "You need admin access to the organization before adding a repository to it."
-          }]
-        })
+            message: 'You need admin access to the organization before adding a repository to it.',
+          }],
+        });
 
-        return GitHub.createRepo(user, "org-name", "repo-name")
-      }).catch(err => {
-        expect(err.status).to.equal(400)
-        expect(err.message).to.equal("You need admin access to the organization before adding a repository to it.")
-        done()
-      }).catch(done)
-    })
+        return GitHub.createRepo(user, 'org-name', 'repo-name');
+      }).catch((err) => {
+        expect(err.status).to.equal(400);
+        expect(err.message).to.equal('You need admin access to the organization before adding a repository to it.');
+        done();
+      }).catch(done);
+    });
 
-    it("should reject if the repo already exists", done => {
-      factory.user().then(user => {
+    it('should reject if the repo already exists', (done) => {
+      factory.user().then((user) => {
         githubAPINocks.createRepoForOrg({
           accessToken: user.accessToken,
-          org: "org-name",
-          repo: "repo-name",
+          org: 'org-name',
+          repo: 'repo-name',
           response: [422, {
-            "errors": [{ "message":"name already exists on this account" }]
-          }]
+            errors: [{ message: 'name already exists on this account' }],
+          }],
+        });
+
+        return GitHub.createRepo(user, 'org-name', 'repo-name');
+      }).catch((err) => {
+        expect(err.status).to.equal(400);
+        expect(err.message).to.equal('A repo with that name already exists.');
+        done();
+      }).catch(done);
+    });
+  });
+
+  describe('.setWebhook(site, user)', () => {
+    it('should set a webhook on the repository', (done) => {
+      let site;
+      let user;
+
+      factory.user()
+        .then((model) => {
+          user = model;
+          return factory.site();
         })
-
-        return GitHub.createRepo(user, "org-name", "repo-name")
-      }).catch(err => {
-        expect(err.status).to.equal(400)
-        expect(err.message).to.equal("A repo with that name already exists.")
-        done()
-      }).catch(done)
-    })
-  })
-
-  describe(".setWebhook(site, user)", () => {
-    it("should set a webhook on the repository", done => {
-      let site, user
-
-      factory.user().then(model => {
-        user = model
-        return factory.site()
-      }).then(model => {
-        site = model
-        githubAPINocks.webhook({
-          accessToken: user.accessToken,
-          owner: site.owner,
-          repo: site.repository,
-          response: 201
+        .then((model) => {
+          site = model;
+          githubAPINocks.webhook({
+            accessToken: user.accessToken,
+            owner: site.owner,
+            repo: site.repository,
+            response: 201,
+          });
+          return GitHub.setWebhook(site, user.id);
         })
-        return GitHub.setWebhook(site, user.id)
-      }).then(() => {
-        done()
-      }).catch(done)
-    })
-
-    it("should resolve if the webhook already exists", done => {
-      let site, user
-
-      factory.user().then(model => {
-        user = model
-        return factory.site()
-      }).then(model => {
-        site = model
-        githubAPINocks.webhook({
-          accessToken: user.accessToken,
-          owner: site.owner,
-          repo: site.repository,
-          response: [400, {
-            errors: [{ message: "Hook already exists on this repository" }]
-          }]
+        .then(() => {
+          done();
         })
-        return GitHub.setWebhook(site, user.id)
-      }).then(() => {
-        done()
-      }).catch(done)
-    })
+        .catch(done);
+    });
 
-    it("should reject if the user does not have admin access to the repository", done => {
-      let site, user
+    it('should resolve if the webhook already exists', (done) => {
+      let site;
+      let user;
 
-      factory.user().then(model => {
-        user = model
-        return factory.site()
-      }).then(model => {
-        site = model
-        githubAPINocks.webhook({
-          accessToken: user.accessToken,
-          owner: site.owner,
-          repo: site.repository,
-          response: [404, {
-            message: "Not Found"
-          }]
+      factory.user()
+        .then((model) => {
+          user = model;
+          return factory.site();
         })
-        return GitHub.setWebhook(site, user.id)
-      }).then(() => {
-        throw new Error("Expected admin access error")
-      }).catch(err => {
-        expect(err.status).to.equal(400)
-        expect(err.message).to.equal("You do not have admin access to this repository")
-        done()
-      }).catch(done)
-    })
-  })
+        .then((model) => {
+          site = model;
+          githubAPINocks.webhook({
+            accessToken: user.accessToken,
+            owner: site.owner,
+            repo: site.repository,
+            response: [400, {
+              errors: [{ message: 'Hook already exists on this repository' }],
+            }],
+          });
+          return GitHub.setWebhook(site, user.id);
+        })
+        .then(() => {
+          done();
+        })
+        .catch(done);
+    });
 
-  describe(".validateUser(accessToken)", () => {
-    it("should resolve if the user is on a whitelisted team", done => {
+    it('should reject if the user does not have admin access to the repository', (done) => {
+      let site;
+      let user;
+
+      factory.user()
+        .then((model) => {
+          user = model;
+          return factory.site();
+        })
+        .then((model) => {
+          site = model;
+          githubAPINocks.webhook({
+            accessToken: user.accessToken,
+            owner: site.owner,
+            repo: site.repository,
+            response: [404, {
+              message: 'Not Found',
+            }],
+          });
+          return GitHub.setWebhook(site, user.id);
+        })
+        .then(() => {
+          throw new Error('Expected admin access error');
+        })
+        .catch((err) => {
+          expect(err.status).to.equal(400);
+          expect(err.message).to.equal('You do not have admin access to this repository');
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('.validateUser(accessToken)', () => {
+    it('should resolve if the user is on a whitelisted team', (done) => {
       githubAPINocks.userOrganizations({
-        accessToken: "123abc",
+        accessToken: '123abc',
         organizations: [{ id: config.passport.github.organizations[0] }],
-      })
+      });
 
-      GitHub.validateUser("123abc").then(() => {
-        done()
-      }).catch(done)
-    })
+      GitHub.validateUser('123abc').then(() => {
+        done();
+      }).catch(done);
+    });
 
-    it("should reject if the user is not on a whitelisted team", done => {
-      const FAKE_INVALID_ORG_ID = 4598345
+    it('should reject if the user is not on a whitelisted team', (done) => {
+      const FAKE_INVALID_ORG_ID = 4598345;
 
       githubAPINocks.userOrganizations({
-        accessToken: "123abc",
+        accessToken: '123abc',
         organizations: [{ id: FAKE_INVALID_ORG_ID }],
-      })
+      });
 
-      GitHub.validateUser("123abc").catch(err => {
-        expect(err.message).to.equal("Unauthorized")
-        done()
-      })
-    })
+      GitHub.validateUser('123abc').catch((err) => {
+        expect(err.message).to.equal('Unauthorized');
+        done();
+      });
+    });
 
-    it("should reject if access token is not a valid GitHub access token", done => {
-      const FAKE_INVALID_ORG_ID = 4598345
-
+    it('should reject if access token is not a valid GitHub access token', (done) => {
       githubAPINocks.userOrganizations({
-        accessToken: "123abc",
+        accessToken: '123abc',
         response: 403,
-      })
+      });
 
-      GitHub.validateUser("123abc").catch(err => {
-        done()
-      })
-    })
-  })
-})
+      GitHub.validateUser('123abc').catch(() => done());
+    });
+  });
+});

--- a/test/api/unit/services/GitHub.test.js
+++ b/test/api/unit/services/GitHub.test.js
@@ -88,6 +88,22 @@ describe("GitHub", () => {
       }).catch(done)
     })
 
+    it("should create a user repository even if the case for the owner and username don't match", done => {
+      let createRepoNock
+
+      factory.user().then(user => {
+        createRepoNock = githubAPINocks.createRepoForUser({
+          accessToken: user.accessToken,
+          repo: "repo-name",
+        })
+
+        return GitHub.createRepo(user, user.username.toUpperCase(), "repo-name")
+      }).then(() => {
+        expect(createRepoNock.isDone()).to.equal(true)
+        done()
+      }).catch(done)
+    })
+
     it("should reject if the user is not authorized to create a repository", done => {
       factory.user().then(user => {
         githubAPINocks.createRepoForOrg({


### PR DESCRIPTION
When creating a repo, the API request is different for creating the repo for a user versus for an org. Because of this reason, we need to compare the repo owner string to the username to determine what kind of request to send.

Federalist downcases the repo name for a new site when creating a site from a template. Because of this, if the user has capital letters in their username, the comparison will fail where it should succeed.

For example, if a user named `FederalistUser` tries to create a template site, the owner name will be `federalistuser`. When the owner string is compared to the user's username, the comparison will fail and a request will be sent to the new org repo API endpoint, resulting in a 404 since the `federalistuser` org does not exist.

This commit fixes the issue by downcasing the username and owner before the comparison. Additionally, a regression test is added for this case.

Ref #957