### PR TITLE
Implement refresh buttons on Builds and Build Logs pages

### DIFF
--- a/frontend/components/site/refreshBuildLogsButton.jsx
+++ b/frontend/components/site/refreshBuildLogsButton.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import autoBind from 'react-autobind';
+
+import buildLogActions from '../../actions/buildLogActions';
+
+
+class RefreshBuildLogsButton extends React.Component {
+  constructor(props) {
+    super(props);
+    autoBind(this);
+  }
+
+  refreshBuildLogs() {
+    buildLogActions.fetchBuildLogs({ id: this.props.buildId });
+  }
+
+  render() {
+    return (
+      <button className="usa-button" onClick={this.refreshBuildLogs}>Refresh logs</button>
+    );
+  }
+}
+
+RefreshBuildLogsButton.propTypes = {
+  buildId: PropTypes.string.isRequired,
+};
+
+export default RefreshBuildLogsButton;

--- a/frontend/components/site/refreshBuildsButton.jsx
+++ b/frontend/components/site/refreshBuildsButton.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import autoBind from 'react-autobind';
+
+import buildActions from '../../actions/buildActions';
+
+
+class RefreshBuildsButton extends React.Component {
+  constructor(props) {
+    super(props);
+    autoBind(this);
+  }
+
+  refreshBuilds() {
+    buildActions.fetchBuilds(this.props.site);
+  }
+
+  render() {
+    return (
+      <button className="usa-button" onClick={this.refreshBuilds}>Refresh builds</button>
+    );
+  }
+}
+
+RefreshBuildsButton.propTypes = {
+  site: PropTypes.shape({
+    id: PropTypes.number,
+  }).isRequired,
+};
+
+export default RefreshBuildsButton;

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import buildLogActions from '../../actions/buildLogActions';
 import LoadingIndicator from '../loadingIndicator';
 import SiteBuildLogTable from './siteBuildLogTable';
+import RefreshBuildLogsButton from './refreshBuildLogsButton';
+
 import { API } from '../../util/federalistApi';
 
 
