### PR TITLE
Remove moment.js locales and add webpack-bundle-analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ public/styles/styles.*.css*
 public/styles/uswds.*.css*
 webpack-manifest.json
 webpackAssets
+public/stats.json
 
 # test coverage reports
 coverage

--- a/README.md
+++ b/README.md
@@ -167,8 +167,10 @@ There are really two applications in one repo here. Right now we're OK with that
 If you are working on the front-end of the application, the things you need to know are:
 
 0. It is a React based application
-0. It is built with `Webpack`
-0. It lives in `/assets/app`
+0. It is built with `webpack`
+0. It lives in `/frontend`
+
+To analyze the contents of the front end JavaScript bundle, use `yarn analyze-webpack` after a build. This will launch a browser window showing a visualization of all the code that makes up the bundle.
 
 #### Using Postgres
 
@@ -178,7 +180,7 @@ By default, the application should use local disk storage in place of a database
 0. Next, you'll have to create the `federalist` database for the application. `$ createdb federalist` should do the trick. If you wish to run the tests, do the same, but for a database named `federalist-test`.
 0. Add postgres to your `/config/local.js` file
 
-```
+```json
 connections: {
   postgres: {
     database: 'federalist'

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "migrate:create": "node migrate.js create",
     "migrate:up": "node migrate.js up || true",
     "migrate:down": "node migrate.js down",
-    "export:sites": "node ./scripts/exportSitesAsCsv.js"
+    "export:sites": "node ./scripts/exportSitesAsCsv.js",
+    "analyze-webpack": "webpack-bundle-analyzer public/stats.json"
   },
   "main": "index.js",
   "repository": {
@@ -108,6 +109,7 @@
     "uswds": "^0.9.0",
     "watch": "^1.0.2",
     "webpack": "^2.6.1",
+    "webpack-bundle-analyzer": "^2.8.2",
     "webpack-manifest-plugin": "^1.1.0"
   },
   "engines": {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,8 +1,10 @@
 import path from 'path';
 
+import webpack from 'webpack';
 import autoprefixer from 'autoprefixer';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import ManifestPlugin from 'webpack-manifest-plugin';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 const extractStyles = new ExtractTextPlugin({
   filename: 'styles/styles.[contenthash].css',
@@ -54,5 +56,19 @@ export default {
       },
     ],
   },
-  plugins: [extractStyles, manifestPlugin],
+  plugins: [
+    extractStyles,
+    manifestPlugin,
+    // When webpack bundles moment, it includes all of its locale files,
+    // which we don't need, so we'll use this plugin to keep them out of the
+    // bundle
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    // Generate a webpack-bundle-analyzer stats file (in public/stats.json)
+    // It can be viewed by running `yarn analyze-webpack`
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'disabled',
+      openAnalyzer: false,
+      generateStatsFile: true,
+    }),
+  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,7 +37,7 @@ acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.0.1:
+acorn@^5.0.0, acorn@^5.0.1, acorn@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
@@ -1416,7 +1416,7 @@ commander@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
 
-commander@2.9.x, commander@^2.8.1, commander@~2.9.0:
+commander@2.9.x, commander@^2.8.1, commander@^2.9.0, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1969,7 +1969,7 @@ dottie@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/dottie/-/dottie-1.1.1.tgz#45c2a3f48bd6528eeed267a69a848eaaca6faa6a"
 
-duplexer@~0.1.1:
+duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
@@ -2390,7 +2390,7 @@ express-winston@^2.3.0:
     chalk "~0.4.0"
     lodash "~4.11.1"
 
-express@^4.14.1:
+express@^4.14.1, express@^4.15.2:
   version "4.15.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
   dependencies:
@@ -2504,6 +2504,10 @@ fileset@^2.0.2:
   dependencies:
     glob "^7.0.3"
     minimatch "^3.0.3"
+
+filesize@^3.5.9:
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.10.tgz#fc8fa23ddb4ef9e5e0ab6e1e64f679a24a56761f"
 
 fill-keys@^1.0.2:
   version "1.0.2"
@@ -2841,6 +2845,12 @@ graceful-fs@~2.0.0:
 growl@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.8.1.tgz#4b2dec8d907e93db336624dcec0183502f8c9428"
+
+gzip-size@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
+  dependencies:
+    duplexer "^0.1.1"
 
 handlebars@^4.0.3:
   version "4.0.10"
@@ -3848,7 +3858,7 @@ lodash@4.12.0, lodash@^4.2.0, lodash@^4.5.1:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.12.0.tgz#2bd6dc46a040f59e686c972ed21d93dc59053258"
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.7.0, lodash@~4.17.2, lodash@~4.17.4:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.7.0, lodash@~4.17.2, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4488,6 +4498,10 @@ once@~1.3.0:
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
+opener@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
 optimist@^0.6.1, optimist@~0.6.1:
   version "0.6.1"
@@ -6300,6 +6314,10 @@ uid-safe@~2.1.4:
   dependencies:
     random-bytes "~1.0.0"
 
+ultron@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
+
 undefsafe@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-0.0.3.tgz#ecca3a03e56b9af17385baac812ac83b994a962f"
@@ -6462,6 +6480,22 @@ watchpack@^1.3.1:
     chokidar "^1.4.3"
     graceful-fs "^4.1.2"
 
+webpack-bundle-analyzer@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.8.2.tgz#8b6240c29a9d63bc72f09d920fb050adbcce9fe8"
+  dependencies:
+    acorn "^5.0.3"
+    chalk "^1.1.3"
+    commander "^2.9.0"
+    ejs "^2.5.6"
+    express "^4.15.2"
+    filesize "^3.5.9"
+    gzip-size "^3.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    opener "^1.4.3"
+    ws "^2.3.1"
+
 webpack-manifest-plugin@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-1.1.0.tgz#6b6c718aade8a2537995784b46bd2e9836057caa"
@@ -6592,6 +6626,13 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+ws@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
+  dependencies:
+    safe-buffer "~5.0.1"
+    ultron "~1.1.0"
 
 xdg-basedir@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This gets rid of moment.js locales from our JS bundle, which saves us almost 200Kb from our bundle (`649K` before,  `461K` after)!

I also added the `webpack-bundle-analyzer` plugin, which generates a stats.json file that can be viewed using `yarn analyze-webpack` to see what comprises the bundle size. Neat! Results look like this:

<img width="1100" alt="screen shot 2017-06-28 at 8 46 58 am" src="https://user-images.githubusercontent.com/697848/27640366-bce03956-5bde-11e7-8334-25871593b533.png">

