### PR TITLE
upgrade eslint-plugin-scanjs-rules version and rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,101 +1,5 @@
-const scanjsRules = {
-  /* no-unsanitized rules */
-  'no-unsanitized/method': 2,
-  'no-unsanitized/property': 2,
-
-  /* ScanJS rules */
-  'scanjs-rules/assign_to_hostname': 1,
-  'scanjs-rules/assign_to_href': 1,
-  'scanjs-rules/assign_to_location': 1,
-  'scanjs-rules/assign_to_mozAudioChannel': 1,
-  'scanjs-rules/assign_to_mozAudioChannelType': 1,
-  'scanjs-rules/assign_to_onmessage': 1,
-  'scanjs-rules/assign_to_pathname': 1,
-  'scanjs-rules/assign_to_protocol': 1,
-  'scanjs-rules/assign_to_search': 1,
-  'scanjs-rules/assign_to_src': 1,
-  'scanjs-rules/call_Function': 1,
-  'scanjs-rules/call_addEventListener': 1,
-  'scanjs-rules/call_addEventListener_cellbroadcastmsgchanged': 1,
-  'scanjs-rules/call_addEventListener_deviceproximity': 1,
-  'scanjs-rules/call_addEventListener_message': 1,
-  'scanjs-rules/call_addEventListener_moznetworkdownload': 1,
-  'scanjs-rules/call_addEventListener_moznetworkupload': 1,
-  // 'scanjs-rules/call_connect': 1,  // we use react-redux's connect in many places safely
-  'scanjs-rules/call_eval': 1,
-  'scanjs-rules/call_execScript': 1,
-  'scanjs-rules/call_generateCRMFRequest': 1,
-  'scanjs-rules/call_getDeviceStorage_apps': 1,
-  'scanjs-rules/call_getDeviceStorage_crashes': 1,
-  'scanjs-rules/call_getDeviceStorage_music': 1,
-  'scanjs-rules/call_getDeviceStorage_pictures': 1,
-  'scanjs-rules/call_getDeviceStorage_sdcard': 1,
-  'scanjs-rules/call_getDeviceStorage_videos': 1,
-  'scanjs-rules/call_hide': 1,
-  'scanjs-rules/call_mozSetMessageHandler': 1,
-  'scanjs-rules/call_mozSetMessageHandler_activity': 1,
-  'scanjs-rules/call_mozSetMessageHandler_wappush_received': 1,
-  'scanjs-rules/call_open_attention': 1,
-  'scanjs-rules/call_open_remote=true': 1,
-  'scanjs-rules/call_parseFromString': 1,
-  'scanjs-rules/call_setAttribute_mozapp': 1,
-  'scanjs-rules/call_setAttribute_mozbrowser': 1,
-  'scanjs-rules/call_setImmediate': 1,
-  'scanjs-rules/call_setInterval': 1,
-  'scanjs-rules/call_setMessageHandler_connect': 1,
-  'scanjs-rules/call_setTimeout': 1,
-  'scanjs-rules/call_write': 1,
-  'scanjs-rules/call_writeln': 1,
-  'scanjs-rules/identifier_indexedDB': 1,
-  'scanjs-rules/identifier_localStorage': 1,
-  'scanjs-rules/identifier_sessionStorage': 1,
-  'scanjs-rules/new_Function': 1,
-  'scanjs-rules/new_MozActivity': 1,
-  'scanjs-rules/new_MozSpeakerManager': 1,
-  'scanjs-rules/new_Notification': 1,
-  // 'scanjs-rules/object_mozSystem': 1,  // bombs out on spread operator, ref: https://github.com/mozfreddyb/eslint-plugin-scanjs-rules/issues/8
-  'scanjs-rules/property_addIdleObserver': 1,
-  'scanjs-rules/property_createContextualFragment': 1,
-  'scanjs-rules/property_geolocation': 1,
-  'scanjs-rules/property_getDataStores': 1,
-  'scanjs-rules/property_getDeviceStorage': 1,
-  'scanjs-rules/property_getUserMedia': 1,
-  'scanjs-rules/property_indexedDB': 1,
-  'scanjs-rules/property_lastKnownHomeNetwork': 1,
-  'scanjs-rules/property_lastKnownNetwork': 1,
-  'scanjs-rules/property_localStorage': 1,
-  'scanjs-rules/property_mgmt': 1,
-  'scanjs-rules/property_mozAlarms': 1,
-  'scanjs-rules/property_mozBluetooth': 1,
-  'scanjs-rules/property_mozCameras': 1,
-  'scanjs-rules/property_mozCellBroadcast': 1,
-  'scanjs-rules/property_mozContacts': 1,
-  'scanjs-rules/property_mozDownloadManager': 1,
-  'scanjs-rules/property_mozFMRadio': 1,
-  'scanjs-rules/property_mozInputMethod': 1,
-  'scanjs-rules/property_mozKeyboard': 1,
-  'scanjs-rules/property_mozMobileConnection': 1,
-  'scanjs-rules/property_mozMobileConnections': 1,
-  'scanjs-rules/property_mozMobileMessage': 1,
-  'scanjs-rules/property_mozNetworkStats': 1,
-  'scanjs-rules/property_mozNfc': 1,
-  'scanjs-rules/property_mozNotification': 1,
-  'scanjs-rules/property_mozPermissionSettings': 1,
-  'scanjs-rules/property_mozPhoneNumberService': 1,
-  'scanjs-rules/property_mozPower': 1,
-  'scanjs-rules/property_mozSettings': 1,
-  'scanjs-rules/property_mozTCPSocket': 1,
-  'scanjs-rules/property_mozTelephony': 1,
-  'scanjs-rules/property_mozTime': 1,
-  'scanjs-rules/property_mozVoicemail': 1,
-  'scanjs-rules/property_mozWifiManager': 1,
-  'scanjs-rules/property_sessionStorage': 1,
-};
-
 const finalRules = {
   /* airbnb config overrides */
-  // allow names to be the same as the default for Redux container testing
-  'import/no-named-as-default': [0],
   'react/jsx-filename-extension': [0],
   'import/no-extraneous-dependencies': [0],
   'class-methods-use-this': [0],
@@ -113,19 +17,32 @@ const finalRules = {
 
 const finalPlugins = [];
 
-let hasScanJs = false;
+let scanjsRulesConfig = null;
 
 try {
-  require('eslint-plugin-scanjs-rules'); // eslint-disable-line global-require
-  hasScanJs = true;
+  // eslint-disable-next-line global-require
+  const scanjsConfig = require('eslint-plugin-scanjs-rules');
+  scanjsRulesConfig = {};
+
+  // bring in all the scanjs rules, prefixed with 'scanjs-rules',
+  // but convert them to eslint errors instead of warnings
+  Object.keys(scanjsConfig.rulesConfig).forEach((rule) => {
+    scanjsRulesConfig[`scanjs-rules/${rule}`] = 1;
+  });
 } catch (err) {
   // eslint-disable-next-line no-console
   console.log('eslint-plugin-scanjs-rules not found, will not include scanjs rules');
 }
 
-if (hasScanJs) {
+if (scanjsRulesConfig) {
   finalPlugins.push('scanjs-rules', 'no-unsanitized');
-  Object.assign(finalRules, scanjsRules);
+
+  const noUnsanitizedRules = {
+    'no-unsanitized/method': 2,
+    'no-unsanitized/property': 2,
+  };
+
+  Object.assign(finalRules, scanjsRulesConfig, noUnsanitizedRules);
 }
 
 module.exports = {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ const finalRules = {
   /* airbnb config overrides */
   'react/jsx-filename-extension': [0],
   'import/no-extraneous-dependencies': [0],
+  'import/no-named-as-default': [0], // allow component to be the same as the default export
   'class-methods-use-this': [0],
   'no-throw-literal': [0],
   'comma-dangle': ['error',

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-no-unsanitized": "^2.0.1",
     "eslint-plugin-react": "^6.10.3",
-    "eslint-plugin-scanjs-rules": "^0.1.5",
+    "eslint-plugin-scanjs-rules": "^0.2.1",
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.11.1",
     "history": "^4.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2309,9 +2309,9 @@ eslint-plugin-react@^6.10.3:
     jsx-ast-utils "^1.3.4"
     object.assign "^4.0.4"
 
-eslint-plugin-scanjs-rules@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-scanjs-rules/-/eslint-plugin-scanjs-rules-0.1.5.tgz#2055381b646cec989dd5b872203bae3321858219"
+eslint-plugin-scanjs-rules@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-scanjs-rules/-/eslint-plugin-scanjs-rules-0.2.1.tgz#a37403fde845df41277e03e5c2073f055d47942d"
   dependencies:
     babel-eslint ">=4.1.1"
     eslint ">=1.1"


### PR DESCRIPTION
Recent changes to `eslint-plugin-scanjs-rules` have gotten rid of a number of rules that aren't needed any more (like Mozilla phone stuff), and has some fixes for buggy rules, so this PR upgrades us to the latest version of the plugin.

In addition, instead of "manually" setting all the `eslint-plugin-scanjs-rules` from their default warning to error (as indicated in our Before You Ship guide), I changed our `.eslintrc.js` to loop through all the exported rules and do it dynamically.

Reminder: do the same upgrade in `federalist-builder`