### PR TITLE
.about.yml maintenance

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -88,6 +88,11 @@ services:
   category: Code Review
   url: https://codeclimate.com/github/18F/federalist
   badge: https://codeclimate.com/github/18F/federalist/badges/gpa.svg
+- name: Gemnasium
+  category: Dependency Analysis
+  url: https://gemnasium.com/github.com/18F/federalist
+  badge: https://gemnasium.com/badges/github.com/18F/federalist.svg
+
 
 # Licenses that apply to the project and/or its components (required)
 # Items by property name pattern:

--- a/.about.yml
+++ b/.about.yml
@@ -20,7 +20,7 @@ parent: federalist
 
 # Maturity stage of the project (required)
 # values: discovery, alpha, beta, live
-stage: beta
+stage: live
 
 # Whether or not the project is actively maintained (required)
 # values: active, deprecated
@@ -39,14 +39,20 @@ testable: true
 #   id: Internal team identifier/user name
 #   role: Team member's role; leads should be designated as 'lead'
 team:
-- github: dhcole
+- github: wslack
   role: lead
-- github: jeremiak
+- github: jseppi
   role: developer
+- github: jmhooper
+  role: developer
+- github: dhcole
+  role: emeritus (lead)
+- github: jeremiak
+  role: emeritus (developer)
 - github: gailswanson
-  role: designer/researcher
+  role: emeritus (designer/researcher)
 - github: melodykramer
-  role: content
+  role: emeritus (content)
 
 # Partners for whom the project is developed
 partners:
@@ -60,6 +66,7 @@ partners:
 stack:
 - Node
 - Express
+- React
 - Webpack
 - AWS
 
@@ -73,10 +80,14 @@ stack:
 #   url: URL for detailed information
 #   badge: URL for the status badge
 services:
-- name: travis
-  category: continuous deployment
+- name: Travis CI
+  category: Continuous Deployment
   url: https://travis-ci.org/18F/federalist
   badge: https://travis-ci.org/18F/federalist.svg?branch=master
+- name: Code Climate
+  category: Code Review
+  url: https://codeclimate.com/github/18F/federalist
+  badge: https://codeclimate.com/github/18F/federalist/badges/gpa.svg
 
 # Licenses that apply to the project and/or its components (required)
 # Items by property name pattern:
@@ -85,7 +96,7 @@ services:
 #     url: URL for the text of the license
 licenses:
   federalist:
-    name: CC0
+    name: CC0-1.0
     url: https://github.com/18F/federalist/blob/master/LICENSE.md
 
 # Blogs or websites associated with project development
@@ -102,5 +113,5 @@ links:
 
 # Email addresses of points-of-contact
 contact:
-- url: mailto:david.cole@gsa.gov
-  text: David Cole
+- url: mailto:william.slack@gsa.gov
+  text: Will Slack

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Federalist
 [![Build Status](https://travis-ci.org/18F/federalist.svg?ref=master)](https://travis-ci.org/18F/federalist)
 [![Code Climate](https://codeclimate.com/github/18F/federalist/badges/gpa.svg)](https://codeclimate.com/github/18F/federalist)
-[![Known Vulnerabilities](https://snyk.io/test/github/18F/federalist/badge.svg)](https://snyk.io/test/github/18F/federalist)
 
 ***Under active development. Everything is subject to change. Learn more at the [documentation site](https://federalist-docs.18f.gov/). Interested in talking to us? [Join our public chat room](https://chat.18f.gov/).***
 


### PR DESCRIPTION
Various fixes/clarifications to our `.about.yml`.

Most significant change is an update to the `team` list. I made previous folks "emeritus" members and added the three current team members (@wslack, @jmhooper, and me).

I also removed the `snyk.io` badge from README.