@@ -21,7 +23,12 @@ class SiteBuildLogs extends React.Component {
 
     // else
     if (!buildLogs.data || !buildLogs.data.length) {
-      return (<p>This build does not have any build logs.</p>);
+      return (
+        <div>
+          <p>This build does not have any build logs.</p>
+          <RefreshBuildLogsButton buildId={this.props.params.buildId} />
+        </div>
+      );
     }
 
     // else
@@ -31,7 +38,12 @@ class SiteBuildLogs extends React.Component {
 
     return (
       <div>
-        <a href={downloadUrl} download={downloadName}>Download logs</a>
+        <div className="log-tools">
+          <ul className="usa-unstyled-list">
+            <li><a href={downloadUrl} download={downloadName}>Download logs</a></li>
+            <li><RefreshBuildLogsButton buildId={buildId} /></li>
+          </ul>
+        </div>
         <SiteBuildLogTable buildLogs={buildLogs.data} />
       </div>
     );

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import autoBind from 'react-autobind';
 import { Link } from 'react-router';
-import LoadingIndicator from '../loadingIndicator';
-import { duration, timeFrom } from '../../util/datetime';
+
 import buildActions from '../../actions/buildActions';
+import LoadingIndicator from '../loadingIndicator';
+import RefreshBuildsButton from './refreshBuildsButton';
+import { duration, timeFrom } from '../../util/datetime';
+
 
 class SiteBuilds extends React.Component {
   static getUsername(build) {
@@ -27,10 +30,6 @@ class SiteBuilds extends React.Component {
     return <LoadingIndicator />;
   }
 
-  static renderEmptyState() {
-    return <p>This site does not have any builds</p>;
-  }
-
   static restartLink(build) {
     /* eslint-disable jsx-a11y/href-no-hash */
     return (
@@ -45,6 +44,11 @@ class SiteBuilds extends React.Component {
     /* eslint-enable jsx-a11y/href-no-hash */
   }
 
+  constructor(props) {
+    super(props);
+    autoBind(this);
+  }
+
   componentDidMount() {
     buildActions.fetchBuilds(this.props.site);
   }
@@ -56,9 +60,21 @@ class SiteBuilds extends React.Component {
     return this.props.builds.data;
   }
 
+  renderEmptyState() {
+    return (
+      <div>
+        <p>This site does not have any builds.</p>
+        <RefreshBuildsButton site={this.props.site} />
+      </div>
+    );
+  }
+
   renderBuildsTable() {
     return (
       <div>
+        <div className="log-tools">
+          <RefreshBuildsButton site={this.props.site} />
+        </div>
         <table className="usa-table-borderless log-table log-table__site-builds">
           <thead>
             <tr>
@@ -112,7 +128,7 @@ class SiteBuilds extends React.Component {
     if (this.props.builds.isLoading) {
       return SiteBuilds.renderLoadingState();
     } else if (!builds.length) {
-      return SiteBuilds.renderEmptyState();
+      return this.renderEmptyState();
     }
     return this.renderBuildsTable();
   }

--- a/frontend/sass/_log-tools.scss
+++ b/frontend/sass/_log-tools.scss
@@ -1,0 +1,8 @@
+.log-tools {
+  float: right;
+
+  li {
+    display: inline;
+    margin-left: 20px;
+  }
+}

--- a/frontend/sass/_tables.scss
+++ b/frontend/sass/_tables.scss
@@ -1,6 +1,7 @@
 
 .log-table {
   font-size: smaller;
+  margin-top: 0;
 
   pre {
     overflow: auto;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -16,6 +16,7 @@
 @import "_text";
 @import "_wells";
 @import "_tables";
+@import "_log-tools";
 
 html,
 body,

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "proxyquire": "^1.7.10",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.3.1",
+    "react-autobind": "^1.0.6",
     "react-dom": "^15.1.0",
     "react-notification-system": "^0.2.14",
     "react-notification-system-redux": "^1.1.2",

--- a/test/frontend/components/site/refreshBuildLogsButton.test.js
+++ b/test/frontend/components/site/refreshBuildLogsButton.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+import proxyquire from 'proxyquire';
+
+proxyquire.noCallThru();
+
+const fetchBuildLogs = spy();
+
+const RefreshBuildLogsButton = proxyquire('../../../../frontend/components/site/refreshBuildLogsButton', {
+  '../../actions/buildLogActions': { fetchBuildLogs },
+}).default;
+
+describe('<RefreshBuildLogsButton />', () => {
+  it('renders correctly', () => {
+    const wrapper = shallow(<RefreshBuildLogsButton buildId={123} />);
+    expect(wrapper.find('button')).to.have.length(1);
+    expect(wrapper.find('button').contains('Refresh logs')).to.be.true;
+  });
+
+  it('dispatches an action to fetch build logs when clicked', () => {
+    const wrapper = shallow(<RefreshBuildLogsButton buildId={456} />);
+    const button = wrapper.find('button');
+    expect(fetchBuildLogs.calledOnce).to.be.false;
+    button.simulate('click');
+    expect(fetchBuildLogs.calledOnce).to.be.true;
+    expect(fetchBuildLogs.calledWith({ id: 456 })).to.be.true;
+  });
+});

--- a/test/frontend/components/site/refreshBuildsButton.js
+++ b/test/frontend/components/site/refreshBuildsButton.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+import proxyquire from 'proxyquire';
+
+proxyquire.noCallThru();
+
+const fetchBuilds = spy();
+
+const RefreshBuildsButton = proxyquire('../../../../frontend/components/site/refreshBuildsButton', {
+  '../../actions/buildActions': { fetchBuilds },
+}).default;
+
+describe('<RefreshBuildsButton />', () => {
+  it('renders correctly', () => {
+    const wrapper = shallow(<RefreshBuildsButton site={{ id: 123 }} />);
+    expect(wrapper.find('button')).to.have.length(1);
+    expect(wrapper.find('button').contains('Refresh builds')).to.be.true;
+  });
+
+  it('dispatches an action to fetch build logs when clicked', () => {
+    const wrapper = shallow(<RefreshBuildsButton site={{ id: 456 }} />);
+    const button = wrapper.find('button');
+    expect(fetchBuilds.calledOnce).to.be.false;
+    button.simulate('click');
+    expect(fetchBuilds.calledOnce).to.be.true;
+    expect(fetchBuilds.calledWith({ id: 456 })).to.be.true;
+  });
+});

--- a/test/frontend/components/site/siteBuildLogs.test.js
+++ b/test/frontend/components/site/siteBuildLogs.test.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import LoadingIndicator from '../../../../frontend/components/loadingIndicator';
+
 import SiteBuildLogs from '../../../../frontend/components/site/siteBuildLogs';
+import LoadingIndicator from '../../../../frontend/components/loadingIndicator';
+
 
 describe('<SiteBuildLogs/>', () => {
   it('should render a download link and <SiteBuildLogTable>', () => {
@@ -25,6 +27,21 @@ describe('<SiteBuildLogs/>', () => {
     expect(downloadLink).to.have.length(1);
     expect(downloadLink.prop('href')).to.equal('/v0/build/123/log?format=text');
     expect(downloadLink.prop('download')).to.equal('build-log-123.txt');
+  });
+
+  it('should render a button to refresh logs', () => {
+    const props = {
+      params: {
+        buildId: 123,
+      },
+      buildLogs: {
+        isLoading: false,
+        data: [],
+      },
+    };
+
+    const wrapper = shallow(<SiteBuildLogs {...props} />);
+    expect(wrapper.find('RefreshBuildLogsButton')).to.have.length(1);
   });
 
   it('should render a loading state if builds are loading', () => {
@@ -57,5 +74,6 @@ describe('<SiteBuildLogs/>', () => {
     expect(wrapper.find('SiteBuildLogTable')).to.have.length(0);
     expect(wrapper.find('p')).to.have.length(1);
     expect(wrapper.find('p').contains('This build does not have any build logs.')).to.be.true;
+    expect(wrapper.find('RefreshBuildLogsButton')).to.have.length(1);
   });
 });

--- a/test/frontend/components/site/siteBuilds.test.js
+++ b/test/frontend/components/site/siteBuilds.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import LoadingIndicator from '../../../../frontend/components/loadingIndicator';
+
 import SiteBuilds from '../../../../frontend/components/site/siteBuilds';
+import LoadingIndicator from '../../../../frontend/components/loadingIndicator';
 
 let user;
 let site;
@@ -62,13 +63,19 @@ describe('<SiteBuilds/>', () => {
     expect(userCell.text()).to.equal('');
   });
 
+  it('should render a button to refresh builds', () => {
+    const wrapper = shallow(<SiteBuilds {...props} />);
+    expect(wrapper.find('RefreshBuildsButton')).to.have.length(1);
+  });
+
   it('should render an empty state if no builds are present', () => {
     props = { builds: { isLoading: false, builds: [] } };
     const wrapper = shallow(<SiteBuilds {...props} />);
 
     expect(wrapper.find('table')).to.have.length(0);
     expect(wrapper.find('p')).to.have.length(1);
-    expect(wrapper.find('p').contains('This site does not have any builds')).to.be.true;
+    expect(wrapper.find('p').contains('This site does not have any builds.')).to.be.true;
+    expect(wrapper.find('RefreshBuildsButton')).to.have.length(1);
   });
 
   it('should render a paragraph about truncation if 100 or more builds are present', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5281,6 +5281,10 @@ react-addons-test-utils@^15.3.1:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
 
+react-autobind@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-autobind/-/react-autobind-1.0.6.tgz#936bb58edf6b89b619c50f82f0e617159fdfd4f1"
+
 react-dom@^15.1.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"


### PR DESCRIPTION
Ref #1039

Looks like this: **Edit** I added the `usa-button` class to the buttons so they are square instead of having the rounded edges like in the screenshots below, so imagine them like that :)

<img width="997" alt="screen shot 2017-06-29 at 3 35 41 pm" src="https://user-images.githubusercontent.com/697848/27712370-5bc5b84e-5cec-11e7-9508-d395bc57d72e.png">

<img width="1044" alt="screen shot 2017-06-29 at 3 35 31 pm" src="https://user-images.githubusercontent.com/697848/27712349-44990900-5cec-11e7-9134-d27c2435812d.png">

<img width="1017" alt="screen shot 2017-06-29 at 3 35 57 pm" src="https://user-images.githubusercontent.com/697848/27712360-51cfb6dc-5cec-11e7-87d9-bcbddbd36b49.png">

