### PR TITLE
rm unecessary call to `yarn --pure-lockfile` in before_deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_deploy:
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.22.2"
   - tar xzvf $HOME/cf.tgz -C $HOME
   - travis_retry cf install-plugin autopilot -f -r CF-Community
-  - yarn --pure-lockfile
   - yarn build
 deploy:
   - provider: script


### PR DESCRIPTION
There's no need to reinstall packages in the `before_deploy` section of the Travis build, and that second call is causing a build error due to some weirdness between Travis+node-sass+yarn+yarn cache, as described in https://github.com/sass/node-sass/issues/1579 and https://github.com/yarnpkg/yarn/issues/3485.

I _think_ removing that second installation will clear up the [`ENOENT` error on deploys from Travis](https://travis-ci.org/18F/federalist/builds/245402569#L1423), and it isn't necessary anyways since all the deps are already installed up in the `install` section of the Travis build.