### PR TITLE
Add site wide error message

### DIFF
--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -7,10 +7,16 @@ const webpackAssets = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
 
 module.exports = {
   index(req, res) {
-    res.render('index.html', {
-      siteWideError: SiteWideErrorLoader.loadSiteWideError(),
+    const context = {
+      siteWideError: null,
       jsBundleName: webpackAssets['main.js'],
       cssBundleName: webpackAssets['main.css'],
-    });
+    };
+
+    if (req.session.authenticated) {
+      context.siteWideError = SiteWideErrorLoader.loadSiteWideError();
+    }
+
+    res.render('index.html', context);
   },
 };

--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const SiteWideErrorLoader = require('../services/SiteWideErrorLoader');
 
 const manifestPath = path.join(__dirname, '..', '..', 'webpack-manifest.json');
 const webpackAssets = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
@@ -7,6 +8,7 @@ const webpackAssets = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
 module.exports = {
   index(req, res) {
     res.render('index.html', {
+      siteWideError: SiteWideErrorLoader.loadSiteWideError(),
       jsBundleName: webpackAssets['main.js'],
       cssBundleName: webpackAssets['main.css'],
     });

--- a/api/services/SiteWideErrorLoader.js
+++ b/api/services/SiteWideErrorLoader.js
@@ -4,14 +4,13 @@ const cfenv = require('cfenv');
 const loadSiteWideError = () => {
   const appEnv = cfenv.getAppEnv();
   const siteWideErrorEnv = appEnv.getServiceCreds('federalist-site-wide-error');
-  if (siteWideErrorEnv) {
+  if (siteWideErrorEnv && siteWideErrorEnv.HEADING && siteWideErrorEnv.BODY) {
     return {
-      display: siteWideErrorEnv.DISPLAY,
       heading: siteWideErrorEnv.HEADING,
       body: siteWideErrorEnv.BODY,
     };
   }
-  return { display: false, heading: '', body: '' };
+  return null;
 };
 
 module.exports = { loadSiteWideError };

--- a/api/services/SiteWideErrorLoader.js
+++ b/api/services/SiteWideErrorLoader.js
@@ -1,0 +1,17 @@
+const cfenv = require('cfenv');
+
+
+const loadSiteWideError = () => {
+  const appEnv = cfenv.getAppEnv();
+  const siteWideErrorEnv = appEnv.getServiceCreds('federalist-site-wide-error');
+  if (siteWideErrorEnv) {
+    return {
+      display: siteWideErrorEnv.DISPLAY,
+      heading: siteWideErrorEnv.HEADING,
+      body: siteWideErrorEnv.BODY,
+    };
+  }
+  return { display: false, heading: '', body: '' };
+};
+
+module.exports = { loadSiteWideError };

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -29,9 +29,31 @@ describe('Main Site', () => {
 
     it('should include a cache-control header', (done) => {
       request(app)
-      .get('/')
+        .get('/')
       .then((response) => {
         expect(response.headers).to.have.property('cache-control', 'max-age=0');
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should render a site wide error if one is present', (done) => {
+      after(() => {
+        delete process.env.VCAP_SERVICES;
+      });
+
+      process.env.VCAP_SERVICES = JSON.stringify({
+        'user-provided': [{
+          credentials: { DISPLAY: true, HEADING: 'Error message heading', BODY: 'Error message body' },
+          name: 'federalist-site-wide-error',
+        }],
+      });
+
+      request(app)
+        .get('/')
+      .then((response) => {
+        expect(response.text).to.match(/Error message heading/);
+        expect(response.text).to.match(/Error message body/);
         done();
       })
       .catch(done);

--- a/test/api/unit/services/SiteWideErrorLoader.test.js
+++ b/test/api/unit/services/SiteWideErrorLoader.test.js
@@ -10,22 +10,31 @@ describe('SiteWideErrorLoader', () => {
     it('should load the site wide error', () => {
       process.env.VCAP_SERVICES = JSON.stringify({
         'user-provided': [{
-          credentials: { DISPLAY: true, HEADING: 'Error message heading', BODY: 'Error message body' },
+          credentials: { HEADING: 'Error message heading', BODY: 'Error message body' },
           name: 'federalist-site-wide-error',
         }],
       });
 
       const siteWideError = SiteWideErrorLoader.loadSiteWideError();
-      expect(siteWideError.display).to.equal(true);
       expect(siteWideError.heading).to.equal('Error message heading');
       expect(siteWideError.body).to.equal('Error message body');
     });
 
-    it('should return an empty error gracefully if no site wide error is present', () => {
+    it('should return null if no site wide error is present', () => {
       const siteWideError = SiteWideErrorLoader.loadSiteWideError();
-      expect(siteWideError.display).to.equal(false);
-      expect(siteWideError.heading).to.equal('');
-      expect(siteWideError.body).to.equal('');
+      expect(siteWideError).to.equal(null);
+    });
+
+    it('should return null if the site wide error user provided service is empty', () => {
+      process.env.VCAP_SERVICES = JSON.stringify({
+        'user-provided': [{
+          credentials: { HEADING: '', BODY: '' },
+          name: 'federalist-site-wide-error',
+        }],
+      });
+
+      const siteWideError = SiteWideErrorLoader.loadSiteWideError();
+      expect(siteWideError).to.equal(null);
     });
   });
 });

--- a/test/api/unit/services/SiteWideErrorLoader.test.js
+++ b/test/api/unit/services/SiteWideErrorLoader.test.js
@@ -1,0 +1,31 @@
+const expect = require('chai').expect;
+const SiteWideErrorLoader = require('../../../../api/services/SiteWideErrorLoader');
+
+describe('SiteWideErrorLoader', () => {
+  describe('.loadSiteWideError()', () => {
+    afterEach(() => {
+      delete process.env.VCAP_SERVICES;
+    });
+
+    it('should load the site wide error', () => {
+      process.env.VCAP_SERVICES = JSON.stringify({
+        'user-provided': [{
+          credentials: { DISPLAY: true, HEADING: 'Error message heading', BODY: 'Error message body' },
+          name: 'federalist-site-wide-error',
+        }],
+      });
+
+      const siteWideError = SiteWideErrorLoader.loadSiteWideError();
+      expect(siteWideError.display).to.equal(true);
+      expect(siteWideError.heading).to.equal('Error message heading');
+      expect(siteWideError.body).to.equal('Error message body');
+    });
+
+    it('should return an empty error gracefully if no site wide error is present', () => {
+      const siteWideError = SiteWideErrorLoader.loadSiteWideError();
+      expect(siteWideError.display).to.equal(false);
+      expect(siteWideError.heading).to.equal('');
+      expect(siteWideError.body).to.equal('');
+    });
+  });
+});

--- a/views/index.html
+++ b/views/index.html
@@ -32,7 +32,7 @@
     <title>Federalist</title>
   </head>
   <body>
-    <% if (siteWideError.display) { %>
+    <% if (siteWideError) { %>
       <div class="usa-alert usa-alert-warning usa-alert-home" role="alert">
         <div class="usa-alert-body">
           <h3 class="usa-alert-heading"><%= siteWideError.heading %></h3>

--- a/views/index.html
+++ b/views/index.html
@@ -32,6 +32,16 @@
     <title>Federalist</title>
   </head>
   <body>
+    <% if (siteWideError.display) { %>
+      <div class="usa-alert usa-alert-warning usa-alert-home" role="alert">
+        <div class="usa-alert-body">
+          <h3 class="usa-alert-heading"><%= siteWideError.heading %></h3>
+          <p class="usa-alert-text">
+            <%- siteWideError.body %>
+          </p>
+        </div>
+      </div>
+    <% } %>
     <div id="js-app">
 
     </div>


### PR DESCRIPTION
This commit adds the ability to display a site wide error message. This can be done via the `federalist-site-wide-error` user provided service which takes the following shape:

```json
{
  "DISPLAY": true,
  "HEADING": "There has been a site wide error",
  "BODY": "This error is breaking things. <a href='www.example.gov'>Click here</a> for more info."
}
```

The error is displayed at the top of the site. The body is displayed as unescaped HTML to allow for the inclusion of links, bulleted lists, etc

Ref #900