### PR TITLE
Fix build authorizer to properly check if user is associated to site

### DIFF
--- a/api/authorizers/build.js
+++ b/api/authorizers/build.js
@@ -1,25 +1,26 @@
-const { User, Site } = require("../models")
+const { User, Site } = require('../models');
 
-const authorize = (user, build) => {
-  return User.findById(user.id, { include: [Site] }).then(user => {
-    for (site of user.Sites) {
-      if (build.site || build.Site.id === site.id) {
-        return Promise.resolve()
+const authorize = (user, build) => (
+  User.findById(user.id, { include: [Site] })
+    .then((userModel) => {
+      const buildSiteId = build.site || build.Site.id;
+      const matchingUserSite = userModel.Sites.find(site => buildSiteId === site.id);
+
+      if (matchingUserSite) {
+        return Promise.resolve();
       }
+      return Promise.reject(403);
     }
-    return Promise.reject(403)
-  })
-}
+  )
+);
 
-const findOne = (user, build) => {
-  return authorize(user, build)
-}
+const findOne = (user, build) => authorize(user, build);
 
 const create = (user, params) => {
-  if (user.id != params.user) {
-    throw 403
+  if (user.id !== params.user) {
+    throw 403;
   }
-  return authorize(user, params)
-}
+  return authorize(user, params);
+};
 
-module.exports = { findOne, create }
+module.exports = { findOne, create };

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -122,15 +122,22 @@ describe('Build API', () => {
     });
 
     it('should render a 403 if the user is not associated with the given site', (done) => {
+      const userProm = factory.user();
+      const authorizedSiteProm = factory.site({ users: Promise.all([userProm]) });
+      const notAuthorizedSiteProm = factory.site();
+      const cookieProm = session(userProm);
+
       Promise.props({
-        site: factory.site(),
-        cookie: session(),
+        user: userProm,
+        authorizedSite: authorizedSiteProm,
+        notAuthorizedSite: notAuthorizedSiteProm,
+        cookie: cookieProm,
       })
-      .then(({ site, cookie }) =>
+      .then(({ notAuthorizedSite, cookie }) =>
         request(app)
           .post('/v0/build/')
           .send({
-            site: site.id,
+            site: notAuthorizedSite.id,
             branch: 'my-branch',
             commitSha: 'Everybody 👏👏👏👏 your hands',
           })

--- a/test/api/unit/services/S3PublishedFileLister.test.js
+++ b/test/api/unit/services/S3PublishedFileLister.test.js
@@ -1,23 +1,23 @@
-const AWSMocks = require('../../support/aws-mocks')
-const expect = require("chai").expect
-const factory = require("../../support/factory")
-const config = require("../../../../config")
+const AWSMocks = require('../../support/aws-mocks');
+const expect = require('chai').expect;
+const factory = require('../../support/factory');
+const config = require('../../../../config');
 
-const S3PublishedFileLister = require("../../../../api/services/S3PublishedFileLister")
+const S3PublishedFileLister = require('../../../../api/services/S3PublishedFileLister');
 
-describe("S3PublishedFileLister", () => {
+describe('S3PublishedFileLister', () => {
   after(() => {
-    AWSMocks.resetMocks()
-  })
+    AWSMocks.resetMocks();
+  });
 
-  describe(".listPublishedPreviews(site)", () => {
-    it("should resolve with a list of published previews for the given site", done => {
-      let site
+  describe('.listPublishedPreviews(site)', () => {
+    it('should resolve with a list of published previews for the given site', (done) => {
+      let site;
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
-        expect(params.Bucket).to.equal(config.s3.bucket)
-        expect(params.Prefix).to.equal(`preview/${site.owner}/${site.repository}/`)
-        expect(params.Delimiter).to.equal("/")
+        expect(params.Bucket).to.equal(config.s3.bucket);
+        expect(params.Prefix).to.equal(`preview/${site.owner}/${site.repository}/`);
+        expect(params.Delimiter).to.equal('/');
         callback(null, {
           Contents: [],
           CommonPrefixes: [
@@ -25,119 +25,122 @@ describe("S3PublishedFileLister", () => {
             { Prefix: `preview/${site.owner}/${site.repository}/def/` },
             { Prefix: `preview/${site.owner}/${site.repository}/ghi/` },
           ],
-        })
-      }
+        });
+      };
 
-      factory.site().then(model => {
-        site = model
-        return S3PublishedFileLister.listPublishedPreviews(site)
-      }).then(publishedPreviews => {
-        expect(publishedPreviews).to.deep.equal(["abc", "def", "ghi"])
-        done()
-      }).catch(done)
-    })
-  })
+      factory.site().then((model) => {
+        site = model;
+        return S3PublishedFileLister.listPublishedPreviews(site);
+      }).then((publishedPreviews) => {
+        expect(publishedPreviews).to.deep.equal(['abc', 'def', 'ghi']);
+        done();
+      }).catch(done);
+    });
+  });
 
-  describe(".listPublishedFilesForBranch(site, branch)", () => {
-    it("should resolve with a list of files for the site's default branch", done => {
-      let site
+  describe('.listPublishedFilesForBranch(site, branch)', () => {
+    it("should resolve with a list of files for the site's default branch", (done) => {
+      let site;
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
-        const prefix = `site/${site.owner}/${site.repository}`
-        expect(params.Bucket).to.equal(config.s3.bucket)
-        expect(params.Prefix).to.equal(prefix)
+        const prefix = `site/${site.owner}/${site.repository}`;
+        expect(params.Bucket).to.equal(config.s3.bucket);
+        expect(params.Prefix).to.equal(prefix);
 
         callback(null, {
           Contents: [
             { Key: `${prefix}/abc`, Size: 123 },
             { Key: `${prefix}/abc/def`, Size: 456 },
             { Key: `${prefix}/ghi`, Size: 789 },
-          ]
-        })
-      }
+          ],
+        });
+      };
 
-      factory.site({ defaultBranch: "master" }).then(model => {
-        site = model
-        return S3PublishedFileLister.listPublishedFilesForBranch(site, "master")
-      }).then(publishedFiles => {
+      factory.site({ defaultBranch: 'master' }).then((model) => {
+        site = model;
+        return S3PublishedFileLister.listPublishedFilesForBranch(site, 'master');
+      }).then((publishedFiles) => {
         expect(publishedFiles).to.deep.equal([
-          { name: "abc", size: 123 },
-          { name: "abc/def", size: 456 },
-          { name: "ghi", size: 789 },
-        ])
-        done()
-      }).catch(done)
-    })
+          { name: 'abc', size: 123 },
+          { name: 'abc/def', size: 456 },
+          { name: 'ghi', size: 789 },
+        ]);
+        done();
+      }).catch(done);
+    });
 
-    it("should resolve with a list of files for the site's demo branch", done => {
-      let site
+    it("should resolve with a list of files for the site's demo branch", (done) => {
+      let site;
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
-        const prefix = `demo/${site.owner}/${site.repository}`
-        expect(params.Bucket).to.equal(config.s3.bucket)
-        expect(params.Prefix).to.equal(prefix)
+        const prefix = `demo/${site.owner}/${site.repository}`;
+        expect(params.Bucket).to.equal(config.s3.bucket);
+        expect(params.Prefix).to.equal(prefix);
 
         callback(null, {
           Contents: [
             { Key: `${prefix}/abc`, Size: 123 },
             { Key: `${prefix}/abc/def`, Size: 456 },
             { Key: `${prefix}/ghi`, Size: 789 },
-          ]
-        })
-      }
+          ],
+        });
+      };
 
-      factory.site({ demoBranch: "demo-branch-name" }).then(model => {
-        site = model
-        return S3PublishedFileLister.listPublishedFilesForBranch(site, "demo-branch-name")
-      }).then(publishedFiles => {
+      factory.site({ demoBranch: 'demo-branch-name' }).then((model) => {
+        site = model;
+        return S3PublishedFileLister.listPublishedFilesForBranch(site, 'demo-branch-name');
+      }).then((publishedFiles) => {
         expect(publishedFiles).to.deep.equal([
-          { name: "abc", size: 123 },
-          { name: "abc/def", size: 456 },
-          { name: "ghi", size: 789 },
-        ])
-        done()
-      }).catch(done)
-    })
+          { name: 'abc', size: 123 },
+          { name: 'abc/def', size: 456 },
+          { name: 'ghi', size: 789 },
+        ]);
+        done();
+      }).catch(done);
+    });
 
