### PR TITLE
Add ability to specify a demo config 

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -106,6 +106,7 @@ module.exports = {
         demoDomain: params.demoDomain,
         config: params.config,
         previewConfig: params.previewConfig,
+        demoConfig: params.demoConfig,
         defaultBranch: params.defaultBranch,
         domain: params.domain,
         engine: params.engine,

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -1,106 +1,111 @@
-const authorizer = require("../authorizers/site")
-const S3SiteRemover = require("../services/S3SiteRemover")
-const SiteCreator = require("../services/SiteCreator")
-const siteSerializer = require("../serializers/site")
-const { User, Site, Build } = require("../models")
+const authorizer = require('../authorizers/site');
+const S3SiteRemover = require('../services/S3SiteRemover');
+const SiteCreator = require('../services/SiteCreator');
+const siteSerializer = require('../serializers/site');
+const { User, Site, Build } = require('../models');
 
 module.exports = {
   find: (req, res) => {
-    User.findById(req.user.id, { include: [ Site ] }).then(user => {
-      return siteSerializer.serialize(user.Sites)
-    }).then(sitesJSON => {
-      res.json(sitesJSON)
-    }).catch(err => {
-      res.error(err)
-    })
+    User.findById(req.user.id, { include: [Site] })
+      .then(user => siteSerializer.serialize(user.Sites))
+      .then((sitesJSON) => {
+        res.json(sitesJSON);
+      }).catch((err) => {
+        res.error(err);
+      });
   },
 
   findOne: (req, res) => {
-    let site
+    let site;
 
-    Promise.resolve(Number(req.params["id"])).then(id => {
+    Promise.resolve(Number(req.params.id)).then((id) => {
       if (isNaN(id)) {
-        throw 404
+        throw 404;
       }
-      return Site.findById(id)
-    }).then(model => {
+      return Site.findById(id);
+    }).then((model) => {
       if (model) {
-        site = model
+        site = model;
       } else {
-        throw 404
+        throw 404;
       }
-      return authorizer.findOne(req.user, site)
-    }).then(() => {
-      return siteSerializer.serialize(site)
-    }).then(siteJSON => {
-      res.json(siteJSON)
-    }).catch(err => {
-      res.error(err)
+      return authorizer.findOne(req.user, site);
     })
+    .then(() => siteSerializer.serialize(site))
+    .then((siteJSON) => {
+      res.json(siteJSON);
+    })
+    .catch((err) => {
+      res.error(err);
+    });
   },
 
   destroy: (req, res) => {
-    let site
-    let siteJSON
+    let site;
+    let siteJSON;
 
-    Promise.resolve(Number(req.params["id"])).then(id => {
-      if (isNaN(id)) {
-        throw 404
-      }
-      return Site.findById(id)
-    }).then(model => {
-      if (model) {
-        site = model
-      } else {
-        throw 404
-      }
-      return siteSerializer.serialize(site)
-    }).then(json => {
-      siteJSON = json
-      return authorizer.destroy(req.user, site)
-    }).then(() => {
-      return S3SiteRemover.removeSite(site)
-    }).then(() => {
-      return site.destroy()
-    }).then(() => {
-      res.json(siteJSON)
-    }).catch(err => {
-      res.error(err)
-    })
+    Promise.resolve(Number(req.params.id))
+      .then((id) => {
+        if (isNaN(id)) {
+          throw 404;
+        }
+        return Site.findById(id);
+      })
+      .then((model) => {
+        if (model) {
+          site = model;
+        } else {
+          throw 404;
+        }
+        return siteSerializer.serialize(site);
+      })
+      .then((json) => {
+        siteJSON = json;
+        return authorizer.destroy(req.user, site);
+      })
+      .then(() => S3SiteRemover.removeSite(site))
+      .then(() => site.destroy())
+      .then(() => {
+        res.json(siteJSON);
+      })
+      .catch((err) => {
+        res.error(err);
+      });
   },
 
   create: (req, res) => {
-    authorizer.create(req.user, req.body).then(() => {
-      return SiteCreator.createSite({
+    authorizer.create(req.user, req.body)
+      .then(() => SiteCreator.createSite({
         user: req.user,
         siteParams: req.body,
+      }))
+      .then(site => siteSerializer.serialize(site))
+      .then((siteJSON) => {
+        res.send(siteJSON);
       })
-    }).then(site => {
-      return siteSerializer.serialize(site)
-    }).then(siteJSON => {
-      res.send(siteJSON)
-    }).catch(err => {
-      res.error(err)
-    })
+      .catch((err) => {
+        res.error(err);
+      });
   },
 
   update: (req, res) => {
-    let site
-    let siteId = Number(req.params["id"])
+    let site;
+    const siteId = Number(req.params.id);
 
-    Promise.resolve(siteId).then(id => {
+    Promise.resolve(siteId).then((id) => {
       if (isNaN(id)) {
-        throw 404
+        throw 404;
       }
-      return Site.findById(id)
-    }).then(model => {
-      site = model
+      return Site.findById(id);
+    }).then((model) => {
+      site = model;
       if (!site) {
-        throw 404
+        throw 404;
       }
-      return authorizer.update(req.user, site)
-    }).then(() => {
-      const params = Object.assign(site, req.body)
+      return authorizer.update(req.user, site);
+    })
+    .then(() => {
+      const params = Object.assign(site, req.body);
       return site.update({
         demoBranch: params.demoBranch,
         demoDomain: params.demoDomain,
@@ -110,28 +115,29 @@ module.exports = {
         defaultBranch: params.defaultBranch,
         domain: params.domain,
         engine: params.engine,
-      })
-    }).then(model => {
-      let site = model
-      return Build.create({
-        user: req.user.id,
-        site: siteId,
-        branch: site.defaultBranch,
-      })
-    }).then(() => {
+      });
+    })
+    .then(model => Build.create({
+      user: req.user.id,
+      site: siteId,
+      branch: model.defaultBranch,
+    }))
+    .then(() => {
       if (site.demoBranch) {
         return Build.create({
           user: req.user.id,
           site: siteId,
           branch: site.demoBranch,
-        })
+        });
       }
-    }).then(() => {
-      return siteSerializer.serialize(site)
-    }).then(siteJSON => {
-      res.send(siteJSON)
-    }).catch(err => {
-      res.error(err)
+      return null;
     })
-  }
-}
+    .then(() => siteSerializer.serialize(site))
+    .then((siteJSON) => {
+      res.send(siteJSON);
+    })
+    .catch((err) => {
+      res.error(err);
+    });
+  },
+};

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -1,81 +1,80 @@
-const url = require("url")
-const config = require("../../config")
+const url = require('url');
+const config = require('../../config');
 
 const afterValidate = (site) => {
-  if (site.defaultBranch == site.demoBranch) {
-    const error = new Error("Default branch and demo branch cannot be the same")
-    error.status = 403
-    throw error
+  if (site.defaultBranch === site.demoBranch) {
+    const error = new Error('Default branch and demo branch cannot be the same');
+    error.status = 403;
+    throw error;
   }
-  if (site.domain && site.domain == site.demoDomain) {
-    const error = new Error("Domain and demo domain cannot be the same")
-    error.status = 403
-    throw error
+  if (site.domain && site.domain === site.demoDomain) {
+    const error = new Error('Domain and demo domain cannot be the same');
+    error.status = 403;
+    throw error;
   }
-}
+};
 
 const associate = ({ Site, Build, User }) => {
   Site.hasMany(Build, {
-    foreignKey: "site",
-  })
+    foreignKey: 'site',
+  });
   Site.belongsToMany(User, {
-    through: "site_users__user_sites",
-    foreignKey: "site_users",
+    through: 'site_users__user_sites',
+    foreignKey: 'site_users',
     timestamps: false,
-  })
-}
+  });
+};
 
 const beforeValidate = (site) => {
   if (site.repository) {
-    site.repository = site.repository.toLowerCase()
+    site.repository = site.repository.toLowerCase(); // eslint-disable-line no-param-reassign
   }
   if (site.owner) {
-    site.owner = site.owner.toLowerCase()
+    site.owner = site.owner.toLowerCase(); // eslint-disable-line no-param-reassign
   }
-}
+};
 
-const toJSON = function() {
+function toJSON() {
   const object = Object.assign({}, this.get({
     plain: true,
-  }))
+  }));
 
-  object.createdAt = object.createdAt.toISOString()
-  object.updatedAt = object.updatedAt.toISOString()
+  object.createdAt = object.createdAt.toISOString();
+  object.updatedAt = object.updatedAt.toISOString();
 
-  const s3Config = config.s3
-  object.siteRoot = `http://${s3Config.bucket}.s3-website-${s3Config.region}.amazonaws.com`
-  object.viewLink = object.domain || [object.siteRoot, 'site', object.owner, object.repository].join('/')
+  const s3Config = config.s3;
+  object.siteRoot = `http://${s3Config.bucket}.s3-website-${s3Config.region}.amazonaws.com`;
+  object.viewLink = object.domain || [object.siteRoot, 'site', object.owner, object.repository].join('/');
   if (object.demoBranch) {
-    object.demoViewLink = object.demoDomain || [object.siteRoot, 'demo', object.owner, object.repository].join('/')
+    object.demoViewLink = object.demoDomain || [object.siteRoot, 'demo', object.owner, object.repository].join('/');
   }
 
-  Object.keys(object).forEach(key => {
+  Object.keys(object).forEach((key) => {
     if (object[key] === null) {
-      delete object[key]
+      delete object[key];
     }
-  })
+  });
 
-  return object
+  return object;
 }
 
