### PR TITLE
Show error message when user has no site data for given site id param

### DIFF
--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import SideNav from './site/SideNav/sideNav';
 import PagesHeader from './site/pagesHeader';
 import AlertBanner from './alertBanner';
+import LoadingIndicator from './loadingIndicator';
 
 const propTypes = {
   params: PropTypes.shape({
@@ -25,7 +26,7 @@ const propTypes = {
   }),
   location: PropTypes.shape({
     pathname: PropTypes.string,
-  }),
+  }).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
@@ -34,7 +35,6 @@ const propTypes = {
 
 const defaultProps = {
   children: null,
-  location: null,
   storeState: null,
 };
 
@@ -54,12 +54,36 @@ class SiteContainer extends React.Component {
   render() {
     const { storeState, children, params, location } = this.props;
 
+    if (storeState.sites.isLoading) {
+      return <LoadingIndicator />;
+    }
+
     const site = this.getCurrentSite(storeState.sites, params.id);
+
+    if (!site) {
+      return (
+        <div className="usa-grid">
+          <div className="usa-alert usa-alert-error" role="alert">
+            <div className="usa-alert-body">
+              <h3 className="usa-alert-heading">Unauthorized</h3>
+              <p className="usa-alert-text">
+                Apologies; you don&apos;t have access to this site in Federalist!
+                <br />
+                Please contact the site owner if you should have access.
+              </p>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    const pageTitle = this.getPageTitle(location.pathname);
     const builds = storeState.builds;
     const buildLogs = storeState.buildLogs;
     const publishedBranches = storeState.publishedBranches;
     const publishedFiles = storeState.publishedFiles;
     const githubBranches = storeState.githubBranches;
+
     const childConfigs = {
       site,
       builds,
@@ -68,12 +92,6 @@ class SiteContainer extends React.Component {
       publishedFiles,
       githubBranches,
     };
-
-    const pageTitle = this.getPageTitle(location.pathname);
-
-    if (!site) {
-      return null;
-    }
 
     return (
       <div className="usa-grid site">

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -1,48 +1,73 @@
 import React from 'react';
-import { Link } from 'react-router';
-
-import { replaceHistory } from '../actions/routeActions';
-import siteActions from '../actions/siteActions';
+import PropTypes from 'prop-types';
 
 import SideNav from './site/SideNav/sideNav';
 import PagesHeader from './site/pagesHeader';
 import AlertBanner from './alertBanner';
 
 const propTypes = {
-  storeState: React.PropTypes.object,
-  params: React.PropTypes.object //{id, branch, splat, fileName}
+  params: PropTypes.shape({
+    id: PropTypes.string,
+    branch: PropTypes.string,
+    fileName: PropTypes.string,
+  }).isRequired,
+  storeState: PropTypes.shape({
+    sites: PropTypes.object,
+    builds: PropTypes.object,
+    buildLogs: PropTypes.object,
+    publishedBranches: PropTypes.object,
+    publishedFiles: PropTypes.object,
+    githubBranches: PropTypes.object,
+    alert: PropTypes.shape({
+      message: PropTypes.string,
+      status: PropTypes.string,
+    }),
+  }),
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+};
+
+const defaultProps = {
+  children: null,
+  location: null,
+  storeState: null,
 };
 
 class SiteContainer extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   getPageTitle(pathname) {
     return pathname.split('/').pop();
   }
 
   getCurrentSite(sitesState, siteId) {
     if (sitesState.isLoading) {
-      return null
+      return null;
     }
 
-    return sitesState.data.find((site) => {
-      // force type coersion
-      return site.id == siteId;
-    });
+    return sitesState.data.find(site => site.id === parseInt(siteId, 10));
   }
 
-  render () {
+  render() {
     const { storeState, children, params, location } = this.props;
 
-    const site = this.getCurrentSite(storeState.sites, params.id)
-    const builds = storeState.builds
-    const buildLogs = storeState.buildLogs
-    const publishedBranches = storeState.publishedBranches
-    const publishedFiles = storeState.publishedFiles
-    const githubBranches = storeState.githubBranches
-    const childConfigs = { site, builds, buildLogs, publishedBranches, publishedFiles, githubBranches }
+    const site = this.getCurrentSite(storeState.sites, params.id);
+    const builds = storeState.builds;
+    const buildLogs = storeState.buildLogs;
+    const publishedBranches = storeState.publishedBranches;
+    const publishedFiles = storeState.publishedFiles;
+    const githubBranches = storeState.githubBranches;
+    const childConfigs = {
+      site,
+      builds,
+      buildLogs,
+      publishedBranches,
+      publishedFiles,
+      githubBranches,
+    };
 
     const pageTitle = this.getPageTitle(location.pathname);
 
@@ -56,7 +81,8 @@ class SiteContainer extends React.Component {
         <div className="usa-width-five-sixths site-main" id="pages-container">
           <AlertBanner
             message={storeState.alert.message}
-            status={storeState.alert.status}/>
+            status={storeState.alert.status}
+          />
           <PagesHeader
             repository={site.repository}
             owner={site.owner}
@@ -78,5 +104,6 @@ class SiteContainer extends React.Component {
 }
 
 SiteContainer.propTypes = propTypes;
+SiteContainer.defaultProps = defaultProps;
 
 export default SiteContainer;

--- a/frontend/routes.js
+++ b/frontend/routes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Link, IndexRedirect, IndexRoute, Redirect } from 'react-router';
+import { Route, IndexRedirect, IndexRoute, Redirect } from 'react-router';
 
 import App from './components/app';
 import SiteList from './components/siteList/siteList';
@@ -7,7 +7,7 @@ import SiteContainer from './components/siteContainer';
 import SiteBuilds from './components/site/siteBuilds';
 import SiteBuildLogs from './components/site/siteBuildLogs';
 import SitePublishedBranchesTable from './components/site/sitePublishedBranchesTable';
-import SitePublishedFilesTable from "./components/site/sitePublishedFilesTable"
+import SitePublishedFilesTable from './components/site/sitePublishedFilesTable';
 import SiteSettings from './components/site/siteSettings';
 import NewSite from './components/AddSite';
 import NotFound from './components/NotFound';
@@ -15,25 +15,25 @@ import Home from './components/home';
 
 export default (
   <Route path="/" component={App}>
-    <IndexRoute component={Home}/>
+    <IndexRoute component={Home} />
     <Route path="sites">
-      <IndexRoute component={SiteList}/>
+      <IndexRoute component={SiteList} />
       <Route path="new" component={NewSite} />
       <Route path=":id" component={SiteContainer}>
         <IndexRedirect to="settings" />
-        <Route path="settings" component={SiteSettings}/>
+        <Route path="settings" component={SiteSettings} />
         <Route path="published">
-          <IndexRoute component={SitePublishedBranchesTable}/>
-          <Route path=":name" component={SitePublishedFilesTable}/>
+          <IndexRoute component={SitePublishedBranchesTable} />
+          <Route path=":name" component={SitePublishedFilesTable} />
         </Route>
         <Route path="builds">
-          <IndexRoute component={SiteBuilds}/>
-          <Route path=":buildId/logs" component={SiteBuildLogs}/>
+          <IndexRoute component={SiteBuilds} />
+          <Route path=":buildId/logs" component={SiteBuildLogs} />
         </Route>
       </Route>
-      <Redirect from="*" to="/not-found"/>
+      <Redirect from="*" to="/not-found" />
     </Route>
-    <Route path="/not-found" component={NotFound}/>
-    <Redirect from="*" to="/sites"/>
+    <Route path="/not-found" component={NotFound} />
+    <Redirect from="*" to="/sites" />
   </Route>
 );

--- a/test/frontend/components/siteContainer.test.js
+++ b/test/frontend/components/siteContainer.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import SiteContainer from '../../../frontend/components/siteContainer';
+
+let props;
+
+describe('<SiteContainer/>', () => {
+  beforeEach(() => {
+    props = {
+      storeState: {
+        alert: {},
+        sites: {
+          isLoading: false,
+          data: [{
+            id: 1,
+            defaultBranch: 'master',
+            engine: 'jekyll',
+            owner: '18f',
+            publishedAt: '2017-06-08T20:53:14.363Z',
+          }],
+        },
+      },
+      location: {
+        pathname: '',
+      },
+      params: {
+        id: '1',
+        branch: 'branch',
+        fileName: 'boop.txt',
+      },
+    };
+  });
+
+  it('renders a LoadingIndicator while sites are loading', () => {
+    props.storeState.sites = {
+      isLoading: true,
+    };
+    const wrapper = shallow(<SiteContainer {...props} />);
+    expect(wrapper.find('LoadingIndicator')).to.have.length(1);
+  });
+
+  it('renders after sites have loaded', () => {
+    const wrapper = shallow(<SiteContainer {...props} />);
+    expect(wrapper.find('LoadingIndicator')).to.have.length(0);
+    expect(wrapper.find('SideNav')).to.have.length(1);
+    expect(wrapper.find('AlertBanner')).to.have.length(1);
+    expect(wrapper.find('PagesHeader')).to.have.length(1);
+  });
+
+  it('renders an error after sites have loaded but no matching site', () => {
+    props.params.id = '999';
+    const wrapper = shallow(<SiteContainer {...props} />);
+    expect(wrapper.find('LoadingIndicator')).to.have.length(0);
+    expect(wrapper.find('.usa-alert-error')).to.have.length(1);
+  });
+});


### PR DESCRIPTION
Ref #1058

This PR modifies the `SiteContainer` component to render an error message after sites have loaded if there is no `site` with the same `id` as in the URL params, which generally means either such a site does not exist, or the user is not authorized to view that site.

`SiteContainer` was also previously untested, so this adds tests for that component.

Looks like this:

<img width="1004" alt="screen shot 2017-07-21 at 12 48 18 pm" src="https://user-images.githubusercontent.com/697848/28478143-b135f154-6e1c-11e7-8258-dd92d754bde9.png">
