### PR TITLE
Bind federalist-site-wide-error service to the app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -11,6 +11,7 @@ services:
 - federalist-production-rds
 - federalist-production-s3
 - federalist-production-env
+- federalist-site-wide-error
 env:
   NEW_RELIC_APP_NAME: federalist-prod
   NODE_ENV: production

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -9,9 +9,9 @@ memory: 256MB
 instances: 2
 services:
 - federalist-staging-rds
-- federalist-staging-redis
 - federalist-staging-s3
 - federalist-staging-env
+- federalist-site-wide-error
 env:
   NODE_ENV: production
   APP_ENV: staging


### PR DESCRIPTION
This commit changes the production and staging manifests so they bind the federalist-site-wide-error service to the app when it deploys. This allows a site wide error to be displayed after a zero downtime deploy.