-const viewLinkForBranch = function(branch) {
-  const s3Root = `http://${config.s3.bucket}.s3-website-${config.s3.region}.amazonaws.com`
+function viewLinkForBranch(branch) {
+  const s3Root = `http://${config.s3.bucket}.s3-website-${config.s3.region}.amazonaws.com`;
 
   if (branch === this.defaultBranch && this.domain) {
-    return this.domain
+    return this.domain;
   } else if (branch === this.defaultBranch) {
-    return `${s3Root}/site/${this.owner}/${this.repository}`
+    return `${s3Root}/site/${this.owner}/${this.repository}`;
   } else if (branch === this.demoBranch && this.demoDomain) {
-    return this.demoDomain
+    return this.demoDomain;
   } else if (branch === this.demoBranch) {
-    return `${s3Root}/demo/${this.owner}/${this.repository}`
-  } else {
-    return url.resolve(config.app.preview_hostname, `/preview/${this.owner}/${this.repository}/${branch}`)
+    return `${s3Root}/demo/${this.owner}/${this.repository}`;
   }
+  return url.resolve(config.app.preview_hostname, `/preview/${this.owner}/${this.repository}/${branch}`);
 }
 
 module.exports = (sequelize, DataTypes) => {
-  const Site = sequelize.define("Site", {
+  const Site = sequelize.define('Site', {
     demoBranch: {
       type: DataTypes.STRING,
     },
@@ -87,15 +86,15 @@ module.exports = (sequelize, DataTypes) => {
     },
     defaultBranch: {
       type: DataTypes.STRING,
-      defaultValue: "master",
+      defaultValue: 'master',
     },
     domain: {
       type: DataTypes.STRING,
     },
     engine: {
       type: DataTypes.ENUM,
-      values: ["jekyll", "hugo", "static"],
-      defaultValue: "static",
+      values: ['jekyll', 'hugo', 'static'],
+      defaultValue: 'static',
     },
     owner: {
       type: DataTypes.STRING,
@@ -115,7 +114,7 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
     },
   }, {
-    tableName: "site",
+    tableName: 'site',
     classMethods: {
       associate,
     },
@@ -126,8 +125,8 @@ module.exports = (sequelize, DataTypes) => {
     hooks: {
       beforeValidate,
       afterValidate,
-    }
-  })
+    },
+  });
 
-  return Site
-}
+  return Site;
+};

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -104,6 +104,9 @@ module.exports = (sequelize, DataTypes) => {
     previewConfig: {
       type: DataTypes.STRING,
     },
+    demoConfig: {
+      type: DataTypes.STRING,
+    },
     publishedAt: {
       type: DataTypes.DATE,
     },

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -10,8 +10,10 @@ const defaultBranch = build => build.branch === build.Site.defaultBranch;
 const demoBranch = build => build.branch === build.Site.demoBranch;
 
 const siteConfig = (build) => {
-  if (defaultBranch(build) || demoBranch(build)) {
+  if (defaultBranch(build)) {
     return build.Site.config;
+  } else if (demoBranch(build)) {
+    return build.Site.demoConfig;
   }
   return build.Site.previewConfig;
 };

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -78,9 +78,11 @@ class SiteSettings extends React.Component {
       <form id="site-edit" onSubmit={this.onSubmit}>
         <div className="usa-grid">
           <div className="usa-width-one-whole">
-            <label htmlFor="defaultBranch" className={defaultBranchClass}>
-              Default branch</label>
+            <label htmlFor="defaultBranchInput" className={defaultBranchClass}>
+              Default branch
+            </label>
             <input
+              id="defaultBranchInput"
               name="defaultBranch"
               className="form-control"
               onChange={this.onChange}
@@ -131,19 +133,21 @@ class SiteSettings extends React.Component {
                 <p className="well-text">
                   Setup a branch to be deployed to a demo url.
                 </p>
-                <p>Branch name:</p>
+                <label htmlFor="demoBranchInput">Branch name:</label>
                 <input
                   name="demoBranch"
+                  id="demoBranchInput"
                   className="form-control"
                   type="text"
                   placeholder="Branch name"
                   value={state.demoBranch}
                   onChange={this.onChange}
                 />
-                <p>Demo domain:</p>
+                <label htmlFor="demoDomainInput">Demo domain:</label>
                 <input
                   name="demoDomain"
                   className="form-control"
+                  id="demoDomainInput"
                   type="text"
                   placeholder="https://preview.example.com"
                   value={state.demoDomain}

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -24,6 +24,7 @@ class SiteSettings extends React.Component {
       demoDomain: site.demoDomain || '',
       config: site.config || '',
       previewConfig: site.previewConfig || '',
+      demoConfig: site.demoConfig || '',
       defaultBranch: site.defaultBranch || '',
       domain: site.domain || '',
       engine: site.engine,
@@ -164,6 +165,23 @@ class SiteSettings extends React.Component {
                 name="config"
                 className="form-control"
                 value={state.config}
+                onChange={this.onChange}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="usa-grid">
+          <div className="usa-width-one-whole">
+            <div className="well">
+              <h3 className="well-heading">Demo configuration</h3>
+              <p className="well-text">
+                Add additional configuration in yaml to be added to your
+                <code>_config.yml</code> file when we build your site&apos;s demo branch.
+              </p>
+              <textarea
+                name="demoConfig"
+                className="form-control"
+                value={state.demoConfig}
                 onChange={this.onChange}
               />
             </div>

--- a/migrations/20170628180932-add-demo-config-to-site.js
+++ b/migrations/20170628180932-add-demo-config-to-site.js
@@ -1,0 +1,19 @@
+exports.up = function up(db, callback) {
+  db.addColumn('site', 'demoConfig', 'text', (addColErr) => {
+    if (addColErr) {
+      callback(addColErr);
+    } else {
+      db.runSql('UPDATE site SET "demoConfig" = config', (runErr) => {
+        if (runErr) {
+          callback(runErr);
+        } else {
+          callback();
+        }
+      });
+    }
+  });
+};
+
+exports.down = function down(db, callback) {
+  db.removeColumn('site', 'demoConfig', callback);
+};

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -41,6 +41,9 @@
     "previewConfig": {
       "type": "string"
     },
+    "demoConfig": {
+      "type": "string"
+    },
     "publishedAt": {
       "type": "string",
       "format": "date-time"

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -220,6 +220,9 @@ paths:
               previewConfig:
                 type: string
                 description: Jekyll configs for the site in the preview environment
+              demoConfig:
+                type: string
+                description: Jekyll configs for the site demo
               repository:
                 type: string
                 description: The name of the GitHub repository for the site
@@ -298,6 +301,9 @@ paths:
               previewConfig:
                 type: string
                 description: Jekyll configs for the site in the preview environment
+              demoConfig:
+                type: string
+                description: Jekyll configs for the site demo
               repository:
                 type: string
                 description: The name of the GitHub repository for the site

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -1,724 +1,739 @@
-const crypto = require("crypto")
-const expect = require("chai").expect
-const nock = require("nock")
-const request = require("supertest")
-const sinon = require("sinon")
+const crypto = require('crypto');
+const expect = require('chai').expect;
+const nock = require('nock');
+const request = require('supertest');
+const sinon = require('sinon');
 
-const app = require("../../../app")
-const factory = require("../support/factory")
-const githubAPINocks = require("../support/githubAPINocks")
-const session = require("../support/session")
-const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
+const app = require('../../../app');
+const factory = require('../support/factory');
+const githubAPINocks = require('../support/githubAPINocks');
+const session = require('../support/session');
+const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
 
-const { Build, Site, User } = require("../../../api/models")
-const S3SiteRemover = require("../../../api/services/S3SiteRemover")
+const { Build, Site, User } = require('../../../api/models');
+const S3SiteRemover = require('../../../api/services/S3SiteRemover');
 
-describe("Site API", () => {
-  var siteResponseExpectations = (response, site) => {
-    expect(response.owner).to.equal(site.owner)
-    expect(response.repository).to.equal(site.repository)
-    expect(response.engine).to.equal(site.engine)
-    expect(response.defaultBranch).to.equal(site.defaultBranch)
-    expect(response.siteRoot).to.be.a("string")
-    expect(response.viewLink).to.be.a("string")
-  }
+describe('Site API', () => {
+  const siteResponseExpectations = (response, site) => {
+    expect(response.owner).to.equal(site.owner);
+    expect(response.repository).to.equal(site.repository);
+    expect(response.engine).to.equal(site.engine);
+    expect(response.defaultBranch).to.equal(site.defaultBranch);
+    expect(response.siteRoot).to.be.a('string');
+    expect(response.viewLink).to.be.a('string');
+  };
 
-  describe("GET /v0/site", () => {
-    it("should require authentication", done => {
-      factory.build().then(build => {
-        return request(app)
-          .get("/v0/site")
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site", 403, response.body)
-        done()
-      }).catch(done)
-    })
-
-    it("should render a list of sites associated with the user", done => {
-      var user, sites, response
-
-      factory.user().then(model => {
-        user = model
-        var sitePromises = Array(3).fill(0).map(() => {
-          return factory.site({ users: [user.id] })
-        })
-        return Promise.all(sitePromises)
-      }).then(models => {
-        sites = models
-        return session(user)
-      }).then(cookie => {
-        return request(app)
-          .get("/v0/site")
-          .set("Cookie", cookie)
-          .expect(200)
-      }).then(resp => {
-        response = resp
-
-        validateAgainstJSONSchema("GET", "/site", 200, response.body)
-
-        expect(response.body).to.be.a("array")
-        expect(response.body).to.have.length(3)
-
-        return Promise.all(sites.map(site => {
-          return Site.findById(site.id, { include: [ User ]})
-        }))
-      }).then(sites => {
-        sites.forEach(site => {
-          const responseSite = response.body.find(candidate => {
-            return candidate.id === site.id
+  describe('GET /v0/site', () => {
+    it('should require authentication', (done) => {
+      factory.build().then(() => request(app)
+          .get('/v0/site')
+          .expect(403))
+          .then((response) => {
+            validateAgainstJSONSchema('GET', '/site', 403, response.body);
+            done();
           })
-          expect(responseSite).not.to.be.undefined
-          siteResponseExpectations(responseSite, site)
+          .catch(done);
+    });
+
+    it('should render a list of sites associated with the user', (done) => {
+      let user;
+      let sites;
+      let response;
+
+      factory.user().then((model) => {
+        user = model;
+        const sitePromises = Array(3).fill(0).map(() => factory.site({ users: [user.id] }));
+        return Promise.all(sitePromises);
+      }).then((models) => {
+        sites = models;
+        return session(user);
+      }).then(cookie => request(app)
+          .get('/v0/site')
+          .set('Cookie', cookie)
+          .expect(200))
+          .then((resp) => {
+            response = resp;
+
+            validateAgainstJSONSchema('GET', '/site', 200, response.body);
+
+            expect(response.body).to.be.a('array');
+            expect(response.body).to.have.length(3);
+
+            return Promise.all(sites.map(site => Site.findById(site.id, { include: [User] })));
+          })
+          .then((foundSites) => {
+            foundSites.forEach((site) => {
+              const responseSite = response.body.find(candidate => candidate.id === site.id);
+              expect(responseSite).not.to.be.undefined;
+              siteResponseExpectations(responseSite, site);
+            });
+            done();
+          })
+          .catch(done);
+    });
+
+    it('should not render any sites not associated with the user', (done) => {
+      const sitePromises = Array(3).fill(0).map(() => factory.site());
+
+      Promise.all(sitePromises).then((site) => {
+        expect(site).to.have.length(3);
+        return session(factory.user());
+      }).then(cookie => request(app)
+          .get('/v0/site')
+          .set('Cookie', cookie)
+          .expect(200))
+          .then((response) => {
+            validateAgainstJSONSchema('GET', '/site', 200, response.body);
+            expect(response.body).to.be.a('array');
+            expect(response.body).to.be.empty;
+            done();
+          })
+          .catch(done);
+    });
+  });
+
+  describe('GET /v0/site/:id', () => {
+    it('should require authentication', (done) => {
+      factory.site().then(site => request(app)
+          .get(`/v0/site/${site.id}`)
+          .expect(403))
+          .then((response) => {
+            validateAgainstJSONSchema('GET', '/site/{id}', 403, response.body);
+            done();
+          })
+          .catch(done);
+    });
+
+    it('should render a JSON representation of the site', (done) => {
+      let site;
+
+      factory.site()
+        .then(s => Site.findById(s.id, { include: [User] }))
+        .then((model) => {
+          site = model;
+          return session(site.Users[0]);
         })
-        done()
-      }).catch(done)
-    })
-
-    it("should not render any sites not associated with the user", done => {
-      var sitePromises = Array(3).fill(0).map(() => {
-        return factory.site()
-      })
-
-      Promise.all(sitePromises).then(site => {
-        expect(site).to.have.length(3)
-        return session(factory.user())
-      }).then(cookie => {
-        return request(app)
-          .get("/v0/site")
-          .set("Cookie", cookie)
+        .then(cookie => request(app)
+          .get(`/v0/site/${site.id}`)
+          .set('Cookie', cookie)
           .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site", 200, response.body)
-        expect(response.body).to.be.a("array")
-        expect(response.body).to.be.empty
-        done()
-      }).catch(done)
-    })
-  })
+        )
+        .then((response) => {
+          validateAgainstJSONSchema('GET', '/site/{id}', 200, response.body);
+          siteResponseExpectations(response.body, site);
+          done();
+        })
+        .catch(done);
+    });
 
-  describe("GET /v0/site/:id", () => {
-    it("should require authentication", done => {
-      factory.site().then(site => {
-        return request(app)
+    it('should respond with a 403 if the user is not associated with the site', (done) => {
+      let site;
+
+      factory.site().then((model) => {
+        site = model;
+        return session(factory.user());
+      }).then(cookie => request(app)
           .get(`/v0/site/${site.id}`)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{id}", 403, response.body)
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', cookie)
+          .expect(403))
+          .then((response) => {
+            validateAgainstJSONSchema('GET', '/site/{id}', 403, response.body);
+            done();
+          })
+          .catch(done);
+    });
+  });
 
-    it("should render a JSON representation of the site", done => {
-      var site
-
-      factory.site().then(site => {
-        return Site.findById(site.id, { include: [ User ] })
-      }).then(model => {
-        site = model
-        return session(site.Users[0])
-      }).then(cookie => {
-        return request(app)
-          .get(`/v0/site/${site.id}`)
-          .set("Cookie", cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{id}", 200, response.body)
-        siteResponseExpectations(response.body, site)
-        done()
-      }).catch(done)
-    })
-
-    it("should respond with a 403 if the user is not associated with the site", done => {
-      var site
-
-      factory.site().then(model => {
-        site = model
-        return session(factory.user())
-      }).then(cookie => {
-        return request(app)
-          .get(`/v0/site/${site.id}`)
-          .set("Cookie", cookie)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{id}", 403, response.body)
-        done()
-      }).catch(done)
-    })
-  })
-
-  describe("POST /v0/site", () => {
+  describe('POST /v0/site', () => {
     beforeEach(() => {
-      nock.cleanAll()
-      githubAPINocks.repo()
-      githubAPINocks.createRepoForOrg()
-      githubAPINocks.webhook()
-    })
+      nock.cleanAll();
+      githubAPINocks.repo();
+      githubAPINocks.createRepoForOrg();
+      githubAPINocks.webhook();
+    });
 
     afterEach(() => {
-      nock.cleanAll()
-    })
+      nock.cleanAll();
+    });
 
-    it("should require authentication", done => {
+    it('should require authentication', (done) => {
       const newSiteRequest = request(app)
-        .post(`/v0/site`)
+        .post('/v0/site')
         .send({
-          organization: "partner-org",
-          repository: "partner-site",
-          defaultBranch: "master",
-          engine: "jekyll"
+          organization: 'partner-org',
+          repository: 'partner-site',
+          defaultBranch: 'master',
+          engine: 'jekyll',
         })
-        .expect(403)
+        .expect(403);
 
-      newSiteRequest.then(response => {
-        validateAgainstJSONSchema("POST", "/site", 403, response.body)
-        done()
-      }).catch(done)
-    })
+      newSiteRequest.then((response) => {
+        validateAgainstJSONSchema('POST', '/site', 403, response.body);
+        done();
+      }).catch(done);
+    });
 
-    it("should create a new site from an existing repository", done => {
-      const siteOwner = crypto.randomBytes(3).toString("hex")
-      const siteRepository = crypto.randomBytes(3).toString("hex")
+    it('should create a new site from an existing repository', (done) => {
+      const siteOwner = crypto.randomBytes(3).toString('hex');
+      const siteRepository = crypto.randomBytes(3).toString('hex');
 
-      session().then(cookie => {
-        return request(app)
-          .post(`/v0/site`)
+      session().then(cookie => request(app)
+          .post('/v0/site')
           .send({
             owner: siteOwner,
             repository: siteRepository,
-            defaultBranch: "master",
-            engine: "jekyll"
+            defaultBranch: 'master',
+            engine: 'jekyll',
           })
-          .set("Cookie", cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("POST", "/site", 200, response.body)
-        return Site.findOne({
-          where: {
-            owner: siteOwner,
-            repository: siteRepository,
-          },
-        })
-      }).then(site => {
-        expect(site).to.not.be.undefined
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', cookie)
+          .expect(200)).then((response) => {
+            validateAgainstJSONSchema('POST', '/site', 200, response.body);
+            return Site.findOne({
+              where: {
+                owner: siteOwner,
+                repository: siteRepository,
+              },
+            });
+          })
+          .then((site) => {
+            expect(site).to.not.be.undefined;
+            done();
+          })
+          .catch(done);
+    });
 
-    it("should add a user to an existing site for an existing repository", done => {
-      let user, site
-      const userPromise = factory.user()
+    it('should add a user to an existing site for an existing repository', (done) => {
+      let user;
+      let site;
+      const userPromise = factory.user();
 
       Promise.props({
         user: userPromise,
         site: factory.site(),
         cookie: session(userPromise),
-      }).then(models => {
-        user = models.user
-        site = models.site
+      }).then((models) => {
+        user = models.user;
+        site = models.site;
 
-        githubAPINocks.repo()
+        githubAPINocks.repo();
 
         return request(app)
-          .post(`/v0/site`)
+          .post('/v0/site')
           .send({
             owner: site.owner,
             repository: site.repository,
-            defaultBranch: "master",
-            engine: "jekyll"
+            defaultBranch: 'master',
+            engine: 'jekyll',
           })
-          .set("Cookie", models.cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("POST", "/site", 200, response.body)
+          .set('Cookie', models.cookie)
+          .expect(200);
+      })
+      .then((response) => {
+        validateAgainstJSONSchema('POST', '/site', 200, response.body);
         return Site.findAll({
           where: {
             owner: site.owner,
             repository: site.repository,
           },
-          include: [ User ],
-        })
-      }).then(sites => {
-        expect(sites).to.have.length(1)
-        const site = sites[0]
-        const addedUser = site.Users.find(candidate => candidate.id === user.id)
-        expect(addedUser).to.not.be.undefined
-        done()
-      }).catch(done)
-    })
+          include: [User],
+        });
+      })
+      .then((sites) => {
+        expect(sites).to.have.length(1);
+        const s = sites[0];
+        const addedUser = s.Users.find(candidate => candidate.id === user.id);
+        expect(addedUser).to.not.be.undefined;
+        done();
+      })
+      .catch(done);
+    });
 
-    it("should create a new repo and site from a template", done => {
-      const siteOwner = crypto.randomBytes(3).toString("hex")
-      const siteRepository = crypto.randomBytes(3).toString("hex")
+    it('should create a new repo and site from a template', (done) => {
+      const siteOwner = crypto.randomBytes(3).toString('hex');
+      const siteRepository = crypto.randomBytes(3).toString('hex');
 
-      nock.cleanAll()
-      githubAPINocks.repo()
-      githubAPINocks.webhook()
+      nock.cleanAll();
+      githubAPINocks.repo();
+      githubAPINocks.webhook();
 
       const createRepoNock = githubAPINocks.createRepoForOrg({
         org: siteOwner,
         repo: siteRepository,
-      })
+      });
 
-      session().then(cookie => {
-        return request(app)
-          .post(`/v0/site`)
+      session().then(cookie => request(app)
+          .post('/v0/site')
           .send({
             owner: siteOwner,
             repository: siteRepository,
-            defaultBranch: "master",
-            engine: "jekyll",
-            template: "team",
+            defaultBranch: 'master',
+            engine: 'jekyll',
+            template: 'team',
           })
-          .set("Cookie", cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("POST", "/site", 200, response.body)
-        return Site.findOne({
-          where: {
-            owner: siteOwner,
-            repository: siteRepository,
-          },
-        })
-      }).then(site => {
-        expect(site).to.not.be.undefined
-        expect(createRepoNock.isDone()).to.equal(true)
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', cookie)
+          .expect(200))
+          .then((response) => {
+            validateAgainstJSONSchema('POST', '/site', 200, response.body);
+            return Site.findOne({
+              where: {
+                owner: siteOwner,
+                repository: siteRepository,
+              },
+            });
+          })
+          .then((site) => {
+            expect(site).to.not.be.undefined;
+            expect(createRepoNock.isDone()).to.equal(true);
+            done();
+          })
+          .catch(done);
+    });
 
-    it("should respond with a 400 if no user or repository is specified", done => {
-      session().then(cookie => {
-        return request(app)
-          .post(`/v0/site`)
+    it('should respond with a 400 if no user or repository is specified', (done) => {
+      session().then(cookie => request(app)
+          .post('/v0/site')
           .send({
-            defaultBranch: "master",
-            engine: "jekyll",
-            template: "team",
+            defaultBranch: 'master',
+            engine: 'jekyll',
+            template: 'team',
           })
-          .set("Cookie", cookie)
-          .expect(400)
-      }).then(response => {
-        validateAgainstJSONSchema("POST", "/site", 400, response.body)
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', cookie)
+          .expect(400)).then((response) => {
+            validateAgainstJSONSchema('POST', '/site', 400, response.body);
+            done();
+          }).catch(done);
+    });
 
-    it("should respond with a 400 if a user has already added a site", done => {
-      const userPromise = factory.user()
+    it('should respond with a 400 if a user has already added a site', (done) => {
+      const userPromise = factory.user();
 
       Promise.props({
         user: userPromise,
         site: factory.site({ users: Promise.all([userPromise]) }),
         cookie: session(userPromise),
-      }).then(({ site, cookie }) => {
-        return request(app)
-          .post(`/v0/site`)
+      }).then(({ site, cookie }) => request(app)
+          .post('/v0/site')
           .send({
             owner: site.owner,
             repository: site.repository,
-            defaultBranch: "master",
-            engine: "jekyll",
+            defaultBranch: 'master',
+            engine: 'jekyll',
           })
-          .set("Cookie", cookie)
-          .expect(400)
-      }).then(response => {
-        validateAgainstJSONSchema("POST", "/site", 400, response.body)
-        expect(response.body.message).to.equal("You've already added this site to Federalist")
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', cookie)
+          .expect(400)).then((response) => {
+            validateAgainstJSONSchema('POST', '/site', 400, response.body);
+            expect(response.body.message).to.equal("You've already added this site to Federalist");
+            done();
+          }).catch(done);
+    });
 
-    it("should respond with a 400 if the user does not have admin access to the repository", done => {
-      const siteOwner = crypto.randomBytes(3).toString("hex")
-      const siteRepository = crypto.randomBytes(3).toString("hex")
+    it('should respond with a 400 if the user does not have admin access to the repository', (done) => {
+      const siteOwner = crypto.randomBytes(3).toString('hex');
+      const siteRepository = crypto.randomBytes(3).toString('hex');
 
-      nock.cleanAll()
+      nock.cleanAll();
       githubAPINocks.repo({
         owner: siteOwner,
         repository: siteRepository,
         response: [200, {
-          permissions: { admin: false, push: false }
+          permissions: { admin: false, push: false },
         }],
-      })
-      githubAPINocks.webhook()
+      });
+      githubAPINocks.webhook();
 
-      session().then(cookie => {
-        return request(app)
-          .post(`/v0/site`)
+      session().then(cookie => request(app)
+          .post('/v0/site')
           .send({
             owner: siteOwner,
             repository: siteRepository,
-            defaultBranch: "master",
-            engine: "jekyll",
+            defaultBranch: 'master',
+            engine: 'jekyll',
           })
-          .set("Cookie", cookie)
-          .expect(400)
-      }).then(response => {
-        validateAgainstJSONSchema("POST", "/site", 400, response.body)
-        expect(response.body.message).to.equal("You do not have admin access to this repository")
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', cookie)
+          .expect(400)).then((response) => {
+            validateAgainstJSONSchema('POST', '/site', 400, response.body);
+            expect(response.body.message).to.equal('You do not have admin access to this repository');
+            done();
+          }).catch(done);
+    });
 
-    it("should respond with a 400 if the site has been created by a user who does not have write access to the repository", done => {
-      let site
-      factory.site().then(model => {
-        site = model
+    it('should respond with a 400 if the site has been created by a user who does not have write access to the repository', (done) => {
+      let site;
+      factory.site().then((model) => {
+        site = model;
 
-        nock.cleanAll()
+        nock.cleanAll();
         githubAPINocks.repo({
           owner: site.owner,
           repository: site.repository,
           response: [200, {
-            permissions: { admin: false, push: false }
+            permissions: { admin: false, push: false },
           }],
-        })
-        githubAPINocks.webhook()
+        });
+        githubAPINocks.webhook();
 
-        return session()
-      }).then(cookie => {
-        return request(app)
-          .post(`/v0/site`)
+        return session();
+      }).then(cookie => request(app)
+          .post('/v0/site')
           .send({
             owner: site.owner,
             repository: site.repository,
-            defaultBranch: "master",
-            engine: "jekyll",
+            defaultBranch: 'master',
+            engine: 'jekyll',
           })
-          .set("Cookie", cookie)
-          .expect(400)
-      }).then(response => {
-        validateAgainstJSONSchema("POST", "/site", 400, response.body)
-        expect(response.body.message).to.equal("You do not have write access to this repository")
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', cookie)
+          .expect(400))
+          .then((response) => {
+            validateAgainstJSONSchema('POST', '/site', 400, response.body);
+            expect(response.body.message).to.equal('You do not have write access to this repository');
+            done();
+          })
+          .catch(done);
+    });
 
-    it("should respond with a 400 if a webhook cannot be created", done => {
-      const siteOwner = crypto.randomBytes(3).toString("hex")
-      const siteRepository = crypto.randomBytes(3).toString("hex")
+    it('should respond with a 400 if a webhook cannot be created', (done) => {
+      const siteOwner = crypto.randomBytes(3).toString('hex');
+      const siteRepository = crypto.randomBytes(3).toString('hex');
 
-      nock.cleanAll()
-      githubAPINocks.repo()
+      nock.cleanAll();
+      githubAPINocks.repo();
       githubAPINocks.webhook({
         owner: siteOwner,
         repo: siteRepository,
         response: [404, {
-          message: "Not Found",
-        }]
-      })
+          message: 'Not Found',
+        }],
+      });
 
-      session().then(cookie => {
-        return request(app)
-          .post(`/v0/site`)
+      session().then(cookie => request(app)
+          .post('/v0/site')
           .send({
             owner: siteOwner,
             repository: siteRepository,
-            defaultBranch: "master",
-            engine: "jekyll",
+            defaultBranch: 'master',
+            engine: 'jekyll',
           })
-          .set("Cookie", cookie)
-          .expect(400)
-      }).then(response => {
-        validateAgainstJSONSchema("POST", "/site", 400, response.body)
-        expect(response.body.message).to.equal("You do not have admin access to this repository")
-        done()
-      }).catch(done)
-    })
-  })
+          .set('Cookie', cookie)
+          .expect(400)).then((response) => {
+            validateAgainstJSONSchema('POST', '/site', 400, response.body);
+            expect(response.body.message).to.equal('You do not have admin access to this repository');
+            done();
+          }).catch(done);
+    });
+  });
 
-  describe("DELETE /v0/site/:id", () => {
+  describe('DELETE /v0/site/:id', () => {
     beforeEach(() => {
-      sinon.stub(S3SiteRemover, "removeSite", () => Promise.resolve())
-    })
+      sinon.stub(S3SiteRemover, 'removeSite', () => Promise.resolve());
+    });
 
     afterEach(() => {
-      S3SiteRemover.removeSite.restore()
-    })
+      S3SiteRemover.removeSite.restore();
+    });
 
-    it("should require authentication", done => {
-      factory.site().then(site => {
-        return request(app)
+    it('should require authentication', (done) => {
+      factory.site().then(site => request(app)
           .delete(`/v0/site/${site.id}`)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("DELETE", "/site/{id}", 403, response.body)
-        done()
-      })
-    })
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('DELETE', '/site/{id}', 403, response.body);
+            done();
+          });
+    });
 
-    it("should allow a user to delete a site associated with their account", done => {
-      var site
+    it('should allow a user to delete a site associated with their account', (done) => {
+      let site;
 
-      factory.site().then(site => {
-        return Site.findById(site.id, { include: [ User ] })
-      }).then(model => {
-        site = model
-        return session(site.Users[0])
-      }).then(cookie => {
-        return request(app)
+      factory.site()
+        .then(s => Site.findById(s.id, { include: [User] }))
+        .then((model) => {
+          site = model;
+          return session(site.Users[0]);
+        })
+        .then(cookie => request(app)
           .delete(`/v0/site/${site.id}`)
-          .set("Cookie", cookie)
+          .set('Cookie', cookie)
           .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("DELETE", "/site/{id}", 200, response.body)
-        siteResponseExpectations(response.body, site)
-        return Site.findAll({ where: { id: site.id } })
-      }).then(sites => {
-        expect(sites).to.be.empty
-        done()
-      }).catch(done)
-    })
+        )
+        .then((response) => {
+          validateAgainstJSONSchema('DELETE', '/site/{id}', 200, response.body);
+          siteResponseExpectations(response.body, site);
+          return Site.findAll({ where: { id: site.id } });
+        })
+        .then((sites) => {
+          expect(sites).to.be.empty;
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should not allow a user to delete a site not associated with their account", done => {
-      var site
+    it('should not allow a user to delete a site not associated with their account', (done) => {
+      let site;
 
-      factory.site().then(site => {
-        return Site.findById(site.id)
-      }).then(model => {
-        site = model
-        return session(factory.user())
-      }).then(cookie => {
-        return request(app)
+      factory.site()
+        .then(s => Site.findById(s.id))
+        .then((model) => {
+          site = model;
+          return session(factory.user());
+        })
+        .then(cookie => request(app)
           .delete(`/v0/site/${site.id}`)
-          .set("Cookie", cookie)
+          .set('Cookie', cookie)
           .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("DELETE", "/site/{id}", 403, response.body)
-        return Site.findAll({ where: { id: site.id } })
-      }).then(sites => {
-        expect(sites).not.to.be.empty
-        done()
-      }).catch(done)
-    })
+        )
+        .then((response) => {
+          validateAgainstJSONSchema('DELETE', '/site/{id}', 403, response.body);
+          return Site.findAll({ where: { id: site.id } });
+        })
+        .then((sites) => {
+          expect(sites).not.to.be.empty;
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should remove all of the site's data from S3", done => {
-      let site
-      const userPromise = factory.user()
-      const sitePromise = factory.site({ users: Promise.all([userPromise]) })
-      const sessionPromise = session(userPromise)
+    it("should remove all of the site's data from S3", (done) => {
+      let site;
+      const userPromise = factory.user();
+      const sitePromise = factory.site({ users: Promise.all([userPromise]) });
+      const sessionPromise = session(userPromise);
 
       Promise.props({
         user: userPromise,
         site: sitePromise,
         cookie: sessionPromise,
-      }).then(results => {
-        site = results.site
-        S3SiteRemover.removeSite.restore()
-        sinon.stub(S3SiteRemover, "removeSite", (calledSite) => {
-          expect(calledSite.id).to.equal(site.id)
-          return Promise.resolve()
-        })
+      }).then((results) => {
+        site = results.site;
+        S3SiteRemover.removeSite.restore();
+        sinon.stub(S3SiteRemover, 'removeSite', (calledSite) => {
+          expect(calledSite.id).to.equal(site.id);
+          return Promise.resolve();
+        });
 
         return request(app)
           .delete(`/v0/site/${site.id}`)
-          .set("Cookie", results.cookie)
+          .set('Cookie', results.cookie)
+          .expect(200);
+      })
+      .then(() => {
+        expect(S3SiteRemover.removeSite.calledOnce).to.equal(true);
+        done();
+      })
+      .catch(done);
+    });
+  });
+
+  describe('PUT /v0/site/:id', () => {
+    it('should require authentication', (done) => {
+      factory.site().then(site => request(app)
+          .put(`/v0/site/${site.id}`)
+          .send({
+            defaultBranch: 'master',
+          })
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('PUT', '/site/{id}', 403, response.body);
+            done();
+          }).catch(done);
+    });
+
+    it('should allow a user to update a site associated with their account', (done) => {
+      let site;
+      let response;
+
+      factory.site({ config: 'old-config', demoConfig: 'old-demo-config', previewConfig: 'old-preview-config' })
+      .then(s => Site.findById(s.id, { include: [User] }))
+      .then((model) => {
+        site = model;
+        return session(site.Users[0]);
+      })
+      .then(cookie => request(app)
+          .put(`/v0/site/${site.id}`)
+          .send({
+            config: 'new-config',
+            demoConfig: 'new-demo-config',
+            previewConfig: 'new-preview-config',
+          })
+          .set('Cookie', cookie)
           .expect(200)
-      }).then(response => {
-        expect(S3SiteRemover.removeSite.calledOnce).to.equal(true)
-        done()
-      }).catch(done)
-    })
-  })
-
-  describe("PUT /v0/site/:id", () => {
-    it("should require authentication", done => {
-      factory.site().then(site => {
-        return request(app)
-          .put(`/v0/site/${site.id}`)
-          .send({
-            defaultBranch: "master"
-          })
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("PUT", "/site/{id}", 403, response.body)
-        done()
-      }).catch(done)
-    })
-
-    it("should allow a user to update a site associated with their account", done => {
-      var site, response
-
-      factory.site({ config: "old-config", demoConfig: "old-demo-config", previewConfig: "old-preview-config" }).then(site => {
-        return Site.findById(site.id, { include: [ User ] })
-      }).then(model => {
-        site = model
-        return session(site.Users[0])
-      }).then(cookie => {
-        return request(app)
-          .put(`/v0/site/${site.id}`)
-          .send({
-            config: "new-config",
-            demoConfig: "new-demo-config",
-            previewConfig: "new-preview-config",
-          })
-          .set("Cookie", cookie)
-          .expect(200)
-      }).then(resp => {
-        response = resp
-        return Site.findById(site.id, { include: [ User ] })
-      }).then(site => {
-        validateAgainstJSONSchema("PUT", "/site/{id}", 200, response.body)
-
-        expect(response.body.config).to.equal("new-config")
-        expect(site.config).to.equal("new-config")
-        expect(response.body.demoConfig).to.equal("new-demo-config")
-        expect(site.demoConfig).to.equal("new-demo-config")
-        expect(response.body.previewConfig).to.equal("new-preview-config")
-        expect(site.previewConfig).to.equal("new-preview-config")
-        siteResponseExpectations(response.body, site)
-
-        done()
-      }).catch(done)
-    })
-
-    it("should not allow a user to update a site not associated with their account", done => {
-      factory.site({ repository: "old-repo-name" }).then(site => {
-        return Site.findById(site.id)
-      }).then(model => {
-        site = model
-        return session(factory.user())
-      }).then(cookie => {
-        return request(app)
-          .put(`/v0/site/${site.id}`)
-          .send({
-            repository: "new-repo-name"
-          })
-          .set("Cookie", cookie)
-          .expect(403)
-      }).then(resp => {
-        response = resp
-        validateAgainstJSONSchema("PUT", "/site/{id}", 403, response.body)
-        return Site.findById(site.id)
-      }).then(site => {
-        expect(site).to.have.property("repository", "old-repo-name")
-        done()
-      }).catch(done)
-    })
-
-    it("should trigger a rebuild of the site", done => {
-      factory.site({ repository: "old-repo-name" }).then(site => {
-        return Site.findById(site.id, { include: [ User, Build ] })
-      }).then(model => {
-        site = model
-        expect(site.Builds).to.have.length(0)
-        return session(site.Users[0])
-      }).then(cookie => {
-        return request(app)
-          .put(`/v0/site/${site.id}`)
-          .send({
-            repository: "new-repo-name"
-          })
-          .set("Cookie", cookie)
-          .expect(200)
-      }).then(resp => {
-        return Site.findById(site.id, { include: [ User, Build ] })
-      }).then(site => {
-        expect(site.Builds).to.have.length(1)
-        expect(site.Builds[0].branch).to.equal(site.defaultBranch)
-        done()
-      }).catch(done)
-    })
-
-    it("should trigger a rebuild of the demo branch if one is present", done => {
-      factory.site({
-        repository: "old-repo-name",
-        demoBranch: "demo",
-        demoDomain: "https://demo.example.gov"
-      }).then(site => {
-        return Site.findById(site.id, { include: [ User, Build ] })
-      }).then(model => {
-        site = model
-        expect(site.Builds).to.have.length(0)
-        return session(site.Users[0])
-      }).then(cookie => {
-        return request(app)
-          .put(`/v0/site/${site.id}`)
-          .send({
-            repository: "new-repo-name"
-          })
-          .set("Cookie", cookie)
-          .expect(200)
-      }).then(resp => {
-        return Site.findById(site.id, { include: [ User, Build ] })
-      }).then(site => {
-        expect(site.Builds).to.have.length(2)
-        const demoBuild = site.Builds.find(candidateBuild => {
-          return candidateBuild.branch === site.demoBranch
+        )
+        .then((resp) => {
+          response = resp;
+          return Site.findById(site.id, { include: [User] });
         })
-        expect(demoBuild).to.not.be.undefined
-        done()
-      }).catch(done)
-    })
+        .then((foundSite) => {
+          validateAgainstJSONSchema('PUT', '/site/{id}', 200, response.body);
 
-    it("should update attributes when the value in the request body is an empty string", done => {
-      let site
-      const userPromise = factory.user()
+          expect(response.body.config).to.equal('new-config');
+          expect(foundSite.config).to.equal('new-config');
+          expect(response.body.demoConfig).to.equal('new-demo-config');
+          expect(foundSite.demoConfig).to.equal('new-demo-config');
+          expect(response.body.previewConfig).to.equal('new-preview-config');
+          expect(foundSite.previewConfig).to.equal('new-preview-config');
+          siteResponseExpectations(response.body, foundSite);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should not allow a user to update a site not associated with their account', (done) => {
+      let siteModel;
+      factory.site({ repository: 'old-repo-name' })
+        .then(site => Site.findById(site.id))
+        .then((model) => {
+          siteModel = model;
+          return session(factory.user());
+        })
+        .then(cookie => request(app)
+            .put(`/v0/site/${siteModel.id}`)
+            .send({
+              repository: 'new-repo-name',
+            })
+            .set('Cookie', cookie)
+            .expect(403)
+        )
+        .then((response) => {
+          validateAgainstJSONSchema('PUT', '/site/{id}', 403, response.body);
+          return Site.findById(siteModel.id);
+        })
+        .then((site) => {
+          expect(site).to.have.property('repository', 'old-repo-name');
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should trigger a rebuild of the site', (done) => {
+      let siteModel;
+      factory.site({ repository: 'old-repo-name' })
+        .then(site => Site.findById(site.id, { include: [User, Build] }))
+        .then((model) => {
+          siteModel = model;
+          expect(siteModel.Builds).to.have.length(0);
+          return session(siteModel.Users[0]);
+        })
+        .then(cookie => request(app)
+          .put(`/v0/site/${siteModel.id}`)
+          .send({
+            repository: 'new-repo-name',
+          })
+          .set('Cookie', cookie)
+          .expect(200)
+        )
+        .then(() => Site.findById(siteModel.id, { include: [User, Build] }))
+        .then((site) => {
+          expect(site.Builds).to.have.length(1);
+          expect(site.Builds[0].branch).to.equal(site.defaultBranch);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should trigger a rebuild of the demo branch if one is present', (done) => {
+      let siteModel;
+      factory.site({
+        repository: 'old-repo-name',
+        demoBranch: 'demo',
+        demoDomain: 'https://demo.example.gov',
+      })
+      .then(site => Site.findById(site.id, { include: [User, Build] }))
+      .then((model) => {
+        siteModel = model;
+        expect(siteModel.Builds).to.have.length(0);
+        return session(siteModel.Users[0]);
+      })
+      .then(cookie => request(app)
+          .put(`/v0/site/${siteModel.id}`)
+          .send({
+            repository: 'new-repo-name',
+          })
+          .set('Cookie', cookie)
+          .expect(200)
+        )
+        .then(() => Site.findById(siteModel.id, { include: [User, Build] }))
+        .then((site) => {
+          expect(site.Builds).to.have.length(2);
+          const demoBuild = site.Builds.find(
+            candidateBuild => candidateBuild.branch === site.demoBranch);
+          expect(demoBuild).to.not.be.undefined;
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should update attributes when the value in the request body is an empty string', (done) => {
+      let site;
+      const userPromise = factory.user();
       const sitePromise = factory.site({
         users: Promise.all([userPromise]),
-        config: "old-config: true",
-        domain: "https://example.com",
-      })
-      const cookiePromise = session(userPromise)
+        config: 'old-config: true',
+        domain: 'https://example.com',
+      });
+      const cookiePromise = session(userPromise);
 
       Promise.props({
         user: userPromise,
         site: sitePromise,
         cookie: cookiePromise,
-      }).then(results => {
-        site = results.site
+      })
+      .then((results) => {
+        site = results.site;
 
         return request(app)
           .put(`/v0/site/${site.id}`)
           .send({
-            config: "",
-            domain: "",
+            config: '',
+            domain: '',
           })
-          .set("Cookie", results.cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("PUT", "/site/{id}", 200, response.body)
-        return Site.findById(site.id)
-      }).then(site => {
-        expect(site.config).to.equal("")
-        expect(site.domain).to.equal("")
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', results.cookie)
+          .expect(200);
+      })
+      .then((response) => {
+        validateAgainstJSONSchema('PUT', '/site/{id}', 200, response.body);
+        return Site.findById(site.id);
+      })
+      .then((foundSite) => {
+        expect(foundSite.config).to.equal('');
+        expect(foundSite.domain).to.equal('');
+        done();
+      })
+      .catch(done);
+    });
 
-    it("should not override existing attributes if they are not present in the request body", done => {
-      let site
-      const userPromise = factory.user()
+    it('should not override existing attributes if they are not present in the request body', (done) => {
+      let site;
+      const userPromise = factory.user();
       const sitePromise = factory.site({
         users: Promise.all([userPromise]),
-        config: "old-config: true",
-        domain: "https://example.com",
-      })
-      const cookiePromise = session(userPromise)
+        config: 'old-config: true',
+        domain: 'https://example.com',
+      });
+      const cookiePromise = session(userPromise);
 
       Promise.props({
         user: userPromise,
         site: sitePromise,
         cookie: cookiePromise,
-      }).then(results => {
-        site = results.site
+      })
+      .then((results) => {
+        site = results.site;
 
         return request(app)
           .put(`/v0/site/${site.id}`)
           .send({
-            config: "new-config: true",
+            config: 'new-config: true',
           })
-          .set("Cookie", results.cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("PUT", "/site/{id}", 200, response.body)
-        return Site.findById(site.id)
-      }).then(site => {
-        expect(site.config).to.equal("new-config: true")
-        expect(site.domain).to.equal("https://example.com")
-        done()
-      }).catch(done)
-    })
-  })
-})
+          .set('Cookie', results.cookie)
+          .expect(200);
+      })
+      .then((response) => {
+        validateAgainstJSONSchema('PUT', '/site/{id}', 200, response.body);
+        return Site.findById(site.id);
+      })
+      .then((foundSite) => {
+        expect(foundSite.config).to.equal('new-config: true');
+        expect(foundSite.domain).to.equal('https://example.com');
+        done();
+      })
+      .catch(done);
+    });
+  });
+});

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -540,7 +540,7 @@ describe("Site API", () => {
     it("should allow a user to update a site associated with their account", done => {
       var site, response
 
-      factory.site({ config: "old-config", previewConfig: "old-preview-config" }).then(site => {
+      factory.site({ config: "old-config", demoConfig: "old-demo-config", previewConfig: "old-preview-config" }).then(site => {
         return Site.findById(site.id, { include: [ User ] })
       }).then(model => {
         site = model
@@ -550,6 +550,7 @@ describe("Site API", () => {
           .put(`/v0/site/${site.id}`)
           .send({
             config: "new-config",
+            demoConfig: "new-demo-config",
             previewConfig: "new-preview-config",
           })
           .set("Cookie", cookie)
@@ -562,6 +563,8 @@ describe("Site API", () => {
 
         expect(response.body.config).to.equal("new-config")
         expect(site.config).to.equal("new-config")
+        expect(response.body.demoConfig).to.equal("new-demo-config")
+        expect(site.demoConfig).to.equal("new-demo-config")
         expect(response.body.previewConfig).to.equal("new-preview-config")
         expect(site.previewConfig).to.equal("new-preview-config")
         siteResponseExpectations(response.body, site)

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -300,6 +300,7 @@ describe("SQS", () => {
       factory.site({
         defaultBranch: "master",
         config: "plugins_dir: _plugins",
+        demoConfig: "plugins_dir: _demo_plugins",
         previewConfig: "plugins_dir: _preview_plugins",
       }).then(site => {
         return factory.build({ site, branch: "master" })
@@ -316,6 +317,7 @@ describe("SQS", () => {
       factory.site({
         demoBranch: "demo",
         config: "plugins_dir: _plugins",
+        demoConfig: "plugins_dir: _demo_plugins",
         previewConfig: "plugins_dir: _preview_plugins",
       }).then(site => {
         return factory.build({ site, branch: "demo" })
@@ -323,7 +325,7 @@ describe("SQS", () => {
         return Build.findById(build.id, { include: [Site, User] })
       }).then(build => {
         const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "CONFIG")).to.equal("plugins_dir: _plugins")
+        expect(messageEnv(message, "CONFIG")).to.equal("plugins_dir: _demo_plugins")
         done()
       }).catch(done)
     })
@@ -332,6 +334,7 @@ describe("SQS", () => {
       factory.site({
         defaultBranch: "master",
         config: "plugins_dir: _plugins",
+        demoConfig: "plugins_dir: _demo_plugins",
         previewConfig: "plugins_dir: _preview_plugins",
       }).then(site => {
         return factory.build({ site, branch: "preview" })

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -1,416 +1,368 @@
-const expect = require("chai").expect
-const config = require("../../../../config")
-const factory = require("../../support/factory")
-const GitHub = require("../../../../api/services/SQS")
-const SQS = require("../../../../api/services/SQS")
-const { Build, Site, User } = require("../../../../api/models")
+const expect = require('chai').expect;
+const config = require('../../../../config');
+const factory = require('../../support/factory');
+const SQS = require('../../../../api/services/SQS');
+const { Build, Site, User } = require('../../../../api/models');
 
-describe("SQS", () => {
-  describe(".sendBuildMessage(build)", () => {
-    it("should send a formatted build message", done => {
-      const oldSendMessage = SQS.sqsClient.sendMessage
-      SQS.sqsClient.sendMessage = (params, callback) => {
-        SQS.sqsClient.sendMessage = oldSendMessage
-        expect(params).to.have.property("MessageBody")
-        expect(params).to.have.property("QueueUrl", config.sqs.queue)
-        done()
-      }
+describe('SQS', () => {
+  describe('.sendBuildMessage(build)', () => {
+    it('should send a formatted build message', (done) => {
+      const oldSendMessage = SQS.sqsClient.sendMessage;
+      SQS.sqsClient.sendMessage = (params) => {
+        SQS.sqsClient.sendMessage = oldSendMessage;
+        expect(params).to.have.property('MessageBody');
+        expect(params).to.have.property('QueueUrl', config.sqs.queue);
+        done();
+      };
       SQS.sendBuildMessage({
-        branch: "master",
-        state: "processing",
+        branch: 'master',
+        state: 'processing',
         Site: {
-          owner: "owner",
-          repository: "formatted-message-repo",
-          engine: "jekyll",
-          defaultBranch: "master"
+          owner: 'owner',
+          repository: 'formatted-message-repo',
+          engine: 'jekyll',
+          defaultBranch: 'master',
         },
         User: {
           passport: {
-            tokens: { accessToken: "123abc" }
-          }
-        }
-      })
-    })
-  })
+            tokens: { accessToken: '123abc' },
+          },
+        },
+      });
+    });
+  });
 
-  describe(".messageBodyForBuild(build)", () => {
+  describe('.messageBodyForBuild(build)', () => {
     const messageEnv = (message, name) => {
-      const element = message.environment.find(element => {
-        return element.name === name
-      })
+      const element = message.environment.find(el => el.name === name);
       if (element) {
-        return element.value
+        return element.value;
       }
-    }
+      return null;
+    };
 
-    it("should set the correct AWS credentials in the message", done => {
-      factory.build().then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "AWS_ACCESS_KEY_ID")).to.equal(config.s3.accessKeyId)
-        expect(messageEnv(message, "AWS_SECRET_ACCESS_KEY")).to.equal(config.s3.secretAccessKey)
-        expect(messageEnv(message, "AWS_DEFAULT_REGION")).to.equal(config.s3.region)
-        expect(messageEnv(message, "BUCKET")).to.equal(config.s3.bucket)
-        done()
-      }).catch(done)
-    })
+    it('should set the correct AWS credentials in the message', (done) => {
+      factory.build()
+        .then(build => Build.findById(build.id, { include: [Site, User] }))
+        .then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'AWS_ACCESS_KEY_ID')).to.equal(config.s3.accessKeyId);
+          expect(messageEnv(message, 'AWS_SECRET_ACCESS_KEY')).to.equal(config.s3.secretAccessKey);
+          expect(messageEnv(message, 'AWS_DEFAULT_REGION')).to.equal(config.s3.region);
+          expect(messageEnv(message, 'BUCKET')).to.equal(config.s3.bucket);
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should set STATUS_CALLBACK in the message", done => {
-      factory.build().then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "STATUS_CALLBACK")).to.equal("http://localhost:1337/v0/build/" + build.id + "/status/" + build.token)
-        done()
-      }).catch(done)
-    })
+    it('should set STATUS_CALLBACK in the message', (done) => {
+      factory.build()
+        .then(build => Build.findById(build.id, { include: [Site, User] }))
+        .then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'STATUS_CALLBACK')).to.equal(`http://localhost:1337/v0/build/${build.id}/status/${build.token}`);
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should set LOG_CALLBACK in the message", done => {
-      factory.build().then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "LOG_CALLBACK")).to.equal("http://localhost:1337/v0/build/" + build.id + "/log/" + build.token)
-        done()
-      }).catch(done)
-    })
+    it('should set LOG_CALLBACK in the message', (done) => {
+      factory.build()
+        .then(build => Build.findById(build.id, { include: [Site, User] }))
+        .then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'LOG_CALLBACK')).to.equal(`http://localhost:1337/v0/build/${build.id}/log/${build.token}`);
+          done();
+        })
+        .catch(done);
+    });
 
     context("building a site's default branch", () => {
-      it("should set an empty string for BASEURL in the message for a site with a custom domain", done => {
+      it('should set an empty string for BASEURL in the message for a site with a custom domain', (done) => {
         const domains = [
-          "www.example.com",
-          "www.example.com/",
-          "https://example.com",
-          "https://example.com/",
-          "http://example.com",
-          "http://example.com/",
-        ]
+          'www.example.com',
+          'www.example.com/',
+          'https://example.com',
+          'https://example.com/',
+          'http://example.com',
+          'http://example.com/',
+        ];
 
-        const baseurlPromises = domains.map(domain => {
-          return factory.site({ domain, defaultBranch: "master" }).then(site => {
-            return factory.build({ site, branch: "master" })
-          }).then(build => {
-            return Build.findById(build.id, { include: [Site, User] })
-          }).then(build => {
-            const message = SQS.messageBodyForBuild(build)
-            return messageEnv(message, "BASEURL")
-          })
+        const baseurlPromises = domains.map(domain => factory.site({ domain, defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'master' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          return messageEnv(message, 'BASEURL');
+        }));
+
+        Promise.all(baseurlPromises).then((baseurls) => {
+          expect(baseurls).to.deep.equal(Array(domains.length).fill(''));
+          done();
         })
+        .catch(done);
+      });
 
-        Promise.all(baseurlPromises).then(baseurls => {
-          expect(baseurls).to.deep.equal(Array(domains.length).fill(""))
-          done()
-        }).catch(done)
-      })
+      it('it should set BASEURL in the message for a site without a custom domain', (done) => {
+        factory.site({ domain: '', owner: 'owner', repository: 'repo', defaultBranch: 'master' })
+          .then(site => factory.build({ site, branch: 'master' }))
+          .then(build => Build.findById(build.id, { include: [Site, User] }))
+          .then((build) => {
+            const message = SQS.messageBodyForBuild(build);
+            expect(messageEnv(message, 'BASEURL')).to.equal('/site/owner/repo');
+            done();
+          })
+          .catch(done);
+      });
 
-      it("it should set BASEURL in the message for a site without a custom domain", done => {
-        factory.site({ domain: "", owner: "owner", repository: "repo", defaultBranch: "master" }).then(site => {
-          return factory.build({ site: site, branch: "master" })
-        }).then(build => {
-          return Build.findById(build.id, { include: [Site, User] })
-        }).then(build => {
-          const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "BASEURL")).to.equal("/site/owner/repo")
-          done()
-        }).catch(done)
-      })
-
-      it("should respect the path component of a custom domain when setting BASEURL in the message", done => {
+      it('should respect the path component of a custom domain when setting BASEURL in the message', (done) => {
         const domains = [
-          "www.example.com/abc/def",
-          "www.example.com/abc/def/",
-          "https://example.com/abc/def",
-          "https://example.com/abc/def/",
-          "http://example.com/abc/def",
-          "http://example.com/abc/def/",
-        ]
+          'www.example.com/abc/def',
+          'www.example.com/abc/def/',
+          'https://example.com/abc/def',
+          'https://example.com/abc/def/',
+          'http://example.com/abc/def',
+          'http://example.com/abc/def/',
+        ];
 
-        const baseurlPromises = domains.map(domain => {
-          return factory.site({ domain, defaultBranch: "master" }).then(site => {
-            return factory.build({ site, branch: "master" })
-          }).then(build => {
-            return Build.findById(build.id, { include: [Site, User] })
-          }).then(build => {
-            const message = SQS.messageBodyForBuild(build)
-            return messageEnv(message, "BASEURL")
-          })
+        const baseurlPromises = domains.map(domain => factory.site({ domain, defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'master' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          return messageEnv(message, 'BASEURL');
+        }));
+
+        Promise.all(baseurlPromises).then((baseurls) => {
+          expect(baseurls).to.deep.equal(Array(domains.length).fill('/abc/def'));
+          done();
         })
+        .catch(done);
+      });
 
-        Promise.all(baseurlPromises).then(baseurls => {
-          expect(baseurls).to.deep.equal(Array(domains.length).fill("/abc/def"))
-          done()
-        }).catch(done)
-      })
-
-      it("should set SITE_PREFIX in the message to 'site/:owner/:repo/'", done => {
-        factory.site({ domain: "", owner: "owner", repository: "repo", defaultBranch: "master" }).then(site => {
-          return factory.build({ site: site, branch: "master" })
-        }).then(build => {
-          return Build.findById(build.id, { include: [Site, User] })
-        }).then(build => {
-          const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "SITE_PREFIX")).to.equal("site/owner/repo")
-          done()
-        }).catch(done)
-      })
-    })
+      it("should set SITE_PREFIX in the message to 'site/:owner/:repo/'", (done) => {
+        factory.site({ domain: '', owner: 'owner', repository: 'repo', defaultBranch: 'master' })
+          .then(site => factory.build({ site, branch: 'master' }))
+          .then(build => Build.findById(build.id, { include: [Site, User] }))
+          .then((build) => {
+            const message = SQS.messageBodyForBuild(build);
+            expect(messageEnv(message, 'SITE_PREFIX')).to.equal('site/owner/repo');
+            done();
+          })
+          .catch(done);
+      });
+    });
 
     context("building a site's demo branch", () => {
-      it("should set an empty string for BASEURL in the message for a site with a demo domain", done => {
+      it('should set an empty string for BASEURL in the message for a site with a demo domain', (done) => {
         const domains = [
-          "www.example.com",
-          "www.example.com/",
-          "https://example.com",
-          "https://example.com/",
-          "http://example.com",
-          "http://example.com/",
-        ]
+          'www.example.com',
+          'www.example.com/',
+          'https://example.com',
+          'https://example.com/',
+          'http://example.com',
+          'http://example.com/',
+        ];
 
-        const baseurlPromises = domains.map(domain => {
-          return factory.site({ demoDomain: domain, demoBranch: "demo" }).then(site => {
-            return factory.build({ site, branch: "demo" })
-          }).then(build => {
-            return Build.findById(build.id, { include: [Site, User] })
-          }).then(build => {
-            const message = SQS.messageBodyForBuild(build)
-            return messageEnv(message, "BASEURL")
-          })
+        const baseurlPromises = domains.map(domain => factory.site({ demoDomain: domain, demoBranch: 'demo' }).then(site => factory.build({ site, branch: 'demo' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          return messageEnv(message, 'BASEURL');
+        }));
+
+        Promise.all(baseurlPromises).then((baseurls) => {
+          expect(baseurls).to.deep.equal(Array(domains.length).fill(''));
+          done();
         })
+        .catch(done);
+      });
 
-        Promise.all(baseurlPromises).then(baseurls => {
-          expect(baseurls).to.deep.equal(Array(domains.length).fill(""))
-          done()
-        }).catch(done)
-      })
+      it('it should set BASEURL in the message for a site without a demo domain', (done) => {
+        factory.site({ demoDomain: '', owner: 'owner', repository: 'repo', demoBranch: 'demo' }).then(site => factory.build({ site, branch: 'demo' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'BASEURL')).to.equal('/demo/owner/repo');
+          done();
+        })
+        .catch(done);
+      });
 
-      it("it should set BASEURL in the message for a site without a demo domain", done => {
-        factory.site({ demoDomain: "", owner: "owner", repository: "repo", demoBranch: "demo" }).then(site => {
-          return factory.build({ site: site, branch: "demo" })
-        }).then(build => {
-          return Build.findById(build.id, { include: [Site, User] })
-        }).then(build => {
-          const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "BASEURL")).to.equal("/demo/owner/repo")
-          done()
-        }).catch(done)
-      })
-
-      it("should respect the path component of a custom domain when setting BASEURL in the message", done => {
+      it('should respect the path component of a custom domain when setting BASEURL in the message', (done) => {
         const domains = [
-          "www.example.com/abc/def",
-          "www.example.com/abc/def/",
-          "https://example.com/abc/def",
-          "https://example.com/abc/def/",
-          "http://example.com/abc/def",
-          "http://example.com/abc/def/",
-        ]
+          'www.example.com/abc/def',
+          'www.example.com/abc/def/',
+          'https://example.com/abc/def',
+          'https://example.com/abc/def/',
+          'http://example.com/abc/def',
+          'http://example.com/abc/def/',
+        ];
 
-        const baseurlPromises = domains.map(domain => {
-          return factory.site({ demoDomain: domain, demoBranch: "demo" }).then(site => {
-            return factory.build({ site, branch: "demo" })
-          }).then(build => {
-            return Build.findById(build.id, { include: [Site, User] })
-          }).then(build => {
-            const message = SQS.messageBodyForBuild(build)
-            return messageEnv(message, "BASEURL")
-          })
+        const baseurlPromises = domains.map(domain => factory.site({ demoDomain: domain, demoBranch: 'demo' }).then(site => factory.build({ site, branch: 'demo' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          return messageEnv(message, 'BASEURL');
+        }));
+
+        Promise.all(baseurlPromises).then((baseurls) => {
+          expect(baseurls).to.deep.equal(Array(domains.length).fill('/abc/def'));
+          done();
         })
+        .catch(done);
+      });
 
-        Promise.all(baseurlPromises).then(baseurls => {
-          expect(baseurls).to.deep.equal(Array(domains.length).fill("/abc/def"))
-          done()
-        }).catch(done)
-      })
-
-      it("should set SITE_PREFIX in the message to 'demo/:owner/:repo'", done => {
-        factory.site({ demoDomain: "", owner: "owner", repository: "repo", demoBranch: "demo" }).then(site => {
-          return factory.build({ site: site, branch: "demo" })
-        }).then(build => {
-          return Build.findById(build.id, { include: [Site, User] })
-        }).then(build => {
-          const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "SITE_PREFIX")).to.equal("demo/owner/repo")
-          done()
-        }).catch(done)
-      })
-    })
+      it("should set SITE_PREFIX in the message to 'demo/:owner/:repo'", (done) => {
+        factory.site({ demoDomain: '', owner: 'owner', repository: 'repo', demoBranch: 'demo' }).then(site => factory.build({ site, branch: 'demo' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'SITE_PREFIX')).to.equal('demo/owner/repo');
+          done();
+        })
+        .catch(done);
+      });
+    });
 
     context("building a site's preview branch", () => {
-      it("should set BASEURL in the message for a site with a custom domain", done => {
-        factory.site({ domain: "www.example.com", owner: "owner", repository: "repo", defaultBranch: "master" }).then(site => {
-          return factory.build({ site: site, branch: "branch" })
-        }).then(build => {
-          return Build.findById(build.id, { include: [Site, User] })
-        }).then(build => {
-          const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "BASEURL")).to.equal("/preview/owner/repo/branch")
-          done()
-        }).catch(done)
-      })
+      it('should set BASEURL in the message for a site with a custom domain', (done) => {
+        factory.site({ domain: 'www.example.com', owner: 'owner', repository: 'repo', defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'branch' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'BASEURL')).to.equal('/preview/owner/repo/branch');
+          done();
+        })
+        .catch(done);
+      });
 
-      it("should set BASEURL in the message for a site without a custom domain", done => {
-        factory.site({ domain: "", owner: "owner", repository: "repo", defaultBranch: "master" }).then(site => {
-          return factory.build({ site: site, branch: "branch" })
-        }).then(build => {
-          return Build.findById(build.id, { include: [Site, User] })
-        }).then(build => {
-          const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "BASEURL")).to.equal("/preview/owner/repo/branch")
-          done()
-        }).catch(done)
-      })
+      it('should set BASEURL in the message for a site without a custom domain', (done) => {
+        factory.site({ domain: '', owner: 'owner', repository: 'repo', defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'branch' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'BASEURL')).to.equal('/preview/owner/repo/branch');
+          done();
+        })
+        .catch(done);
+      });
 
-      it("should set SITE_PREFIX in the message to 'preview/:owner/:repo/:branch'", done => {
-        factory.site({ domain: "", owner: "owner", repository: "repo", defaultBranch: "master" }).then(site => {
-          return factory.build({ site: site, branch: "branch" })
-        }).then(build => {
-          return Build.findById(build.id, { include: [Site, User] })
-        }).then(build => {
-          const message = SQS.messageBodyForBuild(build)
-          expect(messageEnv(message, "SITE_PREFIX")).to.equal("preview/owner/repo/branch")
-          done()
-        }).catch(done)
-      })
-    })
+      it("should set SITE_PREFIX in the message to 'preview/:owner/:repo/:branch'", (done) => {
+        factory.site({ domain: '', owner: 'owner', repository: 'repo', defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'branch' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'SITE_PREFIX')).to.equal('preview/owner/repo/branch');
+          done();
+        })
+        .catch(done);
+      });
+    });
 
-    it("should set CACHE_CONTROL in the message", done => {
-      factory.build().then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "CACHE_CONTROL")).to.equal(config.build.cacheControl)
-        done()
-      }).catch(done)
-    })
+    it('should set CACHE_CONTROL in the message', (done) => {
+      factory.build().then(build => Build.findById(build.id, { include: [Site, User] }))
+        .then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'CACHE_CONTROL')).to.equal(config.build.cacheControl);
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should set BRANCH in the message to the name build's branch", done => {
-      factory.site({ domain: "", defaultBranch: "master" }).then(site => {
-        return factory.build({ site: site, branch: "branch" })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "BRANCH")).to.equal("branch")
-        done()
-      }).catch(done)
-    })
+    it("should set BRANCH in the message to the name build's branch", (done) => {
+      factory.site({ domain: '', defaultBranch: 'master' })
+        .then(site => factory.build({ site, branch: 'branch' }))
+        .then(build => Build.findById(build.id, { include: [Site, User] }))
+        .then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'BRANCH')).to.equal('branch');
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should set CONFIG in the message to the YAML config for the site on the default branch", done => {
+    it('should set CONFIG in the message to the YAML config for the site on the default branch', (done) => {
       factory.site({
-        defaultBranch: "master",
-        config: "plugins_dir: _plugins",
-        demoConfig: "plugins_dir: _demo_plugins",
-        previewConfig: "plugins_dir: _preview_plugins",
-      }).then(site => {
-        return factory.build({ site, branch: "master" })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "CONFIG")).to.equal("plugins_dir: _plugins")
-        done()
-      }).catch(done)
-    })
+        defaultBranch: 'master',
+        config: 'plugins_dir: _plugins',
+        demoConfig: 'plugins_dir: _demo_plugins',
+        previewConfig: 'plugins_dir: _preview_plugins',
+      }).then(site => factory.build({ site, branch: 'master' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+        const message = SQS.messageBodyForBuild(build);
+        expect(messageEnv(message, 'CONFIG')).to.equal('plugins_dir: _plugins');
+        done();
+      })
+      .catch(done);
+    });
 
