### PR TITLE
Fix site builds text and styles

### DIFF
--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -30,13 +30,17 @@ class SiteBuilds extends React.Component {
   }
 
   static restartLink(build) {
+    /* eslint-disable jsx-a11y/href-no-hash */
     return (
-      <button
+      <a
+        href="#"
+        role="button"
         onClick={e => SiteBuilds.restartClicked(e, build)}
       >
         Restart
-      </button>
+      </a>
     );
+    /* eslint-enable jsx-a11y/href-no-hash */
   }
 
   componentDidMount() {
@@ -97,7 +101,7 @@ class SiteBuilds extends React.Component {
             })}
           </tbody>
         </table>
-        { this.builds().length >= 100 ? <p>Build list may have been shortened</p> : null }
+        { this.builds().length >= 100 ? <p>List only displays 100 most recent builds.</p> : null }
       </div>
     );
   }

--- a/test/frontend/components/site/siteBuilds.test.js
+++ b/test/frontend/components/site/siteBuilds.test.js
@@ -78,7 +78,7 @@ describe('<SiteBuilds/>', () => {
 
     const wrapper = shallow(<SiteBuilds {...props} />);
     expect(wrapper.find('p')).to.have.length(1);
-    expect(wrapper.find('p').contains('Build list may have been shortened')).to.be.true;
+    expect(wrapper.find('p').contains('List only displays 100 most recent builds.')).to.be.true;
   });
 
   it('should render a loading state if the builds are loading', () => {


### PR DESCRIPTION
This commit fixes some style and content issue in the site builds
component.

- Re-word text about builds list being truncated
- Style restart button to look like a link

To Do:
- ~Make the Restart and Logs font look the same. @jseppi thinks it is a font-weight difference.~ Edit: it's not font-weight. All style properties look to be the same.