### PR TITLE
set rel='noopener noreferrer' if target='_blank' in LinkButton

### DIFF
--- a/frontend/components/linkButton.js
+++ b/frontend/components/linkButton.js
@@ -1,26 +1,45 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 const propTypes = {
-  alt: React.PropTypes.string,
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.array
+  alt: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
   ]),
-  className: React.PropTypes.string,
-  href: React.PropTypes.string,
-  target: React.PropTypes.string,
-  text: React.PropTypes.string
-}
+  className: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  target: PropTypes.string,
+  text: PropTypes.string,
+};
 
-const LinkButton = ({ className, children, text, href, alt, target }) =>
-  <Link role="button"
-    to={href}
-    className={`usa-button ${className}`}
-    alt={alt}
-    target={target}
-  >{text || children}</Link>;
+const defaultProps = {
+  text: null,
+  children: null,
+  alt: null,
+  className: null,
+  target: null,
+};
+
+const LinkButton = ({ target, href, className, alt, text, children }) => {
+  const rel = target && target.toLowerCase() === '_blank' ? 'noopener noreferrer' : null;
+
+  return (
+    <Link
+      role="button"
+      to={href}
+      className={`usa-button ${className}`}
+      alt={alt}
+      target={target}
+      rel={rel}
+    >
+      {text || children}
+    </Link>);
+};
+
 
 LinkButton.propTypes = propTypes;
+LinkButton.defaultProps = defaultProps;
 
 export default LinkButton;

--- a/frontend/components/site/pagesHeader.js
+++ b/frontend/components/site/pagesHeader.js
@@ -17,7 +17,6 @@ class PagesHeader extends React.Component {
       alt: 'View this website',
       className: 'usa-button-big pull-right icon icon-view icon-white',
       target: '_blank',
-      rel: 'noopener noreferrer',
       href: viewLink,
     };
   }

--- a/test/frontend/components/linkButton.test.js
+++ b/test/frontend/components/linkButton.test.js
@@ -6,37 +6,39 @@ import { Link } from 'react-router';
 import LinkButton from '../../../frontend/components/linkButton';
 
 const linkButton =
-  <LinkButton
+  (<LinkButton
     href="https://site.org"
     text="click here"
     className="another-class"
     alt="alt text"
-  />;
+  />);
 
 class ButtonChild extends React.Component {
   render() {
     return 'I am a child';
   }
-};
+}
 
 describe('<LinkButton/>', () => {
   let wrapper;
 
   describe('props', () => {
-    const props = ['alt', 'className', 'text', 'href'];
+    const props = ['alt', 'className', 'text', 'href', 'target'];
 
     wrapper = shallow(linkButton);
 
-    let propKeys = Object.keys(wrapper.instance().props);
+    const propKeys = Object.keys(wrapper.instance().props);
 
-    props.forEach(prop => {
+    props.forEach((prop) => {
       it(`has prop ${prop}`, () => {
         expect(propKeys.indexOf(prop)).not.to.equal(-1);
       });
     });
   });
 
-  beforeEach(() => wrapper = shallow(linkButton));
+  beforeEach(() => {
+    wrapper = shallow(linkButton);
+  });
 
   it('renders a <Link/> tag', () => {
     expect(wrapper.find(Link)).to.have.length(1);
@@ -47,14 +49,22 @@ describe('<LinkButton/>', () => {
     expect(wrapper.hasClass('another-class')).to.be.true;
   });
 
+  it('adds ref="noopener noreferrer" when target="_blank"', () => {
+    const wrapperWithTarget = shallow(
+      <LinkButton href="https://example.com" target="_blank" text="link" />
+    );
+
+    expect(wrapperWithTarget.prop('rel')).to.equal('noopener noreferrer');
+  });
+
   it('accepts a text property as a child', () => {
     expect(wrapper.children().text()).to.equal('click here');
   });
 
   it('accepts arbitrary react components as children', () => {
     const wrapperWithKids =
-      shallow(<LinkButton href="https://google.com"><ButtonChild/></LinkButton>);
+      shallow(<LinkButton href="https://google.com"><ButtonChild /></LinkButton>);
 
-    expect(wrapperWithKids.contains(<ButtonChild/>)).to.be.true;
+    expect(wrapperWithKids.contains(<ButtonChild />)).to.be.true;
   });
 });


### PR DESCRIPTION
Completes the mitigation of #1041 by ensuring the `<LinkButton>` component results in an anchor tag with `rel='noopener noreferrer'` when it has `target='_blank'`.

Ref #1051