### PR TITLE
Update staging manifest APP_HOSTNAME to use federalist-staging.18f.gov domain

### DIFF
--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -15,7 +15,7 @@ services:
 env:
   NODE_ENV: production
   APP_ENV: staging
-  APP_HOSTNAME: https://federalist-staging.fr.cloud.gov
+  APP_HOSTNAME: https://federalist-staging.18f.gov
   LOG_LEVEL: verbose
   NPM_CONFIG_PRODUCTION: true
   NODE_MODULES_CACHE: false


### PR DESCRIPTION
Changing `APP_HOSTNAME` from `https://federalist-staging.fr.cloud.gov` to `https://federalist-staging.18f.gov` so that we can use the new CloudFront-fronted custom domain.