### PR TITLE
Configure CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,20 @@
+---
+engines:
+  eslint:
+    enabled: true
+    channel: "eslint-3"
+    checks:
+      import/no-unresolved:
+        enabled: false
+      import/extensions:
+        enabled: false
+    config:
+      extensions:
+      - .js
+      - .jsx
+ratings:
+  paths:
+  - "**.js"
+  - "**.jsx"
+exclude_paths:
+- node_modules/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb",
   "rules": {
+    /** airbnb config overrides **/
     "react/jsx-filename-extension": [0],
     "import/no-extraneous-dependencies": [0],
     "class-methods-use-this": [0],


### PR DESCRIPTION
This PR should get code quality reporting in Code Climate.

I decided to punt on test coverage reporting and setting up `scanjs` with `eslint` for separate PRs that can build off of this baseline functionality. Furthermore, using the `nodesecurity` engine in CodeClimate requires a `shrinkwrap.json` be present, but we are using `yarn`, so we don't have one :\ I think I'll see what shakes out at today's ATO meeting to decide what to do regarding static security analysis.

To Do:
- [x] Request and wait for default branch setting change by CodeClimate team
- ~Add nodesecurity engine: https://docs.codeclimate.com/v1.0/docs/nodesecurity~ Won't work because we don't use `npm shrinkwrap`
- ~Figure out test coverage reporting.~ Punt to a separate PR.