### PR TITLE
Use secure cookie when NODE_ENV is 'production'

### DIFF
--- a/config/session.js
+++ b/config/session.js
@@ -3,7 +3,7 @@ const env = require('../services/environment')();
 module.exports = {
   cookie: {
     httpOnly: true,
-    secure: false,
+    secure: process.env.NODE_ENV === 'production',
   },
   key: 'federalist.sid',
   secret: env.FEDERALIST_SESSION_SECRET || 'keyboard-cat',


### PR DESCRIPTION
Ref #1080 

From the [docs](https://github.com/expressjs/session#cookiesecure):
> Please note that secure: true is a recommended option. However, it requires an https-enabled website, i.e., HTTPS is necessary for secure cookies. If secure is set, and you access your site over HTTP, the cookie will not be set. If you have your node.js behind a proxy and are using secure: true, you need to set "trust proxy" in express:

As of https://github.com/18F/federalist/pull/1093 we are using `'trust proxy'` and all of our deployed instances use `HTTPS`, so we should be 👍 