### PR TITLE
Switch to cc-test-reporter to enable PR coverage statuses

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,9 @@
+{
+  "reporter": [
+    "lcov"
+  ],
+  "extension": [
+    ".jsx"
+  ],
+  "cache": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ install:
   - yarn --pure-lockfile
 before_script:
   - "psql -c 'create database travis_ci_test;' -U postgres"
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
 script:
   - scripts/lint-travis.sh
   - yarn test
 after_success:
-  - npm install -g codeclimate-test-reporter
-  - yarn coverage # converts to lcov format
-  - codeclimate-test-reporter < ./coverage/lcov.info
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT ./coverage/lcov.info
 env:
   global:
   - CF_API="https://api.fr.cloud.gov"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "test:client:watch": "watch 'yarn test:client' ./frontend ./test/frontend",
     "lint": "eslint ./api/**/*.js ./config/**/*.js ./frontend/**/*.js ./migration/**/*.js ./script/**/*.js ./services/**/*.js",
     "lint:diff": "./scripts/lint-diff.sh",
-    "coverage": "nyc report --reporter=lcov",
     "migrate:create": "node migrate.js create",
     "migrate:up": "node migrate.js up || true",
     "migrate:down": "node migrate.js down",


### PR DESCRIPTION
use cc-test-reporter and add nyc config file

- cc-test-reporter will enable PR test coverage status reports from Code Climate
- don't output test summary table (it's kind of annoying and too much info)
- make sure to include .jsx files in coverage
- enable nyc cache
- remove unnecessary `coverage` task from `package.json`

To Do:

- [x] extract the `.nycrc` stuff from #1102 since that PR seems to be getting bigger. ~wait on #1102 to be merged since it adds an `.nycrc` file~
- [x] remove the `coverage` task in `package.json` and the call to it in `.travis.yml` because it won't be needed after that merge
- [x] clean up this PR's commit history to just include the changes that made it work
- [ ] After merge: remove `CODECLIMATE_REPO_TOKEN` from https://travis-ci.org/18F/federalist/settings since it is superseded by `CC_TEST_REPORTER_ID`
- ~figure out how to combine back end and front end coverage reports~ Going to punt on this and instead open a new issue for it since I can't figure out any way to do it currently: #1116 