### PR TITLE
Fix issue where SiteRemover caused an internal server error

### DIFF
--- a/api/services/S3SiteRemover.js
+++ b/api/services/S3SiteRemover.js
@@ -1,55 +1,70 @@
-const AWS = require("aws-sdk")
-const config = require("../../config")
+const AWS = require('aws-sdk');
+const config = require('../../config');
 
-const s3Config = config.s3
+const s3Config = config.s3;
 const s3Client = new AWS.S3({
   accessKeyId: s3Config.accessKeyId,
   secretAccessKey: s3Config.secretAccessKey,
   region: s3Config.region,
-})
+});
 
-const removeSite = site => {
-  return Promise.all([
-    getObjectsWithPrefix(`site/${site.owner}/${site.repository}`),
-    getObjectsWithPrefix(`demo/${site.owner}/${site.repository}`),
-    getObjectsWithPrefix(`preview/${site.owner}/${site.repository}`),
-  ]).then(objects => {
-    objects = [].concat.apply([], objects)
-    return deleteObjects(objects)
-  })
-}
+/**
+  Deletes the array of S3 objects passed to it.
 
-const deleteObjects = objects => {
+  Since AWS limits the number of objects that can be deleted at a time, this
+  method deletes the objects 1000 at a time. It does so recursively so each
+  group of 1000 is deleted one after the other instead of simultaneously. This
+  prevents the delete requests from breaking AWS's rate limit.
+*/
+const deleteObjects = (objects) => {
+  if (objects.length === 0) {
+    return Promise.resolve();
+  }
+
+  const objectsToDeleteNow = objects.slice(0, 1000);
+  const objectsToDeleteLater = objects.slice(1000, objects.length);
+
   return new Promise((resolve, reject) => {
     s3Client.deleteObjects({
       Bucket: s3Config.bucket,
       Delete: {
-        Objects: objects.map(object => ({ Key: object }))
+        Objects: objectsToDeleteNow.map(object => ({ Key: object })),
       },
     }, (err, data) => {
       if (err) {
-        reject(err)
+        reject(err);
       } else {
-        resolve(data)
+        resolve(data);
       }
-    })
-  })
-}
+    });
+  }).then(() =>
+    deleteObjects(objectsToDeleteLater)
+  );
+};
 
-const getObjectsWithPrefix = prefix => {
-  return new Promise((resolve, reject) => {
+const getObjectsWithPrefix = prefix =>
+  new Promise((resolve, reject) => {
     s3Client.listObjects({
       Bucket: s3Config.bucket,
       Prefix: prefix,
     }, (err, data) => {
       if (err) {
-        reject(err)
+        reject(err);
       } else {
-        const keys = data.Contents.map(object => object.Key)
-        resolve(keys)
+        const keys = data.Contents.map(object => object.Key);
+        resolve(keys);
       }
-    })
-  })
-}
+    });
+  });
 
-module.exports = { removeSite }
+const removeSite = site =>
+  Promise.all([
+    getObjectsWithPrefix(`site/${site.owner}/${site.repository}`),
+    getObjectsWithPrefix(`demo/${site.owner}/${site.repository}`),
+    getObjectsWithPrefix(`preview/${site.owner}/${site.repository}`),
+  ]).then((objects) => {
+    const mergedObjects = [].concat(...objects);
+    return deleteObjects(mergedObjects);
+  });
+
+module.exports = { removeSite };

--- a/test/api/unit/services/S3SiteRemover.test.js
+++ b/test/api/unit/services/S3SiteRemover.test.js
@@ -1,82 +1,128 @@
-const AWSMocks = require('../../support/aws-mocks')
-const expect = require("chai").expect
-const factory = require("../../support/factory")
-const config = require("../../../../config")
+const AWSMocks = require('../../support/aws-mocks');
+const expect = require('chai').expect;
+const factory = require('../../support/factory');
+const config = require('../../../../config');
 
-const S3SiteRemover = require("../../../../api/services/S3SiteRemover")
+const S3SiteRemover = require('../../../../api/services/S3SiteRemover');
 
