### PR TITLE
Add Gemnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Federalist
 [![Build Status](https://travis-ci.org/18F/federalist.svg?ref=master)](https://travis-ci.org/18F/federalist)
 [![Code Climate](https://codeclimate.com/github/18F/federalist/badges/gpa.svg)](https://codeclimate.com/github/18F/federalist)
-[![Known Vulnerabilities](https://snyk.io/test/github/18F/federalist/badge.svg)](https://snyk.io/test/github/18F/federalist)
+[![Dependency Status](https://gemnasium.com/badges/github.com/18F/federalist.svg)](https://gemnasium.com/github.com/18F/federalist)
 
 ***Under active development. Everything is subject to change. Learn more at the [documentation site](https://federalist-docs.18f.gov/). Interested in talking to us? [Join our public chat room](https://chat.18f.gov/).***
 


### PR DESCRIPTION
ref #1072 

Gemnasium has been setup per https://before-you-ship.18f.gov/security/static-analysis/#gemnasium: https://gemnasium.com/github.com/18F/federalist/

To Do:
- [x] add to `.about.yml` - Done in #1071 