-    it("should resolve with a list of files for a preview branch", done => {
-      let site
+    it('should resolve with a list of files for a preview branch', (done) => {
+      let site;
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
-        const prefix = `preview/${site.owner}/${site.repository}/preview`
-        expect(params.Bucket).to.equal(config.s3.bucket)
-        expect(params.Prefix).to.equal(prefix)
+        const prefix = `preview/${site.owner}/${site.repository}/preview`;
+        expect(params.Bucket).to.equal(config.s3.bucket);
+        expect(params.Prefix).to.equal(prefix);
 
         callback(null, {
           Contents: [
             { Key: `${prefix}/abc`, Size: 123 },
             { Key: `${prefix}/abc/def`, Size: 456 },
             { Key: `${prefix}/ghi`, Size: 789 },
-          ]
-        })
-      }
+          ],
+        });
+      };
 
-      factory.site({ defaultBranch: "master" }).then(model => {
-        site = model
-        return S3PublishedFileLister.listPublishedFilesForBranch(site, "preview")
-      }).then(publishedFiles => {
+      factory.site({ defaultBranch: 'master' }).then((model) => {
+        site = model;
+        return S3PublishedFileLister.listPublishedFilesForBranch(site, 'preview');
+      }).then((publishedFiles) => {
         expect(publishedFiles).to.deep.equal([
-          { name: "abc", size: 123 },
-          { name: "abc/def", size: 456 },
-          { name: "ghi", size: 789 },
-        ])
-        done()
-      }).catch(done)
-    })
+          { name: 'abc', size: 123 },
+          { name: 'abc/def', size: 456 },
+          { name: 'ghi', size: 789 },
+        ]);
+        done();
+      }).catch(done);
+    });
 
-    it("should reject with an error if S3.listObjects is unsuccessful", done => {
-      AWSMocks.mocks.S3.listObjects = (params, cb) => cb(new Error("Test error"))
+    it('should reject with an error if S3.listObjects is unsuccessful', (done) => {
+      AWSMocks.mocks.S3.listObjects = (params, cb) => cb(new Error('Test error'));
 
-      factory.site().then(model => {
-        return S3PublishedFileLister.listPublishedFilesForBranch(site, "preview")
-      }).catch(err => {
-        expect(err.message).to.equal("Test error")
-        done()
-      }).catch(done)
-    })
-  })
-})
+      factory.site()
+        .then(site =>
+          S3PublishedFileLister.listPublishedFilesForBranch(site, 'preview')
+        )
+        .catch((err) => {
+          expect(err.message).to.equal('Test error');
+          done();
+        })
+        .catch(done);
+    });
+  });
+});


### PR DESCRIPTION
This site fixes an issue with the build authorizer that would allow any user to create a build model (or restart one). The problem was a buggy if-condition. Ref #1054

Also:
- fix S3PublishedFileLister.test.js that broke due to proper build auth checking
- fix associated build authorizer and request tests
- lint files

Supersedes PR #1060 that I screwed up with a bad rebase