-    it("should set CONFIG in the message to the YAML config for the site on a demo branch", done => {
+    it('should set CONFIG in the message to the YAML config for the site on a demo branch', (done) => {
       factory.site({
-        demoBranch: "demo",
-        config: "plugins_dir: _plugins",
-        demoConfig: "plugins_dir: _demo_plugins",
-        previewConfig: "plugins_dir: _preview_plugins",
-      }).then(site => {
-        return factory.build({ site, branch: "demo" })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "CONFIG")).to.equal("plugins_dir: _demo_plugins")
-        done()
-      }).catch(done)
-    })
+        demoBranch: 'demo',
+        config: 'plugins_dir: _plugins',
+        demoConfig: 'plugins_dir: _demo_plugins',
+        previewConfig: 'plugins_dir: _preview_plugins',
+      }).then(site => factory.build({ site, branch: 'demo' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+        const message = SQS.messageBodyForBuild(build);
+        expect(messageEnv(message, 'CONFIG')).to.equal('plugins_dir: _demo_plugins');
+        done();
+      })
+      .catch(done);
+    });
 
-    it("should set CONFIG in the message to the YAML config for the site on a preview branch", done => {
+    it('should set CONFIG in the message to the YAML config for the site on a preview branch', (done) => {
       factory.site({
-        defaultBranch: "master",
-        config: "plugins_dir: _plugins",
-        demoConfig: "plugins_dir: _demo_plugins",
-        previewConfig: "plugins_dir: _preview_plugins",
-      }).then(site => {
-        return factory.build({ site, branch: "preview" })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "CONFIG")).to.equal("plugins_dir: _preview_plugins")
-        done()
-      }).catch(done)
-    })
+        defaultBranch: 'master',
+        config: 'plugins_dir: _plugins',
+        demoConfig: 'plugins_dir: _demo_plugins',
+        previewConfig: 'plugins_dir: _preview_plugins',
+      }).then(site => factory.build({ site, branch: 'preview' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+        const message = SQS.messageBodyForBuild(build);
+        expect(messageEnv(message, 'CONFIG')).to.equal('plugins_dir: _preview_plugins');
+        done();
+      })
+      .catch(done);
+    });
 
