### PR TITLE
Require TLD in HttpsUrlInput component

### DIFF
--- a/frontend/components/httpsUrlInput.js
+++ b/frontend/components/httpsUrlInput.js
@@ -13,7 +13,7 @@ const HttpsUrlInput = ({ placeholder, ...props }) => (
   <input
     {...props}
     type="url"
-    pattern="https://.+"
+    pattern="https://.+\.\w{2,}"
     placeholder={placeholder}
     onInvalid={onInvalidUrl}
     onInput={onUrlInput}

--- a/test/frontend/components/httpsUrlInput.test.js
+++ b/test/frontend/components/httpsUrlInput.test.js
@@ -11,7 +11,7 @@ describe('<HttpsUrlInput/>', () => {
     const input = wrapper.find('input');
     expect(input.length).to.equal(1);
     expect(input.prop('type')).to.equal('url');
-    expect(input.prop('pattern')).to.equal('https://.+');
+    expect(input.prop('pattern')).to.equal('https://.+\\.\\w{2,}');
     expect(input.prop('placeholder')).to.equal('https://example.gov');
   });
 


### PR DESCRIPTION
Fixes a minor inconsistency I noticed and described in #1105. Changes our url input pattern to require a TLD of at least 2 characters.