### PR TITLE
Cleanup config/index.js

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,30 +1,40 @@
-const deepExtend = require("deep-extend")
-const fs = require("fs")
-const url = require("url")
+const deepExtend = require('deep-extend');
+const fs = require('fs');
+const path = require('path');
 
-const config = {}
+const config = {};
 
-fs.readdirSync(__dirname).forEach(filename => {
-  if (filename === "env" || filename === "index.js" || filename === "local.js" || filename.match(/.*\.sample\.js/)) {
-    return
-  } else {
-    const filepath = [__dirname, filename].join("/")
-    configName = filename.match(/^(.*).js/)[1]
-    config[configName] = require(filepath)
-  }
-})
-
-if (fs.existsSync([__dirname, "local.js"].join("/"))) {
-  deepExtend(config, require([__dirname, "local.js"].join("/")))
+function validConfigFile(filename) {
+  return (
+    path.extname(filename) === '.js' &&
+    filename !== 'index.js' &&
+    filename !== 'local.js' &&
+    !filename.match(/.*\.sample\.js/)
+  );
 }
 
-const environment = process.env.NODE_ENV
+fs.readdirSync(__dirname)
+  .filter(validConfigFile)
+  .forEach((filename) => {
+    const configName = path.basename(filename, '.js');
+    const filepath = path.join(__dirname, filename);
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    config[configName] = require(filepath);
+  });
+
+if (fs.existsSync([__dirname, 'local.js'].join('/'))) {
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  deepExtend(config, require([__dirname, 'local.js'].join('/')));
+}
+
+const environment = process.env.NODE_ENV;
 
 if (environment) {
-  const environmentFilepath = [__dirname, "env", environment + ".js"].join("/")
+  const environmentFilepath = path.join(__dirname, 'env', `${environment}.js`);
   if (fs.existsSync(environmentFilepath)) {
-    deepExtend(config, require(environmentFilepath))
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    deepExtend(config, require(environmentFilepath));
   }
 }
 
-module.exports = config
+module.exports = config;


### PR DESCRIPTION
I somehow got a `.DS_Store` file in my `config/` directory, which made it so I couldn't start my local version of Federalist at all. The problem was the `.forEach` iteration over files in the `config/` directory wasn't filtering out non-js files, so it prompted me to make a small change to do that.

I ended up doing slightly more refactoring to make the code cleaner:

- use `.filter` to filter out not-desired files from `readdirSync`'s result
- use node's `path` lib in place of `.join('/')`
- fix lint errors