### PR TITLE
Display the app_env in site title unless in production

### DIFF
--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+
 const SiteWideErrorLoader = require('../services/SiteWideErrorLoader');
+const config = require('../../config');
 
 function loadAssetManifest() {
   const manifestPath = path.join(__dirname, '..', '..', 'webpack-manifest.json');
@@ -17,10 +19,13 @@ module.exports = {
       webpackAssets = loadAssetManifest();
     }
 
+    const siteDisplayEnv = config.app.app_env !== 'production' ? config.app.app_env : null;
+
     const context = {
       siteWideError: null,
       jsBundleName: webpackAssets['main.js'],
       cssBundleName: webpackAssets['main.css'],
+      siteDisplayEnv,
     };
 
     if (req.session.authenticated) {

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -2,6 +2,7 @@ const expect = require('chai').expect;
 const request = require('supertest');
 
 const app = require('../../../app');
+const config = require('../../../config');
 const session = require('../support/session');
 const factory = require('../support/factory');
 
@@ -36,6 +37,39 @@ describe('Main Site', () => {
         done();
       })
       .catch(done);
+    });
+
+    context('<title> element', () => {
+      const origAppEnv = config.app.app_env;
+
+      after(() => {
+        // reset config.app.app_env to its original value
+        config.app.app_env = origAppEnv;
+      });
+
+      it('should display the app_env in the title element', (done) => {
+        config.app.app_env = 'testing123';
+        request(app)
+          .get('/')
+          .then((response) => {
+            const titleRegex = /<title>\s*Federalist \| testing123\s*<\/title>/g;
+            expect(response.text.search(titleRegex)).to.be.above(-1);
+            done();
+          })
+          .catch(done);
+      });
+
+      it('should not display the app_env in the title when it is "production"', (done) => {
+        config.app.app_env = 'production';
+        request(app)
+          .get('/')
+          .then((response) => {
+            const titleRegex = /<title>\s*Federalist\s*<\/title>/g;
+            expect(response.text.search(titleRegex)).to.be.above(-1);
+            done();
+          })
+          .catch(done);
+      });
     });
   });
 

--- a/views/index.html
+++ b/views/index.html
@@ -29,7 +29,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Federalist</title>
+    <title>
+      Federalist<% if (siteDisplayEnv) { %> | <%= siteDisplayEnv %><% } %>
+    </title>
   </head>
   <body>
     <% if (siteWideError) { %>


### PR DESCRIPTION
Looks like:

<img width="236" alt="screen shot 2017-06-19 at 5 29 43 pm" src="https://user-images.githubusercontent.com/697848/27308582-f12420a4-5514-11e7-9b5a-61f23ba4415e.png">

In production, the `|` and app_env text are not displayed.
