### PR TITLE
Custom and demo domain validation messages

### DIFF
--- a/frontend/components/httpsUrlInput.js
+++ b/frontend/components/httpsUrlInput.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function onInvalidUrl(event) {
+  event.target.setCustomValidity('Please enter a URL that starts with "https://"');
+}
+
+function onUrlInput(event) {
+  event.target.setCustomValidity('');
+}
+
+const HttpsUrlInput = ({ placeholder, ...props }) => (
+  <input
+    {...props}
+    type="url"
+    pattern="https://.+"
+    placeholder={placeholder}
+    onInvalid={onInvalidUrl}
+    onInput={onUrlInput}
+  />
+);
+
+HttpsUrlInput.propTypes = {
+  placeholder: PropTypes.string,
+};
+
+HttpsUrlInput.defaultProps = {
+  placeholder: 'https://example.gov',
+};
+
+export default HttpsUrlInput;

--- a/frontend/components/site/siteGithubBranchesTable.js
+++ b/frontend/components/site/siteGithubBranchesTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+
 import LoadingIndicator from '../loadingIndicator';
+import { SITE, GITHUB_BRANCHES } from '../../propTypes';
 
 const tableHeader = () => (
   <thead>
@@ -47,7 +48,7 @@ const renderLoadingState = () => <LoadingIndicator />;
 
 const renderErrorState = () => (
   <p>
-    An error occured while downloading branch data from Github.
+    An error occurred while downloading branch data from Github.
     Often this is because the repo is private or has been deleted.
   </p>
 );
@@ -63,18 +64,8 @@ const SiteGithubBranchesTable = ({ site, branches }) => {
 
 
 SiteGithubBranchesTable.propTypes = {
-  site: PropTypes.shape({
-    defaultBranch: PropTypes.string.isRequired,
-    viewLink: PropTypes.string.isRequired,
-    demoViewLink: PropTypes.string,
-    owner: PropTypes.string.isRequired,
-    repository: PropTypes.string.isRequired,
-  }).isRequired,
-  branches: PropTypes.shape({
-    error: PropTypes.object,
-    isLoading: PropTypes.bool.isRequired,
-    data: PropTypes.array,
-  }).isRequired,
+  site: SITE.isRequired,
+  branches: GITHUB_BRANCHES.isRequired,
 };
 
 export default SiteGithubBranchesTable;

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -1,18 +1,30 @@
 /* global window:true */
-
-/* TODO: remove the below line and properly set PropType validation */
-/* eslint react/forbid-prop-types:0 react/require-default-props:0 */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
+import { SITE, GITHUB_BRANCHES } from '../../propTypes';
 import SiteGithubBranchesTable from './siteGithubBranchesTable';
 import SelectSiteEngine from '../selectSiteEngine';
 import githubBranchActions from '../../actions/githubBranchActions';
 import siteActions from '../../actions/siteActions';
 
-class SiteSettings extends React.Component {
+
+const propTypes = {
+  params: PropTypes.shape({
+    id: PropTypes.string,
+  }).isRequired,
+  site: SITE,
+  githubBranches: GITHUB_BRANCHES,
+};
+
+const defaultProps = {
+  site: null,
+  githubBranches: null,
+};
+
+
+export class SiteSettings extends React.Component {
   constructor(props) {
     super(props);
 
@@ -243,10 +255,7 @@ class SiteSettings extends React.Component {
   }
 }
 
-SiteSettings.propTypes = {
-  site: PropTypes.object,
-  params: PropTypes.object,
-  githubBranches: PropTypes.object,
-};
+SiteSettings.propTypes = propTypes;
+SiteSettings.defaultProps = defaultProps;
 
 export default SiteSettings;

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -2,13 +2,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
+import autoBind from 'react-autobind';
 
 import { SITE, GITHUB_BRANCHES } from '../../propTypes';
 import SiteGithubBranchesTable from './siteGithubBranchesTable';
 import SelectSiteEngine from '../selectSiteEngine';
+import HttpsUrlInput from '../httpsUrlInput';
 import githubBranchActions from '../../actions/githubBranchActions';
 import siteActions from '../../actions/siteActions';
-
 
 const propTypes = {
   params: PropTypes.shape({
@@ -42,9 +43,7 @@ export class SiteSettings extends React.Component {
       engine: site.engine,
     };
 
-    this.onSubmit = this.onSubmit.bind(this);
-    this.onDelete = this.onDelete.bind(this);
-    this.onChange = this.onChange.bind(this);
+    autoBind(this);
   }
 
   componentDidMount() {
@@ -125,12 +124,9 @@ export class SiteSettings extends React.Component {
                   See <a href="https://federalist-docs.18f.gov/pages/how-federalist-works/custom-urls/" target="_blank" rel="noopener noreferrer">
                   Federalist&apos;s custom URL documentation</a> for more information.
                 </p>
-                <input
+                <HttpsUrlInput
                   name="domain"
                   className="form-control"
-                  type="url"
-                  pattern="https://.+"
-                  placeholder="https://example.gov"
                   value={state.domain}
                   onChange={this.onChange}
                 />
@@ -157,15 +153,13 @@ export class SiteSettings extends React.Component {
                   onChange={this.onChange}
                 />
                 <label htmlFor="demoDomainInput">Demo domain:</label>
-                <input
+                <HttpsUrlInput
                   name="demoDomain"
                   className="form-control"
                   id="demoDomainInput"
-                  type="url"
-                  pattern="https://.+"
-                  placeholder="https://preview.example.com"
                   value={state.demoDomain}
                   onChange={this.onChange}
+                  placeholder="https://preview.example.com"
                 />
               </div>
             </div>

--- a/frontend/propTypes.js
+++ b/frontend/propTypes.js
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+
+export const SITE = PropTypes.shape({
+  demoBranch: PropTypes.string,
+  demoDomain: PropTypes.string,
+  config: PropTypes.string,
+  previewConfig: PropTypes.string,
+  demoConfig: PropTypes.string,
+  defaultBranch: PropTypes.string,
+  domain: PropTypes.string,
+  engine: PropTypes.string,
+});
+
+export const GITHUB_BRANCHES = PropTypes.shape({
+  error: PropTypes.object,
+  isLoading: PropTypes.bool.isRequired,
+  data: PropTypes.array,
+});

--- a/test/frontend/components/httpsUrlInput.test.js
+++ b/test/frontend/components/httpsUrlInput.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+import HttpsUrlInput from '../../../frontend/components/httpsUrlInput';
+
+describe('<HttpsUrlInput/>', () => {
+  it('renders', () => {
+    const wrapper = shallow(<HttpsUrlInput />);
+    const input = wrapper.find('input');
+    expect(input.length).to.equal(1);
+    expect(input.prop('type')).to.equal('url');
+    expect(input.prop('pattern')).to.equal('https://.+');
+    expect(input.prop('placeholder')).to.equal('https://example.gov');
+  });
+
+  it('uses props', () => {
+    const props = { className: 'boop', placeholder: 'https://boop.gov' };
+    const wrapper = shallow(<HttpsUrlInput {...props} />);
+    const input = wrapper.find('input');
+    expect(input.length).to.equal(1);
+    expect(input.prop('className')).to.equal('boop');
+    expect(input.prop('placeholder')).to.equal('https://boop.gov');
+  });
+
+  it('calls setCustomValidity with correct args', () => {
+    const wrapper = shallow(<HttpsUrlInput />);
+    const input = wrapper.find('input');
+
+    const onInvalidFunc = input.prop('onInvalid');
+    const setCustomValiditySpy = spy();
+    onInvalidFunc({ target: { setCustomValidity: setCustomValiditySpy } });
+    expect(setCustomValiditySpy.calledWith('Please enter a URL that starts with "https://"')).to.equal(true);
+
+    const onInputFunc = input.prop('onInput');
+    onInputFunc({ target: { setCustomValidity: setCustomValiditySpy } });
+    expect(setCustomValiditySpy.calledWith('')).to.equal(true);
+  });
+});

--- a/test/frontend/components/site/siteGithubBranchesTable.test.js
+++ b/test/frontend/components/site/siteGithubBranchesTable.test.js
@@ -3,101 +3,103 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import SiteGithubBranchesTable from '../../../../frontend/components/site/siteGithubBranchesTable';
 
-let site, branches, props;
+let site;
+let branches;
+let props;
 
-describe("<SiteGithubBranchesTable/>", () => {
+describe('<SiteGithubBranchesTable/>', () => {
   beforeEach(() => {
     site = {
-      owner: "owner-name",
-      repository: "repo-name",
-      defaultBranch: "default-ranch",
-      viewLink: "www.example.com/owner-name/repo-name",
+      owner: 'owner-name',
+      repository: 'repo-name',
+      defaultBranch: 'default-ranch',
+      viewLink: 'www.example.com/owner-name/repo-name',
     };
     branches = {
       isLoading: false,
       data: [
-        { name: "branch-name" },
-        { name: "default=branch" },
+        { name: 'branch-name' },
+        { name: 'default=branch' },
       ],
     };
-    props = { site, branches }
+    props = { site, branches };
   });
 
-  it("renders a table with a list of branches", () => {
+  it('renders a table with a list of branches', () => {
     props.branches.data = [
-      { name: "branch-a" },
-      { name: "branch-b" },
+      { name: 'branch-a' },
+      { name: 'branch-b' },
     ];
 
-    const wrapper = shallow(<SiteGithubBranchesTable {...props}/>);
-    const rows = wrapper.find("tbody").find("tr");
+    const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
+    const rows = wrapper.find('tbody').find('tr');
 
-    expect(rows).to.have.length(2)
-    expect(rows.at(0).contains("branch-a")).to.be.true;
-    expect(rows.at(1).contains("branch-b")).to.be.true;
+    expect(rows).to.have.length(2);
+    expect(rows.at(0).contains('branch-a')).to.be.true;
+    expect(rows.at(1).contains('branch-b')).to.be.true;
   });
 
-  it("renders the view URL for the default branch", () => {
+  it('renders the view URL for the default branch', () => {
     props.branches.data = [
-        { name: "master" },
-    ]
-    props.site ={
-      defaultBranch: "master",
-      viewLink: "www.example.com",
+        { name: 'master' },
+    ];
+    props.site = {
+      defaultBranch: 'master',
+      viewLink: 'www.example.com',
     };
 
-    const wrapper = shallow(<SiteGithubBranchesTable {...props}/>);
-    const link = wrapper.find("a");
+    const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
+    const link = wrapper.find('a');
 
-    expect(link.contains("View")).to.be.true;
-    expect(link.prop("href")).to.equal(props.site.viewLink);
+    expect(link.contains('View')).to.be.true;
+    expect(link.prop('href')).to.equal(props.site.viewLink);
   });
 
-  it("renders the view URL for demo branches", () => {
+  it('renders the view URL for demo branches', () => {
     props.branches.data = [
-      { name: "demo" },
-    ]
-    props.site ={
-      demoBranch: "demo",
-      demoViewLink: "demo.example.com",
+      { name: 'demo' },
+    ];
+    props.site = {
+      demoBranch: 'demo',
+      demoViewLink: 'demo.example.com',
     };
 
-    const wrapper = shallow(<SiteGithubBranchesTable {...props}/>);
-    const link = wrapper.find("a");
+    const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
+    const link = wrapper.find('a');
 
-    expect(link.contains("View")).to.be.true;
-    expect(link.prop("href")).to.equal(props.site.demoViewLink);
-  })
+    expect(link.contains('View')).to.be.true;
+    expect(link.prop('href')).to.equal(props.site.demoViewLink);
+  });
 
-  it("renders the the preview URL for preview branches", () => {
+  it('renders the the preview URL for preview branches', () => {
     props.branches.data = [
-      { name: "preview-branch" },
-    ]
-    props.site ={
-      owner: "owner-name",
-      repository: "repo-name",
-      defaultBranch: "master",
+      { name: 'preview-branch' },
+    ];
+    props.site = {
+      owner: 'owner-name',
+      repository: 'repo-name',
+      defaultBranch: 'master',
     };
-    const previewURL = "/preview/owner-name/repo-name/preview-branch/"
+    const previewURL = '/preview/owner-name/repo-name/preview-branch/';
 
-    const wrapper = shallow(<SiteGithubBranchesTable {...props}/>);
-    const link = wrapper.find("a");
+    const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
+    const link = wrapper.find('a');
 
-    expect(link.contains("View")).to.be.true;
-    expect(link.prop("href")).to.equal(previewURL);
+    expect(link.contains('View')).to.be.true;
+    expect(link.prop('href')).to.equal(previewURL);
   });
 
-  it("renders an error if a site has no branch data", () => {
-    props.branches.data = []
+  it('renders an error if a site has no branch data', () => {
+    props.branches.data = [];
 
-    const wrapper = shallow(<SiteGithubBranchesTable {...props}/>);
-    expect(wrapper.find("p").contains("An error occured while downloading branch data from Github. Often this is because the repo is private or has been deleted.")).to.be.true
+    const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
+    expect(wrapper.find('p').contains('An error occurred while downloading branch data from Github. Often this is because the repo is private or has been deleted.')).to.be.true;
   });
 
-  it("renders an error if the branches state contains an error", () => {
-    props.branches.error = new Error("I'm an error ⛔️")
+  it('renders an error if the branches state contains an error', () => {
+    props.branches.error = new Error("I'm an error ⛔️");
 
-    const wrapper = shallow(<SiteGithubBranchesTable {...props}/>);
-    expect(wrapper.find("p").contains("An error occured while downloading branch data from Github. Often this is because the repo is private or has been deleted.")).to.be.true
-  })
+    const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
+    expect(wrapper.find('p').contains('An error occurred while downloading branch data from Github. Often this is because the repo is private or has been deleted.')).to.be.true;
+  });
 });


### PR DESCRIPTION
- add new `<HttpsUrlInput>` component that sets a friendlier custom validity message when a non-https url is entered (ref #1055)
- remove TODO and implement proper propType checking in siteSettings.js
- add and use new propTypes.js for defining reusable PropType constants
- fix spelling error in siteGithubBranchesTable and amend/lint associated test

To Do: 
- [x] actually fix the validation message