### PR TITLE
change p font-size to 15px

### DIFF
--- a/frontend/sass/_text.scss
+++ b/frontend/sass/_text.scss
@@ -19,7 +19,7 @@ h1 {
 
 p {
   font-family: $serif;
-  font-size: .9em;
+  font-size: 15px;
   font-style: italic;
 }
 


### PR DESCRIPTION
The font face we use, Merriweather, looks weird in fractional sizes on Windows, as reported in #1124.

This PR changes the font size to a whole number value of `15px`, which is nearly un-noticeably (to me, anyway) smaller than the computed `15.3px` size we previously had when it was set to `0.9em`.