### PR TITLE
add express-rate-limit for rate limiting

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -1,32 +1,30 @@
-const authorizer = require("../authorizers/user")
-const userSerializer = require("../serializers/user")
-const { User } = require("../models")
+const authorizer = require('../authorizers/user');
+const userSerializer = require('../serializers/user');
+const { User } = require('../models');
 
 module.exports = {
-  usernames: function(req, res) {
-    User.findAll().then(users => {
-      const usernames = users.map(user => ({
-        id: user.id,
-        username: user.username,
-      }))
-      res.json(usernames)
-    }).catch(err => {
-      res.error(err)
-    })
+  usernames(req, res) {
+    User.findAll()
+      .then((users) => {
+        const usernames = users.map(user => ({
+          id: user.id,
+          username: user.username,
+        }));
+        return res.json(usernames);
+      })
+      .catch(err => res.error(err));
   },
 
   me: (req, res) => {
-    let user
+    let user;
 
-    User.findById(req.user.id).then(model => {
-      user = model
-      return authorizer.me(req.user, user)
-    }).then(() => {
-      return userSerializer.serialize(user)
-    }).then(userJSON => {
-      res.json(userJSON)
-    }).catch(err => {
-      res.error(err)
-    })
-  }
+    User.findById(req.user.id)
+      .then((model) => {
+        user = model;
+        return authorizer.me(req.user, user);
+      })
+      .then(() => userSerializer.serialize(user))
+      .then(userJSON => res.json(userJSON))
+      .catch(err => res.error(err));
+  },
 };

--- a/api/routers/build-log.js
+++ b/api/routers/build-log.js
@@ -3,7 +3,7 @@ const BuildLogController = require('../controllers/build-log');
 const buildCallback = require('../policies/buildCallback');
 const sessionAuth = require('../policies/sessionAuth');
 
-router.get('/v0/build/:build_id/log', sessionAuth, BuildLogController.find);
-router.post('/v0/build/:build_id/log/:token', buildCallback, BuildLogController.create);
+router.get('/build/:build_id/log', sessionAuth, BuildLogController.find);
+router.post('/build/:build_id/log/:token', buildCallback, BuildLogController.create);
 
 module.exports = router;

--- a/api/routers/build.js
+++ b/api/routers/build.js
@@ -3,9 +3,9 @@ const BuildController = require('../controllers/build');
 const buildCallback = require('../policies/buildCallback');
 const sessionAuth = require('../policies/sessionAuth');
 
-router.get('/v0/site/:site_id/build', sessionAuth, BuildController.find);
-router.post('/v0/build', sessionAuth, BuildController.create);
-router.get('/v0/build/:id', sessionAuth, BuildController.findOne);
-router.post('/v0/build/:id/status/:token', buildCallback, BuildController.status);
+router.get('/site/:site_id/build', sessionAuth, BuildController.find);
+router.post('/build', sessionAuth, BuildController.create);
+router.get('/build/:id', sessionAuth, BuildController.findOne);
+router.post('/build/:id/status/:token', buildCallback, BuildController.status);
 
 module.exports = router;

--- a/api/routers/index.js
+++ b/api/routers/index.js
@@ -1,14 +1,21 @@
-const router = new require("express").Router()
+const express = require('express');
 
-router.use(require("./auth"))
-router.use(require("./build-log"))
-router.use(require("./build"))
-router.use(require("./main"))
-router.use(require("./preview"))
-router.use(require("./published-branch"))
-router.use(require("./published-file"))
-router.use(require("./site"))
-router.use(require("./user"))
-router.use(require("./webhook"))
+const mainRouter = express.Router();
 
-module.exports = router
+mainRouter.use(require('./auth'));
+mainRouter.use(require('./main'));
+mainRouter.use(require('./preview'));
+mainRouter.use(require('./webhook'));
+
+const apiRouter = express.Router();
+apiRouter.use(require('./build-log'));
+apiRouter.use(require('./build'));
+apiRouter.use(require('./published-branch'));
+apiRouter.use(require('./site'));
+apiRouter.use(require('./user'));
+apiRouter.use(require('./published-file'));
+
+// prefix all api routes with "/v0"
+mainRouter.use('/v0', apiRouter);
+
+module.exports = mainRouter;

