### PR TITLE
Create BranchViewLink component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,11 +25,20 @@ try {
   const scanjsConfig = require('eslint-plugin-scanjs-rules');
   scanjsRulesConfig = {};
 
-  // bring in all the scanjs rules, prefixed with 'scanjs-rules',
+  // ScanJS rules we don't want to use:
+  const ignoredScanjsRules = [
+    // scanjs is looking for a different `connect` than the one we use often from react-redux
+    'call_connect',
+  ];
+
+  // bring in all the scanjs rules (other than those we want ignored),
+  // prefixed with 'scanjs-rules',
   // but convert them to eslint errors instead of warnings
-  Object.keys(scanjsConfig.rulesConfig).forEach((rule) => {
-    scanjsRulesConfig[`scanjs-rules/${rule}`] = 1;
-  });
+  Object.keys(scanjsConfig.rulesConfig)
+    .filter(rule => ignoredScanjsRules.indexOf(rule) === -1)
+    .forEach((rule) => {
+      scanjsRulesConfig[`scanjs-rules/${rule}`] = 1;
+    });
 } catch (err) {
   // eslint-disable-next-line no-console
   console.log('eslint-plugin-scanjs-rules not found, will not include scanjs rules');

--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -21,11 +21,17 @@ module.exports = {
 
     const siteDisplayEnv = config.app.app_env !== 'production' ? config.app.app_env : null;
 
+    const frontendConfig = {
+      TEMPLATES: config.templates,
+      PREVIEW_HOSTNAME: config.app.preview_hostname,
+    };
+
     const context = {
       siteWideError: null,
       jsBundleName: webpackAssets['main.js'],
       cssBundleName: webpackAssets['main.css'],
       siteDisplayEnv,
+      frontendConfig,
     };
 
     if (req.session.authenticated) {

--- a/api/controllers/preview.js
+++ b/api/controllers/preview.js
@@ -1,10 +1,9 @@
-const logger = require("winston")
-const url = require("url")
-const config = require("../../config")
+const url = require('url');
+const config = require('../../config');
 
 module.exports = {
-  redirect: function(req, res) {
-    const target = url.resolve(config.app.preview_hostname, req.path)
-    res.redirect(target)
-  }
-}
+  redirect(req, res) {
+    const target = url.resolve(config.app.preview_hostname, req.path);
+    res.redirect(target);
+  },
+};

--- a/api/routers/preview.js
+++ b/api/routers/preview.js
@@ -1,7 +1,13 @@
-const router = require("express").Router()
-const PreviewController = require("../controllers/preview")
+const router = require('express').Router();
+const PreviewController = require('../controllers/preview');
 
-router.get("/preview/:owner/:repo/:branch", PreviewController.redirect)
-router.get("/preview/:owner/:repo/:branch/*", PreviewController.redirect)
+// These /preview/ routes provide redirects to the proxy app
+// (configured as config.app.preview_hostname).
+// They are used to not break existing links from when
+// Federalist site previews were handled in this application instead
+// of by federalist-proxy.
 
-module.exports = router
+router.get('/preview/:owner/:repo/:branch', PreviewController.redirect);
+router.get('/preview/:owner/:repo/:branch/*', PreviewController.redirect);
+
+module.exports = router;

--- a/api/serializers/published-branch.js
+++ b/api/serializers/published-branch.js
@@ -1,19 +1,15 @@
+const serializeObject = (site, name) => ({
+  name,
+  site: site.toJSON(),
+});
+
 const serialize = (site, branch) => {
   if (branch instanceof Array) {
-    const array = branch.map(name => serializeObject(site, name))
-    return Promise.resolve(array)
-  } else {
-    const object = serializeObject(site, branch)
-    return Promise.resolve(object)
+    const array = branch.map(name => serializeObject(site, name));
+    return Promise.resolve(array);
   }
-}
+  const object = serializeObject(site, branch);
+  return Promise.resolve(object);
+};
 
-const serializeObject = (site, name) => {
-  return {
-    name,
-    site: site.toJSON(),
-    viewLink: site.viewLinkForBranch(name),
-  }
-}
-
-module.exports = { serialize }
+module.exports = { serialize };

--- a/frontend/components/AddSite/TemplateSiteList/index.js
+++ b/frontend/components/AddSite/TemplateSiteList/index.js
@@ -1,10 +1,13 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import TemplateSite from './templateSite';
 
 const propTypes = {
-  templates: React.PropTypes.object.isRequired,
-  handleSubmitTemplate: React.PropTypes.func.isRequired
+  templates: PropTypes.object.isRequired,
+  handleSubmitTemplate: PropTypes.func.isRequired,
+  defaultOwner: PropTypes.string.isRequired,
 };
 
 const MAX_CELLS_PER_ROW = 3;
@@ -30,13 +33,13 @@ const createRowsOf = (values, perRow) => {
   return rows;
 };
 
-class TemplateList extends React.Component {
+export class TemplateList extends React.Component {
 
   constructor(props) {
     super(props);
 
     this.state = {
-      activeChildId: -1
+      activeChildId: -1,
     };
 
     this.handleChooseActive = this.handleChooseActive.bind(this);
@@ -44,7 +47,7 @@ class TemplateList extends React.Component {
 
   handleChooseActive(childId) {
     this.setState({
-      activeChildId: childId
+      activeChildId: childId,
     });
   }
 
@@ -62,30 +65,30 @@ class TemplateList extends React.Component {
 
     let index = 0;
 
-    const templateGrid = templateRows.map((row, rowIndex) => {
-      return (
-        <div className="usa-grid" key={rowIndex}>
-          {row.map((templateName, cellIndex) => {
-            const template = templates[templateName];
-            return (
-              <div
-                  className={`usa-width-one-${cellSize}`}
-                  key={cellIndex}>
-                <TemplateSite
-                  name={templateName}
-                  index={index++}
-                  thumb={template.thumb}
-                  active={this.state.activeChildId}
-                  handleChooseActive={this.handleChooseActive}
-                  handleSubmit={this.props.handleSubmitTemplate}
-                  defaultOwner={this.props.defaultOwner}
-                  {...template} />
-              </div>
-            );
-          })}
-        </div>
-      );
-    });
+    const templateGrid = templateRows.map(row => (
+      <div className="usa-grid" key={row}>
+        {row.map((templateName) => {
+          const template = templates[templateName];
+          return (
+            <div
+              className={`usa-width-one-${cellSize}`}
+              key={templateName}
+            >
+              <TemplateSite
+                name={templateName}
+                index={index++} // eslint-disable-line no-plusplus
+                thumb={template.thumb}
+                active={this.state.activeChildId}
+                handleChooseActive={this.handleChooseActive}
+                handleSubmit={this.props.handleSubmitTemplate}
+                defaultOwner={this.props.defaultOwner}
+                {...template}
+              />
+            </div>
+          );
+        })}
+      </div>
+    ));
 
     return (
       <div>
@@ -102,4 +105,8 @@ class TemplateList extends React.Component {
 
 TemplateList.propTypes = propTypes;
 
-export default TemplateList;
+const mapStateToProps = state => ({
+  templates: state.FRONTEND_CONFIG.TEMPLATES,
+});
+
+export default connect(mapStateToProps)(TemplateList);

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -8,8 +8,6 @@ import SelectSiteEngine from '../selectSiteEngine';
 
 import siteActions from '../../actions/siteActions';
 
-import templates from '../../../config/templates';
-
 const propTypes = {
   storeState: PropTypes.shape({
     user: PropTypes.shape({
@@ -83,7 +81,6 @@ class AddSite extends React.Component {
           </div>
         </div>
         <TemplateSiteList
-          templates={templates}
           handleSubmitTemplate={this.onSubmitTemplate}
           defaultOwner={this.defaultOwner()}
         />

--- a/frontend/components/branchViewLink.js
+++ b/frontend/components/branchViewLink.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { SITE } from '../propTypes';
+
+const isDefaultBranch = (branchName, site) => branchName === site.defaultBranch;
+
+const isDemoBranch = (branchName, site) => branchName === site.demoBranch;
+
+// we only want to link branch names that are alphanumeric plus _ and -
+const isLinkable = s => /^[a-zA-Z0-9_-]+$/.test(s);
+
+const getUrlAndViewText = (branchName, site, previewHostname) => {
+  if (isDefaultBranch(branchName, site)) {
+    return { url: site.viewLink, viewText: 'View site' };
+  } else if (isDemoBranch(branchName, site)) {
+    return { url: site.demoViewLink, viewText: 'View demo' };
+  }
+  return {
+    url: `${previewHostname}/preview/${site.owner}/${site.repository}/${branchName}/`,
+    viewText: 'View preview',
+  };
+};
+
+export const BranchViewLink = ({ branchName, site, previewHostname }) => {
+  if (!isLinkable(branchName)) {
+    return <span>Unlinkable branch name</span>;
+  }
+
+  const { url, viewText } = getUrlAndViewText(branchName, site, previewHostname);
+
+  return (<a href={url} target="_blank" rel="noopener noreferrer">{ viewText }</a>);
+};
+
+BranchViewLink.propTypes = {
+  branchName: PropTypes.string.isRequired,
+  site: SITE.isRequired,
+  previewHostname: PropTypes.string.isRequired,
+};
+
+
+const mapStateToProps = state => ({
+  previewHostname: state.FRONTEND_CONFIG.PREVIEW_HOSTNAME,
+});
+
+export default connect(mapStateToProps)(BranchViewLink);

--- a/frontend/components/disclaimer.js
+++ b/frontend/components/disclaimer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const flagUrl = require('uswds/dist/img/us_flag_small.png');
+import flagUrl from 'uswds/dist/img/us_flag_small.png';
 
 const Disclaimer = () =>
   <div className="usa-disclaimer">

--- a/frontend/components/site/siteGithubBranchesTable.js
+++ b/frontend/components/site/siteGithubBranchesTable.js
@@ -1,46 +1,31 @@
 import React from 'react';
 
 import LoadingIndicator from '../loadingIndicator';
+import BranchViewLink from '../branchViewLink';
 import { SITE, GITHUB_BRANCHES } from '../../propTypes';
-
-const tableHeader = () => (
-  <thead>
-    <tr>
-      <th>Branch</th>
-      <th />
-    </tr>
-  </thead>
-);
-
-const previewURL = (branch, site) => {
-  if (branch.name === site.defaultBranch) {
-    return site.viewLink;
-  } else if (branch.name === site.demoBranch) {
-    return site.demoViewLink;
-  }
-  return `/preview/${site.owner}/${site.repository}/${branch.name}/`;
-};
 
 const branchRow = (branch, site) => (
   <tr key={branch.name}>
-    <td>{branch.name}</td>
     <td>
-      <a href={previewURL(branch, site)} target="_blank" rel="noopener noreferrer">View</a>
+      <p>{branch.name}</p>
+    </td>
+    <td>
+      <BranchViewLink site={site} branchName={branch.name} />
     </td>
   </tr>
 );
 
-const tableBody = (site, branches) => (
-  <tbody>
-    {branches.data.map(branch => branchRow(branch, site))}
-  </tbody>
-);
-
-
 const renderTable = (site, branches) => (
   <table className="usa-table-borderless">
-    {tableHeader()}
-    {tableBody(site, branches)}
+    <thead>
+      <tr>
+        <th>Branch</th>
+        <th />
+      </tr>
+    </thead>
+    <tbody>
+      {branches.data.map(branch => branchRow(branch, site))}
+    </tbody>
   </table>
 );
 

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import publishedBranchActions from '../../actions/publishedBranchActions';
 import LoadingIndicator from '../loadingIndicator';
+import BranchViewLink from '../branchViewLink';
+import { SITE } from '../../propTypes';
 
 class SitePublishedBranchesTable extends React.Component {
   componentDidMount() {
@@ -36,22 +38,24 @@ class SitePublishedBranchesTable extends React.Component {
   renderPublishedBranchRow(branch) {
     return (
       <tr key={branch.name}>
-        <td>{ branch.name }</td>
+        <td>{branch.name}</td>
         <td>
-          { this.renderBranchViewLink(branch) }<br />
-          { this.renderBranchFilesLink(branch) }
+          <ul className="usa-unstyled-list">
+            <li>
+              <BranchViewLink branchName={branch.name} site={this.props.site} />
+            </li>
+            <li>
+              {this.renderBranchFilesLink(branch)}
+            </li>
+          </ul>
         </td>
       </tr>
     );
   }
 
-  renderBranchViewLink(branch) {
-    return <a href={branch.viewLink} target="_blank" rel="noopener noreferrer">View</a>;
-  }
-
   renderBranchFilesLink(branch) {
     const href = `/sites/${branch.site.id}/published/${branch.name}`;
-    return <Link to={href}>Files</Link>;
+    return <Link to={href}>View Files</Link>;
   }
 
   renderLoadingState() {
@@ -84,10 +88,12 @@ SitePublishedBranchesTable.propTypes = {
     isLoading: PropTypes.bool.isRequired,
     data: PropTypes.array,
   }),
+  site: SITE,
 };
 
 SitePublishedBranchesTable.defaultProps = {
   publishedBranches: null,
+  site: null,
 };
 
 export default SitePublishedBranchesTable;

--- a/frontend/reducers.js
+++ b/frontend/reducers.js
@@ -19,4 +19,5 @@ export default {
   user,
   githubBranches,
   notifications,
+  FRONTEND_CONFIG: (state = {}) => state,
 };

--- a/frontend/store.js
+++ b/frontend/store.js
@@ -1,3 +1,4 @@
+/* global window */
 import { combineReducers, createStore, applyMiddleware } from 'redux';
 import { createLogger } from 'redux-logger';
 import { composeWithDevTools } from 'redux-devtools-extension';
@@ -18,8 +19,16 @@ const middlewares = [
   createLogger(), // must be last in the middlewares chain
 ];
 
+// FRONTEND_CONFIG is a global variable rendered into the index.html
+// template by the Main controller. We use it to initialize our
+// store's state with configuration values from the server-side.
+const FRONTEND_CONFIG = typeof window !== 'undefined'
+  ? window.FRONTEND_CONFIG
+  : global.FRONTEND_CONFIG;
+
 const store = createStore(
   reducer,
+  { FRONTEND_CONFIG },
   composeWithDevTools(applyMiddleware(...middlewares))
 );
 

--- a/public/swagger/PublishedBranch.json
+++ b/public/swagger/PublishedBranch.json
@@ -2,8 +2,7 @@
   "type": "object",
   "required": [
     "name",
-    "site",
-    "viewLink"
+    "site"
   ],
   "properties": {
     "name": {
@@ -11,9 +10,6 @@
     },
     "site": {
       "type": "object"
-    },
-    "viewLink": {
-      "type": "string"
     }
   }
 }

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -6,7 +6,6 @@
     "engine",
     "owner",
     "repository",
-    "siteRoot",
     "viewLink"
   ],
   "properties": {
@@ -49,9 +48,6 @@
       "format": "date-time"
     },
     "repository": {
-      "type": "string"
-    },
-    "siteRoot": {
       "type": "string"
     },
     "viewLink": {

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -39,6 +39,18 @@ describe('Main Site', () => {
       .catch(done);
     });
 
+    it('should contain front end config values', (done) => {
+      request(app)
+        .get('/')
+        .then((response) => {
+          expect(response.text.search('FRONTEND_CONFIG')).to.be.above(-1);
+          expect(response.text.search('PREVIEW_HOSTNAME')).to.be.above(-1);
+          expect(response.text.search('TEMPLATES')).to.be.above(-1);
+          done();
+        })
+        .catch(done);
+    });
+
     context('<title> element', () => {
       const origAppEnv = config.app.app_env;
 

--- a/test/api/requests/published-branch.test.js
+++ b/test/api/requests/published-branch.test.js
@@ -1,39 +1,37 @@
-const AWSMocks = require("../support/aws-mocks")
-const expect = require("chai").expect
-const request = require("supertest")
-const app = require("../../../app")
-const config = require("../../../config")
-const factory = require("../support/factory")
-const session = require("../support/session")
-const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
+const AWSMocks = require('../support/aws-mocks');
+const expect = require('chai').expect;
+const request = require('supertest');
+const app = require('../../../app');
+const config = require('../../../config');
+const factory = require('../support/factory');
+const session = require('../support/session');
+const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
 
-describe("Published Branches API", () => {
+describe('Published Branches API', () => {
   after(() => {
-    AWSMocks.resetMocks()
-  })
+    AWSMocks.resetMocks();
+  });
 
-  describe("GET /v0/site/:site_id/published-branch", () => {
-    it("should require authentication", done => {
-      factory.site().then(site => {
-        return request(app)
+  describe('GET /v0/site/:site_id/published-branch', () => {
+    it('should require authentication', (done) => {
+      factory.site().then(site => request(app)
           .get(`/v0/site/${site.id}/published-branch`)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch", 403, response.body)
-        done()
-      }).catch(done)
-    })
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch', 403, response.body);
+            done();
+          }).catch(done);
+    });
 
-    it("should list the previews available on S3 for a user's site", done => {
-      let site
-      const userPromise = factory.user()
-      const sitePromise = factory.site({ users: Promise.all([userPromise]) })
-      const cookiePromise = session(userPromise)
+    it("should list the previews available on S3 for a user's site", (done) => {
+      let site;
+      const userPromise = factory.user();
+      const sitePromise = factory.site({ users: Promise.all([userPromise]) });
+      const cookiePromise = session(userPromise);
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
-        expect(params.Bucket).to.equal(config.s3.bucket)
-        expect(params.Prefix).to.equal(`preview/${site.owner}/${site.repository}/`)
-        expect(params.Delimiter).to.equal("/")
+        expect(params.Bucket).to.equal(config.s3.bucket);
+        expect(params.Prefix).to.equal(`preview/${site.owner}/${site.repository}/`);
+        expect(params.Delimiter).to.equal('/');
         callback(null, {
           Contents: [],
           CommonPrefixes: [
@@ -41,144 +39,137 @@ describe("Published Branches API", () => {
             { Prefix: `preview/${site.owner}/${site.repository}/def/` },
             { Prefix: `preview/${site.owner}/${site.repository}/ghi/` },
           ],
-        })
-      }
+        });
+      };
 
       Promise.props({
         user: userPromise,
         site: sitePromise,
         cookie: cookiePromise,
-      }).then(promisedValues => {
-        site = promisedValues.site
+      }).then((promisedValues) => {
+        site = promisedValues.site;
 
         return request(app)
           .get(`/v0/site/${site.id}/published-branch`)
-          .set("Cookie", promisedValues.cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch", 200, response.body)
-        const branchNames = response.body.map(branch => branch.name)
-        expect(branchNames).to.have.length(4)
-        expect(branchNames).to.include(site.defaultBranch)
-        expect(branchNames).to.include("abc")
-        expect(branchNames).to.include("def")
-        expect(branchNames).to.include("ghi")
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', promisedValues.cookie)
+          .expect(200);
+      }).then((response) => {
+        validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch', 200, response.body);
+        const branchNames = response.body.map(branch => branch.name);
+        expect(branchNames).to.have.length(4);
+        expect(branchNames).to.include(site.defaultBranch);
+        expect(branchNames).to.include('abc');
+        expect(branchNames).to.include('def');
+        expect(branchNames).to.include('ghi');
+        done();
+      }).catch(done);
+    });
 
-    it("should list the demo branch if one is set on the site", done => {
-      let site
-      const userPromise = factory.user()
+    it('should list the demo branch if one is set on the site', (done) => {
+      let site;
+      const userPromise = factory.user();
       const sitePromise = factory.site({
         users: Promise.all([userPromise]),
-        demoBranch: "demo"
-      })
-      const cookiePromise = session(userPromise)
+        demoBranch: 'demo',
+      });
+      const cookiePromise = session(userPromise);
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
-        expect(params.Bucket).to.equal(config.s3.bucket)
-        expect(params.Prefix).to.equal(`preview/${site.owner}/${site.repository}/`)
-        expect(params.Delimiter).to.equal("/")
+        expect(params.Bucket).to.equal(config.s3.bucket);
+        expect(params.Prefix).to.equal(`preview/${site.owner}/${site.repository}/`);
+        expect(params.Delimiter).to.equal('/');
         callback(null, {
           Contents: [],
           CommonPrefixes: [
             { Prefix: `preview/${site.owner}/${site.repository}/abc/` },
           ],
-        })
-      }
+        });
+      };
 
       Promise.props({
         user: userPromise,
         site: sitePromise,
         cookie: cookiePromise,
-      }).then(promisedValues => {
-        site = promisedValues.site
+      }).then((promisedValues) => {
+        site = promisedValues.site;
 
         return request(app)
           .get(`/v0/site/${site.id}/published-branch`)
-          .set("Cookie", promisedValues.cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch", 200, response.body)
-        const branchNames = response.body.map(branch => branch.name)
-        expect(branchNames).to.deep.equal([ site.defaultBranch, site.demoBranch, "abc" ])
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', promisedValues.cookie)
+          .expect(200);
+      }).then((response) => {
+        validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch', 200, response.body);
+        const branchNames = response.body.map(branch => branch.name);
+        expect(branchNames).to.deep.equal([site.defaultBranch, site.demoBranch, 'abc']);
+        done();
+      }).catch(done);
+    });
 
-    it("should 403 if the user is not associated with the site", done => {
-      const user = factory.user()
-      const site = factory.site()
-      const cookie = session(user)
+    it('should 403 if the user is not associated with the site', (done) => {
+      const user = factory.user();
+      const site = factory.site();
+      const cookie = session(user);
 
-      Promise.props({ user, site, cookie }).then(promisedValues => {
-        return request(app)
+      Promise.props({ user, site, cookie }).then(promisedValues => request(app)
           .get(`/v0/site/${promisedValues.site.id}/published-branch`)
-          .set("Cookie", promisedValues.cookie)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch", 403, response.body)
-        done()
-      }).catch(done)
-    })
-  })
+          .set('Cookie', promisedValues.cookie)
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch', 403, response.body);
+            done();
+          }).catch(done);
+    });
+  });
 
-  describe("GET /v0/site/:site_id/published-branch/:branch", () => {
-    it("should require authentication", done => {
-      factory.site().then(site => {
-        return request(app)
+  describe('GET /v0/site/:site_id/published-branch/:branch', () => {
+    it('should require authentication', (done) => {
+      factory.site().then(site => request(app)
           .get(`/v0/site/${site.id}/published-branch/${site.defaultBranch}`)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch/{branch}", 403, response.body)
-        done()
-      }).catch(done)
-    })
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch/{branch}', 403, response.body);
+            done();
+          }).catch(done);
+    });
 
-    it("should render a JSON response for a pubslished branch", done => {
-      let site
-      const userPromise = factory.user()
+    it('should render a JSON response for a pubslished branch', (done) => {
+      let site;
+      const userPromise = factory.user();
       const sitePromise = factory.site({
-        defaultBranch: "master",
+        defaultBranch: 'master',
         users: Promise.all([userPromise]),
-      })
-      const cookiePromise = session(userPromise)
+      });
+      const cookiePromise = session(userPromise);
 
       Promise.props({
         user: userPromise,
         site: sitePromise,
         cookie: cookiePromise,
-      }).then(promisedValues => {
-        site = promisedValues.site
+      }).then((promisedValues) => {
+        site = promisedValues.site;
 
         return request(app)
           .get(`/v0/site/${site.id}/published-branch/master`)
-          .set("Cookie", promisedValues.cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch/{branch}", 200, response.body)
-        expect(response.body.site.id).to.equal(site.id)
-        expect(response.body.name).to.equal("master")
-        expect(response.body.viewLink).to.be.a("string")
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', promisedValues.cookie)
+          .expect(200);
+      }).then((response) => {
+        validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch/{branch}', 200, response.body);
+        expect(response.body.site.id).to.equal(site.id);
+        expect(response.body.name).to.equal('master');
+        done();
+      }).catch(done);
+    });
 
-    it("should 403 if the user is not associated with the site", done => {
-      const user = factory.user()
-      const site = factory.site({ defaultBranch: "master" })
-      const cookie = session(user)
+    it('should 403 if the user is not associated with the site', (done) => {
+      const user = factory.user();
+      const site = factory.site({ defaultBranch: 'master' });
+      const cookie = session(user);
 
-      Promise.props({ user, site, cookie }).then(promisedValues => {
-        return request(app)
+      Promise.props({ user, site, cookie }).then(promisedValues => request(app)
           .get(`/v0/site/${promisedValues.site.id}/published-branch/master`)
-          .set("Cookie", promisedValues.cookie)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch/{branch}", 403, response.body)
-        done()
-      }).catch(done)
-    })
-  })
-})
+          .set('Cookie', promisedValues.cookie)
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch/{branch}', 403, response.body);
+            done();
+          }).catch(done);
+    });
+  });
+});

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -19,7 +19,6 @@ describe('Site API', () => {
     expect(response.repository).to.equal(site.repository);
     expect(response.engine).to.equal(site.engine);
     expect(response.defaultBranch).to.equal(site.defaultBranch);
-    expect(response.siteRoot).to.be.a('string');
     expect(response.viewLink).to.be.a('string');
   };
 

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -18,13 +18,11 @@ describe('Site model', () => {
   });
 
   describe('.viewLinkForBranch(branch)', () => {
-    const s3BaseURL = `http://${config.s3.bucket}.s3-website-${config.s3.region}.amazonaws.com`;
-
     context('for the default branch', () => {
-      it('should return an S3 site link if there is no custom domain', (done) => {
+      it('should return a proxy link if there is no custom domain', (done) => {
         factory.site({ defaultBranch: 'default-branch' }).then((site) => {
           const viewLink = site.viewLinkForBranch('default-branch');
-          expect(viewLink).to.equal(`${s3BaseURL}/site/${site.owner}/${site.repository}`);
+          expect(viewLink).to.equal(`${config.app.preview_hostname}/site/${site.owner}/${site.repository}/`);
           done();
         }).catch(done);
       });
@@ -42,10 +40,10 @@ describe('Site model', () => {
     });
 
     context('for the demo branch', () => {
-      it('should return an s3 demo link if there is no demo domain', (done) => {
+      it('should return a proxy demo link if there is no demo domain', (done) => {
         factory.site({ demoBranch: 'demo-branch' }).then((site) => {
           const viewLink = site.viewLinkForBranch('demo-branch');
-          expect(viewLink).to.equal(`${s3BaseURL}/demo/${site.owner}/${site.repository}`);
+          expect(viewLink).to.equal(`${config.app.preview_hostname}/demo/${site.owner}/${site.repository}/`);
           done();
         }).catch(done);
       });
@@ -66,7 +64,7 @@ describe('Site model', () => {
       it('should return a federalist preview link', (done) => {
         factory.site().then((site) => {
           const viewLink = site.viewLinkForBranch('preview-branch');
-          expect(viewLink).to.equal(`http://localhost:1338/preview/${site.owner}/${site.repository}/preview-branch`);
+          expect(viewLink).to.equal(`${config.app.preview_hostname}/preview/${site.owner}/${site.repository}/preview-branch/`);
           done();
         }).catch(done);
       });

--- a/test/api/unit/serializers/published-branch.test.js
+++ b/test/api/unit/serializers/published-branch.test.js
@@ -1,54 +1,48 @@
-const expect = require("chai").expect
-const validateJSONSchema = require('jsonschema').validate
+const expect = require('chai').expect;
+const validateJSONSchema = require('jsonschema').validate;
 
-const PublishedBranchSchema = require("../../../../public/swagger/PublishedBranch.json")
-const factory = require("../../support/factory")
+const PublishedBranchSchema = require('../../../../public/swagger/PublishedBranch.json');
+const factory = require('../../support/factory');
 
-const PublishedBranchSerializer = require("../../../../api/serializers/published-branch")
+const PublishedBranchSerializer = require('../../../../api/serializers/published-branch');
 
-describe("PublishedBranchesSerializer", () => {
-  describe(".serialize(site, branch, files)", () => {
-    it("should serialize a site with a list of published branches correctly", done => {
-      let site
+describe('PublishedBranchesSerializer', () => {
+  describe('.serialize(site, branch, files)', () => {
+    it('should serialize a site with a list of published branches correctly', (done) => {
+      let site;
 
-      factory.site({ defaultBranch: "default" }).then(model => {
-        site = model
-        return PublishedBranchSerializer.serialize(site, ["default", "preview"])
-      }).then(object => {
-        const defaultViewLink = site.viewLinkForBranch("default")
-        const previewViewLink = site.viewLinkForBranch("preview")
+      factory.site({ defaultBranch: 'default' }).then((model) => {
+        site = model;
+        return PublishedBranchSerializer.serialize(site, ['default', 'preview']);
+      }).then((object) => {
         const result = validateJSONSchema(object, {
-          type: "array",
+          type: 'array',
           items: PublishedBranchSchema,
-        })
+        });
 
-        expect(result.errors).to.be.empty
-        expect(object[0].name).to.equal("default")
-        expect(object[0].viewLink).to.equal(defaultViewLink)
-        expect(object[0].site.id).to.equal(site.id)
-        expect(object[1].name).to.equal("preview")
-        expect(object[1].viewLink).to.equal(previewViewLink)
-        expect(object[1].site.id).to.equal(site.id)
-        done()
-      }).catch(done)
-    })
+        expect(result.errors).to.be.empty;
+        expect(object[0].name).to.equal('default');
+        expect(object[0].site.id).to.equal(site.id);
+        expect(object[1].name).to.equal('preview');
+        expect(object[1].site.id).to.equal(site.id);
+        done();
+      }).catch(done);
+    });
 
-    it("should serialize a site with a single published branch correctly", done => {
-      let site
+    it('should serialize a site with a single published branch correctly', (done) => {
+      let site;
 
-      factory.site({ defaultBranch: "default" }).then(model => {
-        site = model
-        return PublishedBranchSerializer.serialize(site, "default")
-      }).then(object => {
-        const viewLink = site.viewLinkForBranch("default")
-        const result = validateJSONSchema(object, PublishedBranchSchema)
+      factory.site({ defaultBranch: 'default' }).then((model) => {
+        site = model;
+        return PublishedBranchSerializer.serialize(site, 'default');
+      }).then((object) => {
+        const result = validateJSONSchema(object, PublishedBranchSchema);
 
-        expect(result.errors).to.be.empty
-        expect(object.name).to.equal("default")
-        expect(object.viewLink).to.equal(viewLink)
-        expect(object.site.id).to.equal(site.id)
-        done()
-      }).catch(done)
-    })
-  })
-})
+        expect(result.errors).to.be.empty;
+        expect(object.name).to.equal('default');
+        expect(object.site.id).to.equal(site.id);
+        done();
+      }).catch(done);
+    });
+  });
+});

--- a/test/api/unit/services/GithubBuildStatusReporter.test.js
+++ b/test/api/unit/services/GithubBuildStatusReporter.test.js
@@ -128,7 +128,7 @@ describe('GithubBuildStatusReporter', () => {
             owner: 'test-owner',
             repo: 'test-repo',
             sha: '456def',
-            targetURL: `${config.app.preview_hostname}/preview/test-owner/test-repo/preview-branch`,
+            targetURL: `${config.app.preview_hostname}/preview/test-owner/test-repo/preview-branch/`,
           });
 
           return GithubBuildStatusReporter.reportBuildStatus(build);

--- a/test/frontend/components/addSite/addSite.test.js
+++ b/test/frontend/components/addSite/addSite.test.js
@@ -4,8 +4,6 @@ import { expect } from 'chai';
 import { stub } from 'sinon';
 import proxyquire from 'proxyquire';
 
-import templates from '../../../../config/templates';
-
 proxyquire.noCallThru();
 
 const mock = () => () => <div />;
@@ -85,7 +83,6 @@ describe('<AddSite/>', () => {
 
     expect(bannerProps).to.deep.equal({ message: propsWithoutError.storeState.error });
     expect(templateListProps).to.deep.equal({
-      templates,
       handleSubmitTemplate: wrapper.instance().onSubmitTemplate,
       defaultOwner: propsWithoutError.storeState.user.data.username,
     });

--- a/test/frontend/components/branchViewLink.test.js
+++ b/test/frontend/components/branchViewLink.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { BranchViewLink } from '../../../frontend/components/branchViewLink';
+
+describe('<BranchViewLink/>', () => {
+  const testSite = {
+    defaultBranch: 'default-branch',
+    demoBranch: 'demo-branch',
+    viewLink: 'https://prod-url.com',
+    demoViewLink: 'https://demo-url.com',
+    owner: 'test-owner',
+    repository: 'test-repo',
+  };
+
+  let props;
+
+  beforeEach(() => {
+    props = {
+      branchName: 'branch-name',
+      site: testSite,
+      previewHostname: 'https://preview-hostname.com',
+    };
+  });
+
+  it('does not link an unlinkable branch name', () => {
+    props.branchName = 'abc-#-def';
+    const wrapper = shallow(<BranchViewLink {...props} />);
+    expect(wrapper.find('span').length).to.equal(1);
+    expect(wrapper.find('span').text()).to.equal('Unlinkable branch name');
+  });
+
+  it('renders a link to the default branch\'s site', () => {
+    props.branchName = 'default-branch';
+    const wrapper = shallow(<BranchViewLink {...props} />);
+    const anchor = wrapper.find('a');
+    expect(anchor.length).to.equal(1);
+    expect(anchor.prop('href')).to.equal('https://prod-url.com');
+    expect(anchor.text()).equal('View site');
+  });
+
+  it('renders a link to the demo branch\'s site', () => {
+    props.branchName = 'demo-branch';
+    const wrapper = shallow(<BranchViewLink {...props} />);
+    const anchor = wrapper.find('a');
+    expect(anchor.length).to.equal(1);
+    expect(anchor.prop('href')).to.equal('https://demo-url.com');
+    expect(anchor.text()).equal('View demo');
+  });
+
+  it('renders a preview link to the other branches', () => {
+    props.branchName = 'some-other-branch';
+    const wrapper = shallow(<BranchViewLink {...props} />);
+    const anchor = wrapper.find('a');
+    expect(anchor.length).to.equal(1);
+    expect(anchor.prop('href')).to.equal(
+      'https://preview-hostname.com/preview/test-owner/test-repo/some-other-branch/');
+    expect(anchor.text()).equal('View preview');
+  });
+});

--- a/test/frontend/components/site/siteGithubBranchesTable.test.js
+++ b/test/frontend/components/site/siteGithubBranchesTable.test.js
@@ -39,54 +39,27 @@ describe('<SiteGithubBranchesTable/>', () => {
     expect(rows.at(1).contains('branch-b')).to.be.true;
   });
 
-  it('renders the view URL for the default branch', () => {
+  it('renders a connected <BranchViewLink /> for each branch', () => {
     props.branches.data = [
-        { name: 'master' },
-    ];
-    props.site = {
-      defaultBranch: 'master',
-      viewLink: 'www.example.com',
-    };
-
-    const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
-    const link = wrapper.find('a');
-
-    expect(link.contains('View')).to.be.true;
-    expect(link.prop('href')).to.equal(props.site.viewLink);
-  });
-
-  it('renders the view URL for demo branches', () => {
-    props.branches.data = [
+      { name: 'master' },
       { name: 'demo' },
-    ];
-    props.site = {
-      demoBranch: 'demo',
-      demoViewLink: 'demo.example.com',
-    };
-
-    const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
-    const link = wrapper.find('a');
-
-    expect(link.contains('View')).to.be.true;
-    expect(link.prop('href')).to.equal(props.site.demoViewLink);
-  });
-
-  it('renders the the preview URL for preview branches', () => {
-    props.branches.data = [
+      { name: 'bad-?-branch' },
       { name: 'preview-branch' },
     ];
+
     props.site = {
-      owner: 'owner-name',
-      repository: 'repo-name',
       defaultBranch: 'master',
+      viewLink: 'https://www.example.com',
+      demoBranch: 'demo',
+      demoViewLink: 'https://demo.example.com',
     };
-    const previewURL = '/preview/owner-name/repo-name/preview-branch/';
 
     const wrapper = shallow(<SiteGithubBranchesTable {...props} />);
-    const link = wrapper.find('a');
-
-    expect(link.contains('View')).to.be.true;
-    expect(link.prop('href')).to.equal(previewURL);
+    const links = wrapper.find('Connect(BranchViewLink)');
+    expect(links.length).to.equal(4);
+    links.forEach((link, i) => {
+      expect(link.prop('branchName')).to.equal(props.branches.data[i].name);
+    });
   });
 
   it('renders an error if a site has no branch data', () => {

--- a/views/index.html
+++ b/views/index.html
@@ -32,6 +32,10 @@
     <title>
       Federalist<% if (siteDisplayEnv) { %> | <%= siteDisplayEnv %><% } %>
     </title>
+
+    <script>
+      window.FRONTEND_CONFIG = <%- JSON.stringify(frontendConfig) %>;
+    </script>
   </head>
   <body>
     <% if (siteWideError) { %>


### PR DESCRIPTION
- render a message instead of a link if a branch has special characters in it (ref #1018)
  - Only allow alphanumeric, `-`, and `_`
- render different link text for `defaultBranch` and `demoBranch`
- adjust text on normal branch preview links
- remove all S3-based site URLs (as in the "View Site" button) in favor of using a `federalist-proxy` url (configured in `config.app.preview_hostname`)

Looks like:

<img width="546" alt="screen shot 2017-08-22 at 3 02 53 pm" src="https://user-images.githubusercontent.com/697848/29585162-c42d553e-874b-11e7-9f69-b084c3b2f9c9.png">


and:

<img width="555" alt="screen shot 2017-08-22 at 3 05 32 pm" src="https://user-images.githubusercontent.com/697848/29585164-c88c2042-874b-11e7-9e6a-2cda63f0e1fd.png">


Somewhat unrelated - add `.nycrc` config file for `nyc`:
- don't output test summary table (it's kind of annoying and too much info)
- make sure to include .jsx files in coverage

To Do:
- [x] use new component in `<SitePublishedBranchesTable>`
- [x] add tests for new component
- [ ] clean up commit history