-describe("S3SiteRemover", () => {
+describe('S3SiteRemover', () => {
   after(() => {
-    AWSMocks.resetMocks()
-  })
+    AWSMocks.resetMocks();
+  });
 
-  describe(".removeSite(site)", () => {
-    it("should delete all objects in the `site/<org>/<repo>`, `demo/<org>/<repo>`, and `preview/<org>/<repo> directories", done => {
-      const siteObjectsToDelete = []
-      const demoObjectsToDelete = []
-      const previewObjectsToDelete = []
-      let site
-      let objectsWereDeleted = false
-      let siteObjectsWereListed = false
-      let demoObjectWereListed = false
-      let previewObjectsWereListed = false
+  describe('.removeSite(site)', () => {
+    it('should delete all objects in the `site/<org>/<repo>`, `demo/<org>/<repo>`, and `preview/<org>/<repo> directories', (done) => {
+      const siteObjectsToDelete = [];
+      const demoObjectsToDelete = [];
+      const previewObjectsToDelete = [];
+      let site;
+      let objectsWereDeleted = false;
+      let siteObjectsWereListed = false;
+      let demoObjectWereListed = false;
+      let previewObjectsWereListed = false;
 
       AWSMocks.mocks.S3.listObjects = (params, cb) => {
-        expect(params.Bucket).to.equal(config.s3.bucket)
+        expect(params.Bucket).to.equal(config.s3.bucket);
         if (params.Prefix === `site/${site.owner}/${site.repository}`) {
-          siteObjectsWereListed = true
+          siteObjectsWereListed = true;
           cb(null, {
-            Contents: siteObjectsToDelete.map(Key => ({ Key }))
-          })
+            Contents: siteObjectsToDelete.map(Key => ({ Key })),
+          });
         } else if (params.Prefix === `demo/${site.owner}/${site.repository}`) {
-          demoObjectWereListed = true
+          demoObjectWereListed = true;
           cb(null, {
-            Contents: demoObjectsToDelete.map(Key => ({ Key }))
-          })
+            Contents: demoObjectsToDelete.map(Key => ({ Key })),
+          });
         } else if (params.Prefix === `preview/${site.owner}/${site.repository}`) {
-          previewObjectsWereListed = true
+          previewObjectsWereListed = true;
           cb(null, {
-            Contents: previewObjectsToDelete.map(Key => ({ Key }))
-          })
+            Contents: previewObjectsToDelete.map(Key => ({ Key })),
+          });
         }
-      }
+      };
       AWSMocks.mocks.S3.deleteObjects = (params, cb) => {
-        expect(params.Bucket).to.equal(config.s3.bucket)
+        expect(params.Bucket).to.equal(config.s3.bucket);
 
-        const objectsToDelete = siteObjectsToDelete.concat(demoObjectsToDelete).concat(previewObjectsToDelete)
-        expect(params.Delete.Objects).to.have.length(objectsToDelete.length)
-        params.Delete.Objects.forEach(object => {
-          const index = objectsToDelete.indexOf(object.Key)
-          expect(index).to.be.at.least(0)
-          objectsToDelete.splice(index, 1)
-        })
-        objectsWereDeleted = true
-        cb(null, {})
-      }
+        const objectsToDelete = [
+          ...siteObjectsToDelete,
+          ...demoObjectsToDelete,
+          ...previewObjectsToDelete,
+        ];
+        expect(params.Delete.Objects).to.have.length(objectsToDelete.length);
+        params.Delete.Objects.forEach((object) => {
+          const index = objectsToDelete.indexOf(object.Key);
+          expect(index).to.be.at.least(0);
+          objectsToDelete.splice(index, 1);
+        });
+        objectsWereDeleted = true;
+        cb(null, {});
+      };
 
-      factory.site().then(model => {
-        site = model
+      factory.site().then((model) => {
+        site = model;
 
-        const sitePrefix = `site/${site.owner}/${site.repository}`
-        siteObjectsToDelete.push(`${sitePrefix}/index.html`)
-        siteObjectsToDelete.push(`${sitePrefix}/redirect`)
-        siteObjectsToDelete.push(`${sitePrefix}/redirect/index.html`)
-        const demoPrefix = `demo/${site.owner}/${site.repository}`
-        demoObjectsToDelete.push(`${demoPrefix}/index.html`)
-        demoObjectsToDelete.push(`${demoPrefix}/redirect`)
-        demoObjectsToDelete.push(`${demoPrefix}/redirect/index.html`)
-        const previewPrefix = `preview/${site.owner}/${site.repository}`
-        previewObjectsToDelete.push(`${previewPrefix}/index.html`)
-        previewObjectsToDelete.push(`${previewPrefix}/redirect`)
-        previewObjectsToDelete.push(`${previewPrefix}/redirect/index.html`)
+        const sitePrefix = `site/${site.owner}/${site.repository}`;
+        siteObjectsToDelete.push(`${sitePrefix}/index.html`);
+        siteObjectsToDelete.push(`${sitePrefix}/redirect`);
+        siteObjectsToDelete.push(`${sitePrefix}/redirect/index.html`);
+        const demoPrefix = `demo/${site.owner}/${site.repository}`;
+        demoObjectsToDelete.push(`${demoPrefix}/index.html`);
+        demoObjectsToDelete.push(`${demoPrefix}/redirect`);
+        demoObjectsToDelete.push(`${demoPrefix}/redirect/index.html`);
+        const previewPrefix = `preview/${site.owner}/${site.repository}`;
+        previewObjectsToDelete.push(`${previewPrefix}/index.html`);
+        previewObjectsToDelete.push(`${previewPrefix}/redirect`);
+        previewObjectsToDelete.push(`${previewPrefix}/redirect/index.html`);
 
-        return S3SiteRemover.removeSite(site)
+        return S3SiteRemover.removeSite(site);
       }).then(() => {
-        expect(siteObjectsWereListed).to.equal(true)
-        expect(previewObjectsWereListed).to.equal(true)
-        expect(objectsWereDeleted).to.equal(true)
-        done()
-      }).catch(done)
-    })
-  })
-})
+        expect(siteObjectsWereListed).to.equal(true);
+        expect(demoObjectWereListed).to.equal(true);
+        expect(previewObjectsWereListed).to.equal(true);
+        expect(objectsWereDeleted).to.equal(true);
+        done();
+      }).catch(done);
+    });
+
+    it('should delete objects in batches of 1000 at a time', (done) => {
+      let deleteObjectsCallCount = 0;
+
+      AWSMocks.mocks.S3.listObjects = (params, cb) => cb(null, {
+        Contents: Array(750).fill(0).map(() => ({ Key: 'abc123' })),
+      });
+
+      AWSMocks.mocks.S3.deleteObjects = (params, cb) => {
+        expect(params.Delete.Objects).to.have.length.at.most(1000);
+        deleteObjectsCallCount += 1;
+        cb();
+      };
+
+      factory.site()
+      .then(site => S3SiteRemover.removeSite(site))
+      .then(() => {
+        // 750 site, 750 demo, 750 preview objects = 2250 total
+        // 2250 objects means 3 groups of 1000
+        expect(deleteObjectsCallCount).to.equal(3);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should not delete anything if there is nothing to delete', (done) => {
+      AWSMocks.mocks.S3.listObjects = (params, cb) => cb(null, {
+        Contents: [],
+      });
+
+      AWSMocks.mocks.S3.deleteObjects = () => {
+        // The site remover shouldn't delete anything,
+        // Calling delete `deleteObjects` raises an error and fails the test.
+        throw new Error('Attempted to delete objects when there should be none to delete');
+      };
+
+      factory.site()
+      .then(site => S3SiteRemover.removeSite(site))
+      .then(done)
+      .catch(done);
+    });
+  });
+});


### PR DESCRIPTION
This commit fixes 2 issues with the S3SiteRemover service, and adds regression test to prevent the issues in the future.

Both issues relate to how the `delete-objects` API request was sent to the S3 API.

The first issue was that an empty request (i.e. a request to delete 0 objects) would cause a the S3 API to respond with a 500 which would propagate to the S3SiteRemover. This commit adds a guard clause to the top of the `deleteObjects` function to prevent this from happening.

The second issue happened because the `delete-objects` API requests does not allow for the deletion of more than 1000 objects at a time. This commit changes `deleteObjects` function so that it returns a Promise that recursively deletes objects 1000 at a time. This means at most 1000 objects are deleted at a time and no deletion requests are happening simultaneously threatening to break AWS's rate limit.

Ref #990