### PR TITLE
increase 100-build test timeout to 2000ms

### DIFF
--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -323,7 +323,7 @@ describe('Build API', () => {
         done();
       })
       .catch(done);
-    });
+    }).timeout(2000); // this test can take a long time because of all the builds it creates
   });
 
   describe('POST /v0/build/:id/status/:token', () => {


### PR DESCRIPTION
This test failed during a Travis build (ref https://travis-ci.org/18F/federalist/builds/240956620#L2265), likely due to a mocha test timeout. This PR increases the timeout for the specific failing to 2000ms.