### PR TITLE
Validate that domain and demoDomain are urls that start with https://

### DIFF
--- a/api/models/site.js
+++ b/api/models/site.js
@@ -44,22 +44,6 @@ const beforeValidate = (site) => {
   }
 };
 
-
-function isEmptyOrUrl(value, throws = true) {
-  const validUrlOptions = {
-    require_protocol: true,
-    protocols: ['http', 'https'],
-  };
-
-  if (value && value.length && !validator.isURL(value, validUrlOptions)) {
-    if (throws) {
-      throw new Error('URL must start with http:// or https://');
-    }
-    return false;
-  }
-  return true;
-}
-
 function toJSON() {
   const object = Object.assign({}, this.get({
     plain: true,
@@ -67,16 +51,6 @@ function toJSON() {
 
   object.createdAt = object.createdAt.toISOString();
   object.updatedAt = object.updatedAt.toISOString();
-
-  // prevent any invalid domain or demoDomain URLs from being returned
-  // or used in the creation of viewLink or demoViewLink
-  if (!isEmptyOrUrl(object.domain, false)) {
-    object.domain = null;
-  }
-
-  if (!isEmptyOrUrl(object.demoDomain, false)) {
-    object.demoDomain = null;
-  }
 
   const s3Config = config.s3;
   object.siteRoot = `http://${s3Config.bucket}.s3-website-${s3Config.region}.amazonaws.com`;
@@ -107,6 +81,17 @@ function viewLinkForBranch(branch) {
     return `${s3Root}/demo/${this.owner}/${this.repository}`;
   }
   return url.resolve(config.app.preview_hostname, `/preview/${this.owner}/${this.repository}/${branch}`);
+}
+
+function isEmptyOrUrl(value) {
+  const validUrlOptions = {
+    require_protocol: true,
+    protocols: ['https'],
+  };
+
+  if (value && value.length && !validator.isURL(value, validUrlOptions)) {
+    throw new Error('URL must start with https://');
+  }
 }
 
 module.exports = (sequelize, DataTypes) => {

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -117,7 +117,7 @@ class SiteSettings extends React.Component {
                   name="domain"
                   className="form-control"
                   type="url"
-                  pattern="https?://.+"
+                  pattern="https://.+"
                   placeholder="https://example.gov"
                   value={state.domain}
                   onChange={this.onChange}
@@ -150,7 +150,7 @@ class SiteSettings extends React.Component {
                   className="form-control"
                   id="demoDomainInput"
                   type="url"
-                  pattern="https?://.+"
+                  pattern="https://.+"
                   placeholder="https://preview.example.com"
                   value={state.demoDomain}
                   onChange={this.onChange}

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -116,7 +116,8 @@ class SiteSettings extends React.Component {
                 <input
                   name="domain"
                   className="form-control"
-                  type="text"
+                  type="url"
+                  pattern="https?://.+"
                   placeholder="https://example.gov"
                   value={state.domain}
                   onChange={this.onChange}
@@ -148,7 +149,8 @@ class SiteSettings extends React.Component {
                   name="demoDomain"
                   className="form-control"
                   id="demoDomainInput"
-                  type="text"
+                  type="url"
+                  pattern="https?://.+"
                   placeholder="https://preview.example.com"
                   value={state.demoDomain}
                   onChange={this.onChange}

--- a/migrations/20170703201056-clean-domain-demoDomain.js
+++ b/migrations/20170703201056-clean-domain-demoDomain.js
@@ -1,0 +1,34 @@
+
+// if field value starts with 'http://',
+// then replace 'http://' with 'https://'
+const httpToHttps = field => (`UPDATE site SET "${field}" = replace("${field}", 'http://', 'https://') ` +
+          `WHERE "${field}" like 'http://%'`);
+
+// if field value is not empty or null and doesn't start with 'https://',
+// then prepend with 'https://'
+const prependHttps = field => (`UPDATE site SET "${field}" = 'https://' || "${field}" ` +
+          `WHERE "${field}" <> '' AND ` +
+          `"${field}" NOT LIKE 'https://%'`);
+
+exports.up = function up(db) {
+  return db
+    .runSql(httpToHttps('domain'))
+    .then(() => {
+      db.runSql(prependHttps('domain'));
+    })
+    .then(() => {
+      db.runSql(httpToHttps('demoDomain'));
+    })
+    .then(() => {
+      db.runSql(prependHttps('demoDomain'));
+    })
+    .catch((err) => {
+      console.log(err); // eslint-disable-line no-console
+    });
+};
+
+
+exports.down = function down(db, callback) {
+  // noop reversal for this migration
+  callback();
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "sequelize": "^3.30.0",
     "underscore": "^1.8.3",
     "urlsafe-base64": "^1.0.0",
+    "validator": "^5.2.0",
     "whatwg-fetch": "^1.0.0",
     "winston": "^2.3.1",
     "yamljs": "^0.2.8"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "cfenv": "^1.0.0",
     "connect-session-sequelize": "^4.1.0",
     "core-js": "^2.4.1",
-    "db-migrate": "^0.9.17",
+    "db-migrate": "^0.10.0-beta.20",
+    "db-migrate-pg": "^0.2.4",
     "deep-extend": "^0.4.1",
     "ejs": "^2.5.6",
     "express": "^4.14.1",
@@ -51,6 +52,7 @@
     "migrate:create": "node migrate.js create",
     "migrate:up": "node migrate.js up || true",
     "migrate:down": "node migrate.js down",
+    "migrate:test": "node migrate.js up --dry-run",
     "export:sites": "node ./scripts/exportSitesAsCsv.js",
     "analyze-webpack": "webpack-bundle-analyzer public/stats.json"
   },

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -1,102 +1,125 @@
-const expect = require("chai").expect
-const sinon = require("sinon")
-const config = require("../../../../config")
-const factory = require("../../support/factory")
-const { Site } = require("../../../../api/models")
+const expect = require('chai').expect;
+const config = require('../../../../config');
+const factory = require('../../support/factory');
+const { Site } = require('../../../../api/models');
 
-describe("Site model", () => {
-  describe("before validate hook", () => {
-    it("should lowercase the owner and repository values", done => {
+describe('Site model', () => {
+  describe('before validate hook', () => {
+    it('should lowercase the owner and repository values', (done) => {
       Site.create({
-        owner: "RepoOwner",
-        repository: "RepoName",
-      }).then(site => {
-        expect(site.owner).to.equal("repoowner")
-        expect(site.repository).to.equal("reponame")
-        done()
-      }).catch(done)
-    })
-  })
+        owner: 'RepoOwner',
+        repository: 'RepoName',
+      }).then((site) => {
+        expect(site.owner).to.equal('repoowner');
+        expect(site.repository).to.equal('reponame');
+        done();
+      }).catch(done);
+    });
+  });
 
-  describe(".viewLinkForBranch(branch)", () => {
-    const s3BaseURL = `http://${config.s3.bucket}.s3-website-${config.s3.region}.amazonaws.com`
+  describe('.viewLinkForBranch(branch)', () => {
+    const s3BaseURL = `http://${config.s3.bucket}.s3-website-${config.s3.region}.amazonaws.com`;
 
-    context("for the default branch", () => {
-      it("should return an S3 site link if there is no custom domain", done => {
-        factory.site({ defaultBranch: "default-branch" }).then(site => {
-          const viewLink = site.viewLinkForBranch("default-branch")
-          expect(viewLink).to.equal(`${s3BaseURL}/site/${site.owner}/${site.repository}`)
-          done()
-        }).catch(done)
-      })
+    context('for the default branch', () => {
+      it('should return an S3 site link if there is no custom domain', (done) => {
+        factory.site({ defaultBranch: 'default-branch' }).then((site) => {
+          const viewLink = site.viewLinkForBranch('default-branch');
+          expect(viewLink).to.equal(`${s3BaseURL}/site/${site.owner}/${site.repository}`);
+          done();
+        }).catch(done);
+      });
 
-      it("should return the custom domain if there is a cutom domain", done => {
+      it('should return the custom domain if there is a custom domain', (done) => {
         factory.site({
-          domain: "https://www.example.gov",
-          defaultBranch: "default-branch",
-        }).then(site => {
-          const viewLink = site.viewLinkForBranch("default-branch")
-          expect(viewLink).to.equal("https://www.example.gov")
-          done()
-        }).catch(done)
-      })
-    })
+          domain: 'https://www.example.gov',
+          defaultBranch: 'default-branch',
+        }).then((site) => {
+          const viewLink = site.viewLinkForBranch('default-branch');
+          expect(viewLink).to.equal('https://www.example.gov');
+          done();
+        }).catch(done);
+      });
+    });
 
-    context("for the demo branch", () => {
-      it("should return an s3 demo link if there is no demo domain", done => {
-        factory.site({ demoBranch: "demo-branch" }).then(site => {
-          const viewLink = site.viewLinkForBranch("demo-branch")
-          expect(viewLink).to.equal(`${s3BaseURL}/demo/${site.owner}/${site.repository}`)
-          done()
-        }).catch(done)
-      })
+    context('for the demo branch', () => {
+      it('should return an s3 demo link if there is no demo domain', (done) => {
+        factory.site({ demoBranch: 'demo-branch' }).then((site) => {
+          const viewLink = site.viewLinkForBranch('demo-branch');
+          expect(viewLink).to.equal(`${s3BaseURL}/demo/${site.owner}/${site.repository}`);
+          done();
+        }).catch(done);
+      });
 
-      it("should return the demo domain if there is a demo domain", done => {
+      it('should return the demo domain if there is a demo domain', (done) => {
         factory.site({
-          demoDomain: "https://demo.example.gov",
-          demoBranch: "demo-branch",
-        }).then(site => {
-          const viewLink = site.viewLinkForBranch("demo-branch")
-          expect(viewLink).to.equal("https://demo.example.gov")
-          done()
-        }).catch(done)
-      })
-    })
+          demoDomain: 'https://demo.example.gov',
+          demoBranch: 'demo-branch',
+        }).then((site) => {
+          const viewLink = site.viewLinkForBranch('demo-branch');
+          expect(viewLink).to.equal('https://demo.example.gov');
+          done();
+        }).catch(done);
+      });
+    });
 
-    context("for a preview branch", () => {
-      it("should return a federalist preview link", done => {
-        factory.site().then(site => {
-          const viewLink = site.viewLinkForBranch("preview-branch")
-          expect(viewLink).to.equal(`http://localhost:1338/preview/${site.owner}/${site.repository}/preview-branch`)
-          done()
-        }).catch(done)
-      })
-    })
-  })
+    context('for a preview branch', () => {
+      it('should return a federalist preview link', (done) => {
+        factory.site().then((site) => {
+          const viewLink = site.viewLinkForBranch('preview-branch');
+          expect(viewLink).to.equal(`http://localhost:1338/preview/${site.owner}/${site.repository}/preview-branch`);
+          done();
+        }).catch(done);
+      });
+    });
+  });
 
-  it("should not let the domain and demoDomain be equal", done => {
+  it('should not let the domain and demoDomain be equal', (done) => {
     Site.create({
-      owner: "owner",
-      repository: "repository",
-      domain: "https://www.example.gov",
-      demoDomain: "https://www.example.gov",
-    }).catch(err => {
-      expect(err.status).to.equal(403)
-      expect(err.message).to.equal("Domain and demo domain cannot be the same")
-      done()
-    }).catch(done)
-  })
+      owner: 'owner',
+      repository: 'repository',
+      domain: 'https://www.example.gov',
+      demoDomain: 'https://www.example.gov',
+    }).catch((err) => {
+      expect(err.status).to.equal(403);
+      expect(err.message).to.equal('Domain and demo domain cannot be the same');
+      done();
+    }).catch(done);
+  });
 
-  it("should not let the defaultBranch and demoBranch be equal", done => {
+  it('should not let the defaultBranch and demoBranch be equal', (done) => {
     Site.create({
-      owner: "owner",
-      repository: "repository",
-      defaultBranch: "preview",
-      demoBranch: "preview",
-    }).catch(err => {
-      expect(err.status).to.equal(403)
-      expect(err.message).to.equal("Default branch and demo branch cannot be the same")
-      done()
-    }).catch(done)
-  })
-})
+      owner: 'owner',
+      repository: 'repository',
+      defaultBranch: 'preview',
+      demoBranch: 'preview',
+    }).catch((err) => {
+      expect(err.status).to.equal(403);
+      expect(err.message).to.equal('Default branch and demo branch cannot be the same');
+      done();
+    }).catch(done);
+  });
+
+  it('should validate that the domain is a valid URL', (done) => {
+    Site.create({
+      owner: 'owner',
+      repository: 'repository',
+      domain: 'boop://beep.com',
+    }).catch((err) => {
+      expect(err.status).to.equal(403);
+      expect(err.message).to.equal('domain: URL must start with http:// or https://');
+      done();
+    }).catch(done);
+  });
+
+  it('should validate that the demoDomain is a valid URL', (done) => {
+    Site.create({
+      owner: 'owner',
+      repository: 'repository',
+      demoDomain: 'beep.com',
+    }).catch((err) => {
+      expect(err.status).to.equal(403);
+      expect(err.message).to.equal('demoDomain: URL must start with http:// or https://');
+      done();
+    }).catch(done);
+  });
+});

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -106,7 +106,7 @@ describe('Site model', () => {
       domain: 'boop://beep.com',
     }).catch((err) => {
       expect(err.status).to.equal(403);
-      expect(err.message).to.equal('domain: URL must start with http:// or https://');
+      expect(err.message).to.equal('domain: URL must start with https://');
       done();
     }).catch(done);
   });