-    it("should set REPOSITORY in the message to the site's repo name", done => {
-      factory.site({ repository: "site-repo" }).then(site => {
-        return factory.build({ site: site })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "REPOSITORY")).to.equal("site-repo")
-        done()
-      }).catch(done)
-    })
+    it("should set REPOSITORY in the message to the site's repo name", (done) => {
+      factory.site({ repository: 'site-repo' }).then(site => factory.build({ site })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+        const message = SQS.messageBodyForBuild(build);
+        expect(messageEnv(message, 'REPOSITORY')).to.equal('site-repo');
+        done();
+      })
+      .catch(done);
+    });
 
-    it("should set OWNER in the message to the site's owner", done => {
-      factory.site({ owner: "site-owner" }).then(site => {
-        return factory.build({ site: site })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "OWNER")).to.equal("site-owner")
-        done()
-      }).catch(done)
-    })
+    it("should set OWNER in the message to the site's owner", (done) => {
+      factory.site({ owner: 'site-owner' }).then(site => factory.build({ site })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+        const message = SQS.messageBodyForBuild(build);
+        expect(messageEnv(message, 'OWNER')).to.equal('site-owner');
+        done();
+      })
+      .catch(done);
+    });
 
-    it("should set GITHUB_TOKEN in the message to the user's GitHub access token", done => {
-      let user
+    it("should set GITHUB_TOKEN in the message to the user's GitHub access token", (done) => {
+      let user;
 
-      factory.user({ githubAccessToken: "fake-github-token-123" }).then(model => {
-        user = model
-        return factory.site({ users: [user] })
-      }).then(site => {
-        return factory.build({ user: user, site: site })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "GITHUB_TOKEN")).to.equal("fake-github-token-123")
-        done()
-      }).catch(done)
-    })
+      factory.user({ githubAccessToken: 'fake-github-token-123' })
+        .then((model) => {
+          user = model;
+          return factory.site({ users: [user] });
+        })
+        .then(site => factory.build({ user, site }))
+        .then(build => Build.findById(build.id, { include: [Site, User] }))
+        .then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'GITHUB_TOKEN')).to.equal('fake-github-token-123');
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should set GENERATOR in the message to the site's build engine (e.g. 'jekyll')", done => {
-      factory.site({ engine: "hugo" }).then(site => {
-        return factory.build({ site: site })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "GENERATOR")).to.equal("hugo")
-        done()
-      }).catch(done)
-    })
+    it("should set GENERATOR in the message to the site's build engine (e.g. 'jekyll')", (done) => {
+      factory.site({ engine: 'hugo' })
+        .then(site => factory.build({ site }))
+        .then(build => Build.findById(build.id, { include: [Site, User] }))
+        .then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'GENERATOR')).to.equal('hugo');
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should set SOURCE_REPO and SOURCE_OWNER in the repository if the build has a source owner / repo", done => {
-      factory.site({ engine: "hugo" }).then(site => {
-        return factory.build({ source: { repository: "template", owner: "18f" } })
-      }).then(build => {
-        return Build.findById(build.id, { include: [Site, User] })
-      }).then(build => {
-        const message = SQS.messageBodyForBuild(build)
-        expect(messageEnv(message, "SOURCE_REPO")).to.equal("template")
-        expect(messageEnv(message, "SOURCE_OWNER")).to.equal("18f")
-        done()
-      }).catch(done)
-    })
-  })
-})
+    it('should set SOURCE_REPO and SOURCE_OWNER in the repository if the build has a source owner / repo', (done) => {
+      factory.site({ engine: 'hugo' })
+        .then(() => factory.build({ source: { repository: 'template', owner: '18f' } }))
+        .then(build => Build.findById(build.id, { include: [Site, User] }))
+        .then((build) => {
+          const message = SQS.messageBodyForBuild(build);
+          expect(messageEnv(message, 'SOURCE_REPO')).to.equal('template');
+          expect(messageEnv(message, 'SOURCE_OWNER')).to.equal('18f');
+          done();
+        })
+        .catch(done);
+    });
+  });
+});


### PR DESCRIPTION
First commit contains the functional changes; second one is linting fixes; third one is a minor change to use `<label>`s on text `<input>`s.

I added the new for the demo config section in between the "Site configuration" and "Preview configuration" sections:

<img width="743" alt="screen shot 2017-06-28 at 2 37 20 pm" src="https://user-images.githubusercontent.com/697848/27656662-6cdfc472-5c0f-11e7-8f02-2d1501124597.png">

