### PR TITLE
Improve styling of log tables to not overrun the page width

### DIFF
--- a/frontend/components/site/siteBuildLogTable.jsx
+++ b/frontend/components/site/siteBuildLogTable.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 function SiteBuildLogTable({ buildLogs }) {
   return (
-    <table>
+    <table className="usa-table-borderless log-table log-table__site-build-log">
       <thead>
         <tr>
           <th>Source</th>
@@ -16,7 +16,7 @@ function SiteBuildLogTable({ buildLogs }) {
           <tr key={log.id}>
             <td>{log.source}</td>
             <td>
-              <pre style={{ whiteSpace: 'pre-wrap' }}>
+              <pre>
                 {log.output}
               </pre>
             </td>

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import { Link } from 'react-router';
 import LoadingIndicator from '../loadingIndicator';
 import { duration, timeFrom } from '../../util/datetime';
@@ -57,7 +59,7 @@ class SiteBuilds extends React.Component {
   renderBuildsTable() {
     return (
       <div>
-        <table className="usa-table-borderless build-log-table">
+        <table className="usa-table-borderless log-table log-table__site-builds">
           <thead>
             <tr>
               <th scope="col">Branch</th>
@@ -70,7 +72,6 @@ class SiteBuilds extends React.Component {
           </thead>
           <tbody>
             {this.builds().map((build) => {
-              const rowClass = `usa-alert-${build.state}`;
               let message;
 
               switch (build.state) {
@@ -86,12 +87,12 @@ class SiteBuilds extends React.Component {
               }
 
               return (
-                <tr key={build.id} className={rowClass}>
+                <tr key={build.id}>
                   <td>{ build.branch }</td>
                   <td>{ SiteBuilds.getUsername(build) }</td>
                   <td>{ timeFrom(build.completedAt) }</td>
                   <td>{ duration(build.createdAt, build.completedAt) }</td>
-                  <td>{ message }</td>
+                  <td><pre>{ message }</pre></td>
                   <td>
                     { SiteBuilds.restartLink(build) }<br />
                     { SiteBuilds.buildLogsLink(build) }
@@ -118,23 +119,28 @@ class SiteBuilds extends React.Component {
 }
 
 SiteBuilds.propTypes = {
-  builds: React.PropTypes.arrayOf(React.PropTypes.shape({
-    isLoading: React.PropTypes.boolean,
-    data: React.PropTypes.arrayOf(React.PropTypes.shape({
-      id: React.PropTypes.number,
-      state: React.PropTypes.string,
-      error: React.PropTypes.string,
-      branch: React.PropTypes.string,
-      completedAt: React.PropTypes.string,
-      createdAt: React.PropTypes.string,
-      user: React.PropTypes.shape({
-        username: React.PropTypes.string,
+  builds: PropTypes.shape({
+    isLoading: PropTypes.boolean,
+    data: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number,
+      state: PropTypes.string,
+      error: PropTypes.string,
+      branch: PropTypes.string,
+      completedAt: PropTypes.string,
+      createdAt: PropTypes.string,
+      user: PropTypes.shape({
+        username: PropTypes.string,
       }),
     })),
-  })).isRequired,
-  site: React.PropTypes.shape({
-    id: React.PropTypes.number,
-  }).isRequired,
+  }),
+  site: PropTypes.shape({
+    id: PropTypes.number,
+  }),
+};
+
+SiteBuilds.defaultProps = {
+  builds: null,
+  site: null,
 };
 
 export default SiteBuilds;

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -1,30 +1,20 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
+
 import { Link } from 'react-router';
-import publishedBranchActions from "../../actions/publishedBranchActions";
-import LoadingIndicator from "../loadingIndicator"
+import publishedBranchActions from '../../actions/publishedBranchActions';
+import LoadingIndicator from '../loadingIndicator';
 
 class SitePublishedBranchesTable extends React.Component {
   componentDidMount() {
-    publishedBranchActions.fetchPublishedBranches({ id: this.props.params.id })
+    publishedBranchActions.fetchPublishedBranches({ id: this.props.params.id });
   }
 
   publishedBranches() {
     if (this.props.publishedBranches.isLoading || !this.props.publishedBranches.data) {
-      return []
-    } else {
-      return this.props.publishedBranches.data
+      return [];
     }
-  }
-
-  render() {
-    const branches = this.publishedBranches()
-    if (this.props.publishedBranches.isLoading) {
-      return this.renderLoadingState()
-    } else if (!branches.length) {
-      return this.renderEmptyState()
-    } else {
-      return this.renderPublishedBranchesTable()
-    }
+    return this.props.publishedBranches.data;
   }
 
   renderPublishedBranchesTable() {
@@ -40,7 +30,7 @@ class SitePublishedBranchesTable extends React.Component {
           { this.publishedBranches().map(this.renderPublishedBranchRow.bind(this)) }
         </tbody>
       </table>
-    )
+    );
   }
 
   renderPublishedBranchRow(branch) {
@@ -52,28 +42,52 @@ class SitePublishedBranchesTable extends React.Component {
           { this.renderBranchFilesLink(branch) }
         </td>
       </tr>
-    )
+    );
   }
 
   renderBranchViewLink(branch) {
-    return <a href={branch.viewLink} target="_blank">View</a>
+    return <a href={branch.viewLink} target="_blank" rel="noopener noreferrer">View</a>;
   }
 
   renderBranchFilesLink(branch) {
-    const href = `/sites/${branch.site.id}/published/${branch.name}`
-    return <Link to={href}>Files</Link>
+    const href = `/sites/${branch.site.id}/published/${branch.name}`;
+    return <Link to={href}>Files</Link>;
   }
 
   renderLoadingState() {
-    return <LoadingIndicator/>
+    return <LoadingIndicator />;
   }
 
   renderEmptyState() {
-    return <p>
+    return (<p>
       No branches have been published.
       Please wait for build to complete or check logs for error message.
-    </p>
+    </p>);
+  }
+
+  render() {
+    const branches = this.publishedBranches();
+    if (this.props.publishedBranches.isLoading) {
+      return this.renderLoadingState();
+    } else if (!branches.length) {
+      return this.renderEmptyState();
+    }
+    return this.renderPublishedBranchesTable();
   }
 }
 
-export default SitePublishedBranchesTable
+SitePublishedBranchesTable.propTypes = {
+  params: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  publishedBranches: PropTypes.shape({
+    isLoading: PropTypes.bool.isRequired,
+    data: PropTypes.array,
+  }),
+};
+
+SitePublishedBranchesTable.defaultProps = {
+  publishedBranches: null,
+};
+
+export default SitePublishedBranchesTable;

--- a/frontend/components/site/sitePublishedFilesTable.js
+++ b/frontend/components/site/sitePublishedFilesTable.js
@@ -1,40 +1,28 @@
-import React from 'react'
-import publishedFileActions from "../../actions/publishedFileActions";
-import LoadingIndicator from '../loadingIndicator'
+import React from 'react';
+import PropTypes from 'prop-types';
 
-class SitePublishedBranch extends React.Component {
+import publishedFileActions from '../../actions/publishedFileActions';
+import LoadingIndicator from '../loadingIndicator';
+
+class SitePublishedFilesTable extends React.Component {
   componentDidMount() {
-    const site = { id: this.props.params.id }
-    const branch = this.props.params.name
-    publishedFileActions.fetchPublishedFiles(site, branch)
+    const site = { id: this.props.params.id };
+    const branch = this.props.params.name;
+    publishedFileActions.fetchPublishedFiles(site, branch);
   }
 
   publishedFiles() {
-    const branch = this.props.params.name
+    const branch = this.props.params.name;
     if (this.props.publishedFiles.data && !this.props.publishedFiles.isLoading) {
-      return this.props.publishedFiles.data.filter(file => {
-        return file.publishedBranch.name === branch
-      })
-    } else {
-      return []
+      return this.props.publishedFiles.data.filter(file => file.publishedBranch.name === branch);
     }
-  }
-
-  render() {
-    const files = this.publishedFiles()
-    if (this.props.publishedFiles.isLoading) {
-      return this.renderLoadingState()
-    } else if (!files.length) {
-      return this.renderEmptyState()
-    } else {
-      return this.renderPublishedFilesTable(files)
-    }
+    return [];
   }
 
   renderPublishedFilesTable(files) {
-    return <div>
+    return (<div>
       <h3>{this.props.params.name}</h3>
-      <table className="usa-table-borderless build-log-table">
+      <table className="usa-table-borderless">
         <thead>
           <tr>
             <th>File</th>
@@ -42,27 +30,52 @@ class SitePublishedBranch extends React.Component {
           </tr>
         </thead>
         <tbody>
-          { files.map(file => this.renderBranchFileRow(file)) }
+          { files.filter(f => !!f.name).map(this.renderBranchFileRow) }
         </tbody>
       </table>
-    </div>
+    </div>);
   }
 
   renderBranchFileRow(file) {
-    const viewFileLink = `${file.publishedBranch.viewLink}/${file.name}`
-    return <tr key={file.name}>
+    const viewFileLink = `${file.publishedBranch.viewLink}/${file.name}`;
+    return (<tr key={file.name}>
       <td>{file.name}</td>
-      <td><a href={viewFileLink} target="_blank">View</a></td>
-    </tr>
+      <td><a href={viewFileLink} target="_blank" rel="noopener noreferrer">View</a></td>
+    </tr>);
   }
 
   renderLoadingState() {
-    return <LoadingIndicator/>
+    return <LoadingIndicator />;
   }
 
   renderEmptyState() {
-    return <p>No published branch files available</p>
+    return (<p>No published branch files available.</p>);
+  }
+
+  render() {
+    const files = this.publishedFiles();
+    if (this.props.publishedFiles.isLoading) {
+      return this.renderLoadingState();
+    } else if (!files.length) {
+      return this.renderEmptyState();
+    }
+    return this.renderPublishedFilesTable(files);
   }
 }
 
-export default SitePublishedBranch
+SitePublishedFilesTable.propTypes = {
+  params: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  publishedFiles: PropTypes.shape({
+    isLoading: PropTypes.bool.isRequired,
+    data: PropTypes.array,
+  }),
+};
+
+SitePublishedFilesTable.defaultProps = {
+  publishedFiles: null,
+};
+
+export default SitePublishedFilesTable;

--- a/frontend/sass/_logs.scss
+++ b/frontend/sass/_logs.scss
@@ -1,7 +1,0 @@
-.build-log-table td:last-child {
-  word-break: break-word;
-}
-
-.build-log-table td {
-  vertical-align: top;
-}

--- a/frontend/sass/_tables.scss
+++ b/frontend/sass/_tables.scss
@@ -1,0 +1,16 @@
+
+.log-table {
+  font-size: smaller;
+
+  pre {
+    overflow: auto;
+    white-space: pre-wrap;
+    margin: 0;
+    max-height: 200px;
+    max-width: 200px;
+  }
+}
+
+.log-table__site-build-log pre {
+  max-width: 400px;
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -14,9 +14,9 @@
 @import "_image-manager";
 @import "_labels";
 @import "_loader";
-@import "_logs";
 @import "_text";
 @import "_wells";
+@import "_tables";
 
 html,
 body,

--- a/test/frontend/components/site/sitePublishedFilesTable.test.js
+++ b/test/frontend/components/site/sitePublishedFilesTable.test.js
@@ -1,66 +1,68 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import LoadingIndicator from '../../../../frontend/components/loadingIndicator'
+import LoadingIndicator from '../../../../frontend/components/loadingIndicator';
 import SitePublishedFilesTable from '../../../../frontend/components/site/sitePublishedFilesTable';
 
 
-describe("<SitePublishedFilesTable/>", () => {
-  it("should render the branch name", () => {
-    const publishedBranch = { name: "master", viewLink: "www.example.gov/master" }
+describe('<SitePublishedFilesTable/>', () => {
+  it('should render the branch name', () => {
+    const publishedBranch = { name: 'master', viewLink: 'www.example.gov/master' };
     const props = {
-      params: { id: 1, name: "master" },
+      params: { id: 1, name: 'master' },
       publishedFiles: {
         isLoading: false,
         data: [
-          { name: "abc", publishedBranch },
-        ],
-      }
-    }
-
-    const wrapper = shallow(<SitePublishedFilesTable {...props} />)
-    expect(wrapper.find("h3").contains("master")).to.be.true
-  })
-
-  it("should render a table with the files for the given branch", () => {
-    const correctBranch = { name: "master", viewLink: "www.example.gov/master" }
-    const incorrectBranch = { name: "preview", viewLink: "www.example.gov/preview" }
-    const props = {
-      params: { id: 1, name: "master" },
-      publishedFiles: {
-        isLoading: false,
-        data: [
-          { name: "abc", publishedBranch: correctBranch },
-          { name: "abc/def", publishedBranch: correctBranch },
-          { name: "xyz", publishedBranch: incorrectBranch },
+          { name: 'abc', publishedBranch },
         ],
       },
-    }
+    };
 
-    const wrapper = shallow(<SitePublishedFilesTable {...props} />)
-    expect(wrapper.find("table")).to.have.length(1)
-    expect(wrapper.find("table").contains("abc")).to.be.true
-    expect(wrapper.find("table").contains("abc/def")).to.be.true
-    expect(wrapper.find("table").contains("xyz")).to.be.false
-  })
+    const wrapper = shallow(<SitePublishedFilesTable {...props} />);
+    expect(wrapper.find('h3').contains('master')).to.be.true;
+  });
 
-  it("should render a loading state if the files are loading", () => {
+  it('should render a table with the files for the given branch', () => {
+    const correctBranch = { name: 'master', viewLink: 'www.example.gov/master' };
+    const incorrectBranch = { name: 'preview', viewLink: 'www.example.gov/preview' };
     const props = {
-      params: { id: 1, name: "master" },
-      publishedFiles: { isLoading: true }
-    }
+      params: { id: 1, name: 'master' },
+      publishedFiles: {
+        isLoading: false,
+        data: [
+          { name: 'abc', publishedBranch: correctBranch },
+          { name: 'abc/def', publishedBranch: correctBranch },
+          { name: null, publishedBranch: correctBranch }, // shouldn't be rendered b/c no name
+          { name: 'xyz', publishedBranch: incorrectBranch },
+        ],
+      },
+    };
 
-    const wrapper = shallow(<SitePublishedFilesTable {...props} />)
+    const wrapper = shallow(<SitePublishedFilesTable {...props} />);
+    expect(wrapper.find('table')).to.have.length(1);
+    expect(wrapper.find('tbody > tr')).to.have.length(2);
+    expect(wrapper.find('table').contains('abc')).to.be.true;
+    expect(wrapper.find('table').contains('abc/def')).to.be.true;
+    expect(wrapper.find('table').contains('xyz')).to.be.false;
+  });
+
+  it('should render a loading state if the files are loading', () => {
+    const props = {
+      params: { id: 1, name: 'master' },
+      publishedFiles: { isLoading: true },
+    };
+
+    const wrapper = shallow(<SitePublishedFilesTable {...props} />);
     expect(wrapper.find(LoadingIndicator)).to.have.length(1);
-  })
+  });
 
-  it("should render an empty state if there are no files", () => {
+  it('should render an empty state if there are no files', () => {
     const props = {
-      params: { id: 1, name: "master" },
-      publishedFiles: { isLoading: false, data: [] }
-    }
+      params: { id: 1, name: 'master' },
+      publishedFiles: { isLoading: false, data: [] },
+    };
 
-    const wrapper = shallow(<SitePublishedFilesTable {...props} />)
-    expect(wrapper.find("p").contains("No published branch files available")).to.be.true
-  })
-})
+    const wrapper = shallow(<SitePublishedFilesTable {...props} />);
+    expect(wrapper.find('p').contains('No published branch files available.')).to.be.true;
+  });
+});


### PR DESCRIPTION
**Open against branch `983-download-logs` (PR https://github.com/18F/federalist/pull/1014)**

This PR adds some new table styling classes and rules so that tables with pre-formatted content do not cause overruns of the page width. Ref #844.

Also filter out files with no names, which are redirect objects, from the `SitePublishedFilesTable` (ref #1015).

Build Table looks like this now:

<img width="1030" alt="screen shot 2017-06-19 at 3 07 26 pm" src="https://user-images.githubusercontent.com/697848/27304879-25736a28-5505-11e7-97d7-d856ad350de3.png">

Rows that have long messages look like this, and are scrollable:

<img width="794" alt="screen shot 2017-06-19 at 3 07 53 pm" src="https://user-images.githubusercontent.com/697848/27304865-1b3c743c-5505-11e7-929c-594f9cb04327.png">


Build Log Table looks like this now, with scrollable "Output" cells:

<img width="835" alt="screen shot 2017-06-19 at 3 38 07 pm" src="https://user-images.githubusercontent.com/697848/27304931-5f5d5ce4-5505-11e7-8ab6-7ab8203caacd.png">



