### PR TITLE
Add ability to select hugo as a site's build engine

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
   "rules": {
     "react/jsx-filename-extension": [0],
     "import/no-extraneous-dependencies": [0],
+    "class-methods-use-this": [0],
     "comma-dangle": ["error",
       {
         "arrays": "always-multiline",

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -13,17 +13,19 @@ const propTypes = {
   storeState: React.PropTypes.shape({
     user: React.PropTypes.shape({
       username: React.PropTypes.string,
-      id: React.PropTypes.number
+      id: React.PropTypes.number,
     }),
-    error: React.PropTypes.string
-  })
-}
+    error: React.PropTypes.string,
+  }),
+};
+
+const defaultProps = {
+  storeState: null,
+};
 
 class AddSite extends React.Component {
   constructor(props) {
     super(props);
-
-    const { user } = props.storeState;
 
     this.state = {
       owner: this.defaultOwner(),
@@ -34,15 +36,6 @@ class AddSite extends React.Component {
 
     this.onChange = this.onChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
-  }
-
-  defaultOwner() {
-    const userState = this.props.storeState.user
-    if (userState.data) {
-      return userState.data.username
-    } else {
-      return ""
-    }
   }
 
   onSubmit(event) {
@@ -62,6 +55,14 @@ class AddSite extends React.Component {
     this.setState(nextState);
   }
 
+  defaultOwner() {
+    const userState = this.props.storeState.user;
+    if (userState.data) {
+      return userState.data.username;
+    }
+    return '';
+  }
+
   render() {
     return (
       <div>
@@ -74,7 +75,9 @@ class AddSite extends React.Component {
         <div className="usa-grid">
           <div className="usa-width-one-whole">
             <p>
-              There are a few different ways you can add sites to Federalist. You can start with a brand new site by selecting one of our template sites below. Or you can specify the Github repository where your site&#39;s code lives.
+              There are a few different ways you can add sites to Federalist.
+              You can start with a brand new site by selecting one of our template sites below.
+              Or you can specify the Github repository where your site&#39;s code lives.
             </p>
           </div>
         </div>
@@ -88,7 +91,7 @@ class AddSite extends React.Component {
             <h2>Or add your own Github repository</h2>
           </div>
         </div>
-        <form onSubmit={ this.onSubmit }>
+        <form onSubmit={this.onSubmit}>
           <div className="usa-grid">
             <div className="col-md-12">
               <div className="form-group">
@@ -99,7 +102,8 @@ class AddSite extends React.Component {
                   className="form-control"
                   name="owner"
                   value={this.state.owner}
-                  onChange={this.onChange} />
+                  onChange={this.onChange}
+                />
               </div>
               <div className="form-group">
                 <label htmlFor="repository">Repository&#39;s Name</label>
@@ -109,7 +113,8 @@ class AddSite extends React.Component {
                   name="repository"
                   id="repository"
                   value={this.state.repository}
-                  onChange={this.onChange} />
+                  onChange={this.onChange}
+                />
               </div>
               <div className="form-group">
                 <SelectSiteEngine value={this.state.engine} onChange={this.onChange} />
@@ -122,7 +127,8 @@ class AddSite extends React.Component {
                   className="form-control"
                   name="defaultBranch"
                   value={this.state.defaultBranch}
-                  onChange={this.onChange}/>
+                  onChange={this.onChange}
+                />
               </div>
             </div>
           </div>
@@ -131,8 +137,9 @@ class AddSite extends React.Component {
               <LinkButton
                 className="usa-button-secondary"
                 text="Cancel"
-                href="/sites" />
-              <button type="submit" className="usa-button usa-button-primary" style={{display: 'inline-block'}}>
+                href="/sites"
+              />
+              <button type="submit" className="usa-button usa-button-primary" style={{ display: 'inline-block' }}>
                 Submit repository-based site
               </button>
             </div>
@@ -144,5 +151,6 @@ class AddSite extends React.Component {
 }
 
 AddSite.propTypes = propTypes;
+AddSite.defaultProps = defaultProps;
 
 export default AddSite;

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import TemplateSiteList from './TemplateSiteList';
 import LinkButton from '../linkButton';
 import AlertBanner from '../alertBanner';
+import SelectSiteEngine from '../selectSiteEngine';
 
 import siteActions from '../../actions/siteActions';
 
@@ -111,17 +112,7 @@ class AddSite extends React.Component {
                   onChange={this.onChange} />
               </div>
               <div className="form-group">
-                <label htmlFor="engine">Static site engine</label>
-                <select
-                  name="engine"
-                  id="engine"
-                  className="form-control"
-                  value={this.state.engine}
-                  onChange={this.onChange}
-                >
-                  <option value="jekyll">Jekyll</option>
-                  <option value="static">Static (just publish the files in the repository)</option>
-                </select>
+                <SelectSiteEngine value={this.state.engine} onChange={this.onChange} />
               </div>
               <div className="form-group">
                 <label htmlFor="defaultBranch">Default branch</label>

--- a/frontend/components/app.js
+++ b/frontend/components/app.js
@@ -80,7 +80,9 @@ App.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
-  location: PropTypes.objectOf(PropTypes.string),
+  location: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+  }),
 };
 
 App.defaultProps = {

--- a/frontend/components/selectSiteEngine.jsx
+++ b/frontend/components/selectSiteEngine.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const availableEngines = [
+  {
+    label: 'Jekyll',
+    value: 'jekyll',
+  },
+  {
+    label: 'Hugo',
+    value: 'hugo',
+  },
+  {
+    label: 'Static (just publish the files in the repository)',
+    value: 'static',
+  },
+];
+
+function makeOptions(opts) {
+  return opts.map(({ label, value }) => (
+    <option key={value} value={value}>{label}</option>
+  ));
+}
+
+const SelectSiteEngine = ({ value, onChange }) => (
+  <div>
+    <label htmlFor="engine">Static site engine</label>
+    <select
+      name="engine"
+      id="engine"
+      className="form-control"
+      value={value}
+      onChange={onChange}
+    >
+      {makeOptions(availableEngines)}
+    </select>
+  </div>
+);
+
+
+SelectSiteEngine.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+};
+
+SelectSiteEngine.defaultProps = {
+  onChange: () => {},
+};
+
+export default SelectSiteEngine;

--- a/frontend/components/selectSiteEngine.jsx
+++ b/frontend/components/selectSiteEngine.jsx
@@ -7,7 +7,7 @@ const availableEngines = [
     value: 'jekyll',
   },
   {
-    label: 'Hugo',
+    label: 'Hugo (experimental)',
     value: 'hugo',
   },
   {

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 
 import SiteGithubBranchesTable from './siteGithubBranchesTable';
 import LinkButton from '../linkButton';
+import SelectSiteEngine from '../selectSiteEngine';
 import githubBranchActions from '../../actions/githubBranchActions';
 import siteActions from '../../actions/siteActions';
 
@@ -89,16 +90,7 @@ class SiteSettings extends React.Component {
         </div>
         <div className="usa-grid">
           <div className="usa-width-one-whole">
-            <label htmlFor="engine">Static site engine</label>
-            <select
-              name="engine"
-              className="form-control"
-              value={state.engine}
-              onChange={this.onChange}
-            >
-              <option value="jekyll">Jekyll</option>
-              <option value="static">Static (just publish the files in the repository)</option>
-            </select>
+            <SelectSiteEngine value={state.engine} onChange={this.onChange} />
           </div>
         </div>
         <div className="usa-grid">

--- a/test/frontend/components/addSite/addSite.test.js
+++ b/test/frontend/components/addSite/addSite.test.js
@@ -1,17 +1,14 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { stub, spy } from 'sinon';
-import templates from '../../../../config/templates';
+import { stub } from 'sinon';
 import proxyquire from 'proxyquire';
+
+import templates from '../../../../config/templates';
 
 proxyquire.noCallThru();
 
-const mock = () => {
-  return function() {
-    return <div></div>;
-  };
-};
+const mock = () => () => <div />;
 
 const TemplateSiteList = mock();
 const LinkButton = mock();
@@ -27,17 +24,15 @@ const user = {
   },
 };
 
-const error = {error: 'whoooooops'};
-
 const propsWithoutError = {
-  storeState: { user, error: ''}
+  storeState: { user, error: '' },
 };
 
 const Fixture = proxyquire('../../../../frontend/components/AddSite', {
   './TemplateSiteList': TemplateSiteList,
   '../linkButton': LinkButton,
   '../alertBanner': AlertBanner,
-  '../../actions/siteActions': { addSite  }
+  '../../actions/siteActions': { addSite },
 }).default;
 
 describe('<AddSite/>', () => {
@@ -53,7 +48,7 @@ describe('<AddSite/>', () => {
       owner: user.data.username,
       engine: 'jekyll',
       defaultBranch: 'master',
-      repository: ''
+      repository: '',
     };
 
     expect(actualState).to.deep.equal(expectedState);
@@ -90,9 +85,9 @@ describe('<AddSite/>', () => {
     const templateListProps = wrapper.find(TemplateSiteList).props();
     const formProps = wrapper.find('form').props();
 
-    expect(bannerProps).to.deep.equal({message: propsWithoutError.storeState.error});
+    expect(bannerProps).to.deep.equal({ message: propsWithoutError.storeState.error });
     expect(templateListProps).to.deep.equal({
-      templates: templates,
+      templates,
       handleSubmitTemplate: wrapper.instance().onSubmitTemplate,
       defaultOwner: propsWithoutError.storeState.user.data.username,
     });
@@ -100,7 +95,7 @@ describe('<AddSite/>', () => {
   });
 
   it('calls addSite action when add site form is submitted', () => {
-    wrapper.find('form').simulate('submit', {preventDefault: () => {}});
+    wrapper.find('form').simulate('submit', { preventDefault: () => {} });
     expect(addSite.called).to.be.true;
   });
 
@@ -108,7 +103,7 @@ describe('<AddSite/>', () => {
     const repoInput = wrapper.find('input[name="repository"]');
     const newValue = 'ohyeah';
 
-    repoInput.simulate('change', {target: { name: 'repository', value: newValue}});
+    repoInput.simulate('change', { target: { name: 'repository', value: newValue } });
     expect(wrapper.state().repository).to.equal(newValue);
   });
 });

--- a/test/frontend/components/addSite/addSite.test.js
+++ b/test/frontend/components/addSite/addSite.test.js
@@ -64,7 +64,7 @@ describe('<AddSite/>', () => {
 
     expect(wrapper.find('input[name="owner"]').props().value).to.equal(owner);
     expect(wrapper.find('input[name="repository"]').props().value).to.equal(repository);
-    expect(wrapper.find('select[name="engine"]').props().value).to.equal(engine);
+    expect(wrapper.find('SelectSiteEngine').props().value).to.equal(engine);
     expect(wrapper.find('input[name="defaultBranch"]').props().value).to.equal(defaultBranch);
   });
 

--- a/test/frontend/components/selectSiteEngine.test.js
+++ b/test/frontend/components/selectSiteEngine.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+
+import SelectSiteEngine from '../../../frontend/components/selectSiteEngine';
+
+const expectedEngineValues = ['jekyll', 'hugo', 'static'];
+
+describe('<SelectSiteEngine />', () => {
+  const props = {
+    value: expectedEngineValues[0],
+    onChange: spy(),
+  };
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<SelectSiteEngine {...props} />);
+  });
+
+  it('renders a select element with expect options', () => {
+    const select = wrapper.find('select#engine');
+    expect(select).to.have.length(1);
+    expect(select.props().value).to.equal(props.value);
+
+    expectedEngineValues.forEach((engine) => {
+      expect(wrapper.find(`option[value="${engine}"]`)).to.have.length(1);
+    });
+  });
+
+  it('calls props.onChange when a new option is selected', () => {
+    const select = wrapper.find('select#engine');
+    expect(props.onChange.notCalled).to.be.true;
+    select.simulate('change', { target: { value: expectedEngineValues[2] } });
+    expect(props.onChange.calledOnce).to.be.true;
+  });
+});


### PR DESCRIPTION
This PR adds hugo as a build engine option 🎉 

Also:
- Extract SelectSiteEngine component since it is used in two places
- Add test for new SelectSiteEngine component

ref #969 

Functional code changes are in the first commit; linter fixes are in the second.