### PR TITLE
Dynamically return robots.txt based on app_env and req.hostname

### DIFF
--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -43,7 +43,7 @@ module.exports = {
 
     // If this is the production instance and the request came to the production hostname
     if (config.app.app_env === 'production' &&
-      config.app.hostname === `${req.protocol}://${req.hostname}`) {
+      config.app.hostname === `https://${req.hostname}`) {
       // then send the production robots.txt content
       return res.send(PROD_CONTENT);
     }

--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -34,4 +34,21 @@ module.exports = {
 
     res.render('index.html', context);
   },
+
+  robots(req, res) {
+    const PROD_CONTENT = 'User-Agent: *\nDisallow: /preview\n';
+    const DENY_ALL_CONTENT = 'User-Agent: *\nDisallow: /\n';
+
+    res.set('Content-Type', 'text/plain');
+
+    // If this is the production instance and the request came to the production hostname
+    if (config.app.app_env === 'production' &&
+      config.app.hostname === `${req.protocol}://${req.hostname}`) {
+      // then send the production robots.txt content
+      return res.send(PROD_CONTENT);
+    }
+
+    // otherwise send the "deny all" robots.txt content
+    return res.send(DENY_ALL_CONTENT);
+  },
 };

--- a/api/routers/main.js
+++ b/api/routers/main.js
@@ -3,5 +3,6 @@ const MainController = require('../controllers/main');
 
 router.get('/', MainController.index);
 router.get('/sites(/*)?', MainController.index);
+router.get('/robots.txt', MainController.robots);
 
 module.exports = router;

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,9 @@ applications:
 - name: federalist
 buildpack: nodejs_buildpack
 stack: cflinuxfs2
-domain: fr.cloud.gov
+routes:
+- route: federalist.18f.gov
+- route: federalist.fr.cloud.gov
 disk_quota: 2G
 memory: 256MB
 instances: 5

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,0 @@
-# The robots.txt file is used to control how search engines index your live URLs.
-# See http://www.robotstxt.org/wc/norobots.html for more information.
-
-
-
-# To prevent search engines from seeing the site altogether, uncomment the next two lines:
-User-Agent: *
-Disallow: /preview

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -3,7 +3,9 @@ applications:
 - name: federalist-staging
 buildpack: nodejs_buildpack
 stack: cflinuxfs2
-domain: fr.cloud.gov
+routes:
+- route: federalist-staging.18f.gov
+- route: federalist-staging.fr.cloud.gov
 disk_quota: 2G
 memory: 256MB
 instances: 2

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
   rules: {
     'no-unused-expressions': [0], // because chai's expect is weird
 
-    /** ScanJS rule overrides from main .eslintrc **/
+    /* ScanJS rule overrides from main .eslintrc */
     'scanjs-rules/assign_to_search': 0,
+    'scanjs-rules/assign_to_hostname': 0,
   },
 };

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -167,7 +167,7 @@ describe('robots.txt', () => {
 
   it('denies robots when in production but non-production hostname', (done) => {
     config.app.app_env = 'production';
-    config.app.hostname = 'http://prod-url.com';
+    config.app.hostname = 'https://prod-url.com';
 
     request(app)
       .get('/robots.txt')
@@ -183,7 +183,7 @@ describe('robots.txt', () => {
 
   it('allows robots when in production and with production hostname', (done) => {
     config.app.app_env = 'production';
-    config.app.hostname = 'http://prod-url.com';
+    config.app.hostname = 'https://prod-url.com';
 
     request(app)
       .get('/robots.txt')

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -142,3 +142,58 @@ describe('Main Site', () => {
     });
   });
 });
+
+describe('robots.txt', () => {
+  const origAppConfig = Object.assign({}, config.app);
+
+  after(() => {
+    // reset config.app.app_env to its original value
+    config.app = origAppConfig;
+  });
+
+  it('denies robots when not in production', (done) => {
+    config.app.app_env = 'boop';
+
+    request(app)
+      .get('/robots.txt')
+      .expect(200)
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .then((response) => {
+        expect(response.text).to.equal('User-Agent: *\nDisallow: /\n');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('denies robots when in production but non-production hostname', (done) => {
+    config.app.app_env = 'production';
+    config.app.hostname = 'http://prod-url.com';
+
+    request(app)
+      .get('/robots.txt')
+      .set('host', 'non-prod-url.com')
+      .expect(200)
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .then((response) => {
+        expect(response.text).to.equal('User-Agent: *\nDisallow: /\n');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('allows robots when in production and with production hostname', (done) => {
+    config.app.app_env = 'production';
+    config.app.hostname = 'http://prod-url.com';
+
+    request(app)
+      .get('/robots.txt')
+      .set('host', 'prod-url.com')
+      .expect(200)
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .then((response) => {
+        expect(response.text).to.equal('User-Agent: *\nDisallow: /preview\n');
+        done();
+      })
+      .catch(done);
+  });
+});


### PR DESCRIPTION
This PR makes it so `robots.txt` with our production rules is only returned if `app_env == 'production' && request.hostname == 'federalist.18f.gov'`

Otherwise a `robots.txt` that denies all is returned.

Ref #1079 