--- a/api/routers/published-branch.js
+++ b/api/routers/published-branch.js
@@ -2,7 +2,7 @@ const router = require('express').Router();
 const PublishedBranchController = require('../controllers/published-branch');
 const sessionAuth = require('../policies/sessionAuth');
 
-router.get('/v0/site/:site_id/published-branch', sessionAuth, PublishedBranchController.find);
-router.get('/v0/site/:site_id/published-branch/:branch', sessionAuth, PublishedBranchController.findOne);
+router.get('/site/:site_id/published-branch', sessionAuth, PublishedBranchController.find);
+router.get('/site/:site_id/published-branch/:branch', sessionAuth, PublishedBranchController.findOne);
 
 module.exports = router;

--- a/api/routers/published-file.js
+++ b/api/routers/published-file.js
@@ -2,6 +2,6 @@ const router = require('express').Router();
 const PublishedFileController = require('../controllers/published-file');
 const sessionAuth = require('../policies/sessionAuth');
 
-router.get('/v0/site/:site_id/published-branch/:branch/published-file', sessionAuth, PublishedFileController.find);
+router.get('/site/:site_id/published-branch/:branch/published-file', sessionAuth, PublishedFileController.find);
 
 module.exports = router;

--- a/api/routers/site.js
+++ b/api/routers/site.js
@@ -2,10 +2,10 @@ const router = require('express').Router();
 const SiteController = require('../controllers/site');
 const sessionAuth = require('../policies/sessionAuth');
 
-router.get('/v0/site', sessionAuth, SiteController.find);
-router.post('/v0/site', sessionAuth, SiteController.create);
-router.get('/v0/site/:id', sessionAuth, SiteController.findOne);
-router.put('/v0/site/:id', sessionAuth, SiteController.update);
-router.delete('/v0/site/:id', sessionAuth, SiteController.destroy);
+router.get('/site', sessionAuth, SiteController.find);
+router.post('/site', sessionAuth, SiteController.create);
+router.get('/site/:id', sessionAuth, SiteController.findOne);
+router.put('/site/:id', sessionAuth, SiteController.update);
+router.delete('/site/:id', sessionAuth, SiteController.destroy);
 
 module.exports = router;

--- a/api/routers/user.js
+++ b/api/routers/user.js
@@ -1,8 +1,9 @@
 const router = require('express').Router();
+
 const UserController = require('../controllers/user');
 const sessionAuth = require('../policies/sessionAuth');
 
-router.get('/v0/usernames', sessionAuth, UserController.usernames);
-router.get('/v0/me', sessionAuth, UserController.me);
+router.get('/usernames', sessionAuth, UserController.usernames);
+router.get('/me', sessionAuth, UserController.me);
 
 module.exports = router;

--- a/app.js
+++ b/app.js
@@ -72,16 +72,8 @@ app.use(expressWinston.errorLogger({
   ],
 }));
 
-const limiter = new RateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute window
-  max: 50, // limit each IP to 50 requests per window
-  delayAfter: 25, // delay requests by delayMs after 25 are made in a window
-  delayMs: 500, // delay requests by 500 ms
-});
-
-if (config.app.app_env !== 'development') {
-  app.use(limiter); // must be set before router is added to app
-}
+const limiter = new RateLimit(config.rateLimiting);
+app.use(limiter); // must be set before router is added to app
 
 app.use(router);
 

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -1,1 +1,1 @@
-module.exports = {}
+module.exports = {};

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,10 +1,10 @@
-const env = require("../../services/environment")()
-const cfenv = require("cfenv")
+const env = require('../../services/environment')();
+const cfenv = require('cfenv');
 
-const appEnv = cfenv.getAppEnv()
+const appEnv = cfenv.getAppEnv();
 
 // Database Config
-const rdsCreds = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-rds`)
+const rdsCreds = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-rds`);
 if (rdsCreds) {
   module.exports.postgres = {
     database: rdsCreds.db_name,
@@ -12,36 +12,45 @@ if (rdsCreds) {
     user: rdsCreds.username,
     password: rdsCreds.password,
     port: rdsCreds.port,
-  }
+  };
 } else {
-  throw new Error("No database credentials found.")
+  throw new Error('No database credentials found.');
 }
 
 // S3 Configs