@@ -118,7 +118,7 @@ describe('Site model', () => {
       demoDomain: 'beep.com',
     }).catch((err) => {
       expect(err.status).to.equal(403);
-      expect(err.message).to.equal('demoDomain: URL must start with http:// or https://');
+      expect(err.message).to.equal('demoDomain: URL must start with https://');
       done();
     }).catch(done);
   });

--- a/test/api/unit/serializers/site.test.js
+++ b/test/api/unit/serializers/site.test.js
@@ -6,8 +6,6 @@ const factory = require('../../support/factory');
 
 const SiteSerializer = require('../../../../api/serializers/site');
 
-const badUrl = 'javascript:alert("hi")'; // eslint-disable-line no-script-url
-
 describe('SiteSerializer', () => {
   describe('.serialize(serializable)', () => {
     it('should serialize an object correctly', (done) => {
@@ -16,34 +14,6 @@ describe('SiteSerializer', () => {
         .then((object) => {
           const result = validateJSONSchema(object, siteSchema);
           expect(result.errors).to.be.empty;
-          done();
-        })
-        .catch(done);
-    });
-
-    it('should not include invalid domain or viewLink', (done) => {
-      factory.site()
-        .then((s) => {
-          s.domain = badUrl; // eslint-disable-line no-param-reassign
-          return SiteSerializer.serialize(s);
-        })
-        .then((object) => {
-          expect(object.domain).to.be.empty;
-          expect(object.viewLink.indexOf(badUrl)).to.equal(-1);
-          done();
-        })
-        .catch(done);
-    });
-
-    it('should not include invalid demoDomain or demoViewLink', (done) => {
-      factory.site({ demoBranch: 'demo-branch' })
-        .then((s) => {
-          s.demoDomain = badUrl; // eslint-disable-line no-param-reassign
-          return SiteSerializer.serialize(s);
-        })
-        .then((object) => {
-          expect(object.demoDomain).to.be.empty;
-          expect(object.demoViewLink.indexOf(badUrl)).to.equal(-1);
           done();
         })
         .catch(done);

--- a/test/api/unit/serializers/site.test.js
+++ b/test/api/unit/serializers/site.test.js
@@ -1,37 +1,69 @@
-const expect = require("chai").expect
-const validateJSONSchema = require('jsonschema').validate
+const expect = require('chai').expect;
+const validateJSONSchema = require('jsonschema').validate;
 
-const siteSchema = require("../../../../public/swagger/Site.json")
-const factory = require("../../support/factory")
+const siteSchema = require('../../../../public/swagger/Site.json');
+const factory = require('../../support/factory');
 
-const SiteSerializer = require("../../../../api/serializers/site")
+const SiteSerializer = require('../../../../api/serializers/site');
 
-describe("SiteSerializer", () => {
-  describe(".serialize(serializable)", () => {
-    it("should serialize an object correctly", done => {
-      factory.site().then(site => {
-        return SiteSerializer.serialize(site)
-      }).then(object => {
-        const result = validateJSONSchema(object, siteSchema)
-        expect(result.errors).to.be.empty
-        done()
-      }).catch(done)
-    })
+const badUrl = 'javascript:alert("hi")'; // eslint-disable-line no-script-url
 
-    it("should serialize an array correctly", done => {
-      const sites = Array(3).fill(0).map(() => factory.site())
+describe('SiteSerializer', () => {
+  describe('.serialize(serializable)', () => {
+    it('should serialize an object correctly', (done) => {
+      factory.site()
+        .then(site => SiteSerializer.serialize(site))
+        .then((object) => {
+          const result = validateJSONSchema(object, siteSchema);
+          expect(result.errors).to.be.empty;
+          done();
+        })
+        .catch(done);
+    });
 
-      Promise.all(sites).then(sites => {
-        return SiteSerializer.serialize(sites)
-      }).then(object => {
-        const arraySchema = {
-          type: "array",
-          items: siteSchema,
-        }
-        const result = validateJSONSchema(object, arraySchema)
-        expect(result.errors).to.be.empty
-        done()
-      }).catch(done)
-    })
-  })
-})
+    it('should not include invalid domain or viewLink', (done) => {
+      factory.site()
+        .then((s) => {
+          s.domain = badUrl; // eslint-disable-line no-param-reassign
+          return SiteSerializer.serialize(s);
+        })
+        .then((object) => {
+          expect(object.domain).to.be.empty;
+          expect(object.viewLink.indexOf(badUrl)).to.equal(-1);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should not include invalid demoDomain or demoViewLink', (done) => {
+      factory.site({ demoBranch: 'demo-branch' })
+        .then((s) => {
+          s.demoDomain = badUrl; // eslint-disable-line no-param-reassign
+          return SiteSerializer.serialize(s);
+        })
+        .then((object) => {
+          expect(object.demoDomain).to.be.empty;
+          expect(object.demoViewLink.indexOf(badUrl)).to.equal(-1);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should serialize an array correctly', (done) => {
+      const sites = Array(3).fill(0).map(() => factory.site());
+
+      Promise.all(sites)
+        .then(SiteSerializer.serialize)
+        .then((object) => {
+          const arraySchema = {
+            type: 'array',
+            items: siteSchema,
+          };
+          const result = validateJSONSchema(object, arraySchema);
+          expect(result.errors).to.be.empty;
+          done();
+        })
+        .catch(done);
+    });
+  });
+});

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -80,8 +80,6 @@ describe('SQS', () => {
     context("building a site's default branch", () => {
       it('should set an empty string for BASEURL in the message for a site with a custom domain', (done) => {
         const domains = [
-          'www.example.com',
-          'www.example.com/',
           'https://example.com',
           'https://example.com/',
           'http://example.com',
@@ -114,8 +112,6 @@ describe('SQS', () => {
 
       it('should respect the path component of a custom domain when setting BASEURL in the message', (done) => {
         const domains = [
-          'www.example.com/abc/def',
-          'www.example.com/abc/def/',
           'https://example.com/abc/def',
           'https://example.com/abc/def/',
           'http://example.com/abc/def',
@@ -150,8 +146,6 @@ describe('SQS', () => {
     context("building a site's demo branch", () => {
       it('should set an empty string for BASEURL in the message for a site with a demo domain', (done) => {
         const domains = [
-          'www.example.com',
-          'www.example.com/',
           'https://example.com',
           'https://example.com/',
           'http://example.com',
@@ -181,8 +175,6 @@ describe('SQS', () => {
 
       it('should respect the path component of a custom domain when setting BASEURL in the message', (done) => {
         const domains = [
-          'www.example.com/abc/def',
-          'www.example.com/abc/def/',
           'https://example.com/abc/def',
           'https://example.com/abc/def/',
           'http://example.com/abc/def',
@@ -213,7 +205,7 @@ describe('SQS', () => {
 
     context("building a site's preview branch", () => {
       it('should set BASEURL in the message for a site with a custom domain', (done) => {
-        factory.site({ domain: 'www.example.com', owner: 'owner', repository: 'repo', defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'branch' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+        factory.site({ domain: 'http://www.example.com', owner: 'owner', repository: 'repo', defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'branch' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
           const message = SQS.messageBodyForBuild(build);
           expect(messageEnv(message, 'BASEURL')).to.equal('/preview/owner/repo/branch');
           done();

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -82,8 +82,6 @@ describe('SQS', () => {
         const domains = [
           'https://example.com',
           'https://example.com/',
-          'http://example.com',
-          'http://example.com/',
         ];
 
         const baseurlPromises = domains.map(domain => factory.site({ domain, defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'master' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
@@ -114,8 +112,6 @@ describe('SQS', () => {
         const domains = [
           'https://example.com/abc/def',
           'https://example.com/abc/def/',
-          'http://example.com/abc/def',
-          'http://example.com/abc/def/',
         ];
 
         const baseurlPromises = domains.map(domain => factory.site({ domain, defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'master' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
@@ -148,8 +144,6 @@ describe('SQS', () => {
         const domains = [
           'https://example.com',
           'https://example.com/',
-          'http://example.com',
-          'http://example.com/',
         ];
 
         const baseurlPromises = domains.map(domain => factory.site({ demoDomain: domain, demoBranch: 'demo' }).then(site => factory.build({ site, branch: 'demo' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
@@ -177,8 +171,6 @@ describe('SQS', () => {
         const domains = [
           'https://example.com/abc/def',
           'https://example.com/abc/def/',
-          'http://example.com/abc/def',
-          'http://example.com/abc/def/',
         ];
 
         const baseurlPromises = domains.map(domain => factory.site({ demoDomain: domain, demoBranch: 'demo' }).then(site => factory.build({ site, branch: 'demo' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
@@ -205,7 +197,7 @@ describe('SQS', () => {
 
     context("building a site's preview branch", () => {
       it('should set BASEURL in the message for a site with a custom domain', (done) => {
-        factory.site({ domain: 'http://www.example.com', owner: 'owner', repository: 'repo', defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'branch' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
+        factory.site({ domain: 'https://www.example.com', owner: 'owner', repository: 'repo', defaultBranch: 'master' }).then(site => factory.build({ site, branch: 'branch' })).then(build => Build.findById(build.id, { include: [Site, User] })).then((build) => {
           const message = SQS.messageBodyForBuild(build);
           expect(messageEnv(message, 'BASEURL')).to.equal('/preview/owner/repo/branch');
           done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,7 +200,7 @@ asn1.js@^4.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
-asn1@~0.2.3:
+asn1@~0.2.0, asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
 
@@ -950,10 +950,6 @@ big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 
-bignumber.js@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-3.1.2.tgz#f3bdb99ad5268a15fc1f0bed2fb018e2693fe236"
-
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
@@ -964,7 +960,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.3.4, bluebird@^3.4.6:
+bluebird@^3.1.1, bluebird@^3.3.4, bluebird@^3.4.6:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
@@ -1083,12 +1079,6 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
   dependencies:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
-
-bson@~0.2:
-  version "0.2.22"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-0.2.22.tgz#fcda103f26d0c074d5a52d50927db80fd02b4b39"
-  dependencies:
-    nan "~1.8"
 
 buffer-writer@1.0.1:
   version "1.0.1"
@@ -1394,7 +1384,7 @@ colors@1.0.3, colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-colors@~1.1.2:
+colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -1775,23 +1765,44 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-db-migrate@^0.9.17:
-  version "0.9.26"
-  resolved "https://registry.yarnpkg.com/db-migrate/-/db-migrate-0.9.26.tgz#f523e1e6d3a168587e2fddec74b0e41ea3f9794b"
+db-migrate-base@^1.5.2:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/db-migrate-base/-/db-migrate-base-1.5.3.tgz#c2d3b653573ca77c3811c286456592e06d66fa1a"
   dependencies:
-    async "~0.9.0"
-    dotenv "~0.5.1"
-    final-fs "^1.6.0"
-    mkdirp "~0.5.0"
-    moment "~2.9.0"
-    mongodb "^1.4.30"
-    mysql "^2.10.2"
-    optimist "~0.6.1"
-    parse-database-url "~0.2.2"
+    bluebird "^3.1.1"
+
+db-migrate-pg@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/db-migrate-pg/-/db-migrate-pg-0.2.4.tgz#e2fa44dc748e4ef8c1605d21b8f57a851e600280"
+  dependencies:
+    bluebird "^3.1.1"
+    db-migrate-base "^1.5.2"
     pg "^4.5.5"
-    pkginfo "~0.3.0"
-    semver "~4.3.3"
-    sqlite3 "^3.1.4"
+    semver "^5.0.3"
+
+db-migrate-shared@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/db-migrate-shared/-/db-migrate-shared-1.1.3.tgz#edb3c817b295022c61984c187267419bb36a2d58"
+
+db-migrate@^0.10.0-beta.20:
+  version "0.10.0-beta.20"
+  resolved "https://registry.yarnpkg.com/db-migrate/-/db-migrate-0.10.0-beta.20.tgz#b5af2d4341d57f0ad693ad9af31e31601e33648c"
+  dependencies:
+    balanced-match "^0.4.2"
+    bluebird "^3.1.1"
+    db-migrate-shared "^1.1.2"
+    dotenv "^2.0.0"
+    final-fs "^1.6.0"
+    inflection "^1.10.0"
+    mkdirp "~0.5.0"
+    moment "^2.14.1"
+    optimist "~0.6.1"
+    parse-database-url "~0.3.0"
+    pkginfo "^0.4.0"
+    prompt "^1.0.0"
+    resolve "^1.1.6"
+    semver "^5.3.0"
+    tunnel-ssh "^4.0.0"
 
 debug@2, debug@2.6.8, debug@^2.2.0, debug@^2.6.3:
   version "2.6.8"
@@ -1804,6 +1815,12 @@ debug@2.2.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
+
+debug@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+  dependencies:
+    ms "0.7.2"
 
 debug@2.6.7, debug@^2.1.1:
   version "2.6.7"
@@ -1828,6 +1845,10 @@ deep-eql@^0.1.3:
 deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
+deep-equal@~0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.2.2.tgz#84b745896f34c684e98f2ce0e42abaf43bba017d"
 
 deep-extend@^0.4.1, deep-extend@~0.4.0:
   version "0.4.2"
@@ -1961,9 +1982,9 @@ domutils@1.5.1, domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-dotenv@~0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-0.5.1.tgz#87d181f76102afd1a2b85c277ddd8b8795dc565b"
+dotenv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-2.0.0.tgz#bd759c357aaa70365e01c96b7b0bec08a6e0d949"
 
 dottie@^1.0.0:
   version "1.1.1"
@@ -3032,6 +3053,10 @@ https-proxy-agent@^0.3.5:
     debug "2"
     extend "3"
 
+i@0.3.x:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/i/-/i-0.3.5.tgz#1d2b854158ec8169113c6cb7f6b6801e99e211d5"
+
 iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
@@ -3084,7 +3109,7 @@ infinity-agent@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/infinity-agent/-/infinity-agent-2.0.3.tgz#45e0e2ff7a9eb030b27d62b74b3744b7a7ac4216"
 
-inflection@^1.6.0:
+inflection@^1.10.0, inflection@^1.6.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
 
@@ -3592,12 +3617,6 @@ jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
-kerberos@0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/kerberos/-/kerberos-0.0.11.tgz#cb29891c21c22ac195f3140b97dd12204fea7dc2"
-  dependencies:
-    nan "~1.8"
-
 kind-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
@@ -3770,7 +3789,7 @@ lodash.defaults@^3.1.2:
     lodash.assign "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash.defaults@^4.0.1:
+lodash.defaults@^4.0.1, lodash.defaults@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
@@ -4080,7 +4099,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -4110,22 +4129,13 @@ moment-timezone@^0.5.4:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.10.3, moment@^2.13.0:
+"moment@>= 2.9.0", moment@^2.10.3, moment@^2.13.0, moment@^2.14.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-moment@~2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.9.0.tgz#77ec1175fa294f42627f10c8e6de6302c036f6d5"
-
-mongodb@^1.4.30:
-  version "1.4.40"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-1.4.40.tgz#cfd80b74fdf0fa053f2ccfb5f49c47ca32a38efb"
-  dependencies:
-    bson "~0.2"
-  optionalDependencies:
-    kerberos "0.0.11"
-    readable-stream latest
+"mongodb-uri@>= 0.9.7":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/mongodb-uri/-/mongodb-uri-0.9.7.tgz#0f771ad16f483ae65f4287969428e9fbc4aa6181"
 
 mpath@~0.2.1:
   version "0.2.1"
@@ -4135,33 +4145,21 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
+ms@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-mute-stream@0.0.5:
+mute-stream@0.0.5, mute-stream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
-
-mysql@^2.10.2:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.13.0.tgz#998f1f8ca46e2e3dd7149ce982413653986aae47"
-  dependencies:
-    bignumber.js "3.1.2"
-    readable-stream "1.1.14"
-    sqlstring "2.2.0"
 
 nan@^2.3.0, nan@^2.3.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
-
-nan@~1.8:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-1.8.4.tgz#3c76b5382eab33e44b758d2813ca9d92e9342f34"
-
-nan@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.4.0.tgz#fb3c59d45fe4effe215f0b890f8adf6eb32d2232"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4172,6 +4170,10 @@ ncname@1.0.x:
   resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
   dependencies:
     xml-char-classes "^1.0.0"
+
+ncp@1.0.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-1.0.1.tgz#d15367e5cb87432ba117d2bf80fdf45aecfb4246"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -4269,7 +4271,7 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-pre-gyp@^0.6.36, node-pre-gyp@~0.6.31:
+node-pre-gyp@^0.6.36:
   version "0.6.36"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
   dependencies:
@@ -4591,9 +4593,11 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
-parse-database-url@~0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/parse-database-url/-/parse-database-url-0.2.2.tgz#48615ae7a7c0fc77e3294d23542a6a5273c3570b"
+parse-database-url@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/parse-database-url/-/parse-database-url-0.3.0.tgz#369666321e927c9ade63cdfc1aaaf6fb37453d0d"
+  dependencies:
+    mongodb-uri ">= 0.9.7"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -4781,9 +4785,13 @@ pkginfo@0.2.x:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.2.3.tgz#7239c42a5ef6c30b8f328439d9b9ff71042490f8"
 
-pkginfo@~0.3.0:
+pkginfo@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
+
+pkginfo@0.x.x, pkginfo@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.0.tgz#349dbb7ffd38081fcadc0853df687f0c7744cd65"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -5139,6 +5147,17 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prompt@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prompt/-/prompt-1.0.0.tgz#8e57123c396ab988897fb327fd3aedc3e735e4fe"
+  dependencies:
+    colors "^1.1.2"
+    pkginfo "0.x.x"
+    read "1.0.x"
+    revalidator "0.1.x"
+    utile "0.3.x"
+    winston "2.1.x"
+
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
@@ -5385,7 +5404,13 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@1.1.14, readable-stream@^1.1.13:
+read@1.0.x:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  dependencies:
+    mute-stream "~0.0.4"
+
+readable-stream@^1.1.13:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
@@ -5394,7 +5419,7 @@ readable-stream@1.1.14, readable-stream@^1.1.13:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@latest:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.0.tgz#640f5dcda88c91a8dc60787145629170813a1ed2"
   dependencies:
@@ -5626,13 +5651,17 @@ retry-as-promised@^2.0.0:
     cross-env "^3.1.2"
     debug "^2.2.0"
 
+revalidator@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
@@ -5717,11 +5746,11 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.3.0, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-semver@^4.1.0, semver@~4.3.3:
+semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 
@@ -5934,16 +5963,19 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sqlite3@^3.1.4:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.8.tgz#4cbcf965d8b901d1b1015cbc7fc415aae157dfaa"
+ssh2-streams@~0.1.15:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/ssh2-streams/-/ssh2-streams-0.1.19.tgz#f80ececc2de1a39e1aa64469851ec32bc96b83f9"
   dependencies:
-    nan "~2.4.0"
-    node-pre-gyp "~0.6.31"
+    asn1 "~0.2.0"
+    semver "^5.1.0"
+    streamsearch "~0.1.2"
 
-sqlstring@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.2.0.tgz#c3135c4ea8abcd7e7ee741a4966a891d86a4f191"
+ssh2@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-0.5.4.tgz#1bf6b6b28c96eaef267f4d6c46a5a2517a599e27"
+  dependencies:
+    ssh2-streams "~0.1.15"
 
 sshpk@^1.7.0:
   version "1.13.1"
@@ -5999,6 +6031,10 @@ stream-http@^2.3.1:
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
+
+streamsearch@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -6259,6 +6295,14 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tunnel-ssh@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tunnel-ssh/-/tunnel-ssh-4.1.3.tgz#911216ad79df1009082c5713fed26476ed239bad"
+  dependencies:
+    debug "2.6.0"
+    lodash.defaults "^4.1.0"
+    ssh2 "0.5.4"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -6413,6 +6457,17 @@ util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
+
+utile@0.3.x:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/utile/-/utile-0.3.0.tgz#1352c340eb820e4d8ddba039a4fbfaa32ed4ef3a"
+  dependencies:
+    async "~0.9.0"
+    deep-equal "~0.2.1"
+    i "0.3.x"
+    mkdirp "0.x.x"
+    ncp "1.0.x"
+    rimraf "2.x.x"
 
 utils-merge@1.0.0:
   version "1.0.0"
@@ -6583,6 +6638,18 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
+winston@2.1.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.1.1.tgz#3c9349d196207fd1bdff9d4bc43ef72510e3a12e"
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    pkginfo "0.3.x"
+    stack-trace "0.0.x"
+
 winston@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/winston/-/winston-2.3.1.tgz#0b48420d978c01804cf0230b648861598225a119"
@@ -6598,17 +6665,13 @@ wkx@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/wkx/-/wkx-0.2.0.tgz#76c24f16acd0cd8f93cd34aa331e0f7961256e84"
 
-wordwrap@0.0.2:
+wordwrap@0.0.2, wordwrap@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
 
 wordwrap@^1.0.0, wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
These changes are a mitigation of an XSS vulnerability described in #1047

- Use url-type inputs for domain and demoDomain on the site settings page, and check that they start with **`https://`**
- Add url validation to site model's domain and demoDomain fields
- ~Ensure that no invalid urls are returned in the site model's toJSON method~
- Add a migration to update all `domain` and `demoDomains` so that they start with `"https://"`
- Upgrade db-migrate package
- Add/modify tests

To Do:
- [x] only accept `https://` URLs
- [x] add a migration that cleans existing `domain` and `demoDomain` fields.
- [x] remove newly added logic from `Site.toJSON` since it will be superseded by the above change.