-const s3Creds = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-s3`)
+const s3Creds = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-s3`);
 if (s3Creds) {
   module.exports.s3 = {
     accessKeyId: s3Creds.access_key_id,
     secretAccessKey: s3Creds.secret_access_key,
     region: s3Creds.region,
     bucket: s3Creds.bucket,
-  }
+  };
 } else {
-  throw new Error("No S3 credentials found")
+  throw new Error('No S3 credentials found');
 }
 
 // SQS Configs
-const sqsKey = env.FEDERALIST_AWS_BUILD_KEY
-const sqsSecret = env.FEDERALIST_AWS_BUILD_SECRET
-const sqsQueue = env.FEDERALIST_SQS_QUEUE
-const sqsRegion = env.FEDERALIST_SQS_REGION
+const sqsKey = env.FEDERALIST_AWS_BUILD_KEY;
+const sqsSecret = env.FEDERALIST_AWS_BUILD_SECRET;
+const sqsQueue = env.FEDERALIST_SQS_QUEUE;
+const sqsRegion = env.FEDERALIST_SQS_REGION;
 if (sqsKey && sqsSecret && sqsQueue) {
   module.exports.sqs = {
     accessKeyId: sqsKey,
     secretAccessKey: sqsSecret,
     region: sqsRegion,
     queue: sqsQueue,
-  }
+  };
 } else {
-  throw new Error("Now SQS credentials found")
+  throw new Error('No SQS credentials found');
 }
+
+// See https://github.com/nfriedly/express-rate-limit/blob/master/README.md#configuration
+// for all express-rate-limit options available
+module.exports.rateLimiting = {
+  windowMs: 1 * 60 * 1000, // 1 minute window
+  max: 50, // limit each IP to 50 requests per window
+  delayAfter: 25, // delay requests by delayMs after 25 are made in a window
+  delayMs: 500, // delay requests by 500 ms
+};

--- a/config/rateLimiting.js
+++ b/config/rateLimiting.js
@@ -1,0 +1,10 @@
+/*
+ Options to pass to the RateLimit constructor
+ See https://github.com/nfriedly/express-rate-limit/blob/master/README.md#configuration
+ for all options available
+*/
+module.exports = {
+  max: 0,
+  delayAfter: 0,
+  delayMs: 0,
+};

--- a/config/session.js
+++ b/config/session.js
@@ -1,13 +1,13 @@
-const env = require("../services/environment")()
+const env = require('../services/environment')();
 
 module.exports = {
   cookie: {
     httpOnly: true,
     secure: false,
   },
-  key: "federalist.sid",
-  secret: env.FEDERALIST_SESSION_SECRET || "keyboard-cat",
+  key: 'federalist.sid',
+  secret: env.FEDERALIST_SESSION_SECRET || 'keyboard-cat',
   proxy: true,
   resave: true,
   saveUninitialized: true,
-}
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "deep-extend": "^0.4.1",
     "ejs": "^2.5.6",
     "express": "^4.14.1",
+    "express-rate-limit": "^2.9.0",
     "express-session": "^1.5.0",
     "express-winston": "^2.3.0",
     "github": "^0.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,6 +1905,12 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  dependencies:
+    clone "^1.0.2"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
@@ -2493,6 +2499,12 @@ expand-range@^1.8.1:
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
   dependencies:
     fill-range "^2.1.0"
+
+express-rate-limit@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-2.9.0.tgz#62c29fc939d72f0a03a87428c647fc4ee0d15978"
+  dependencies:
+    defaults "^1.0.3"
 
 express-session@^1.5.0:
   version "1.15.3"


### PR DESCRIPTION
ref #1092 

Adds simple rate limiting using [express-rate-limit](https://github.com/nfriedly/express-rate-limit) for all requests.

Also:
- refactor router into separate routers for improved understandability/readability:
  - `apiRouter` for all API routes, ie, those that start with `/v0`
  - `mainRouter` for all other routes
- fix linting errors on touched files

To Do:
- [x] ensure `req.ip` is different per user -- ie, that it is not the cloud.gov router IP
  - Update: `req.ip` is indeed the IP of the proxy, but we can use `app.enable('trust proxy')` to get the correct ip in `req.ip`
- [x] add `app.enable('trust proxy')`
- [x] figure out good parameters to use for the rate limiter
- [x] move rate limit options to config 