### PR TITLE
Destroy session after log out

### DIFF
--- a/api/controllers/auth.js
+++ b/api/controllers/auth.js
@@ -1,20 +1,20 @@
-const passport = require("../services/passport")
+const passport = require('../services/passport');
 
 const AuthController = {
-  logout: function (req, res) {
-    passport.logout(req, res)
+  logout(req, res) {
+    passport.logout(req, res);
   },
 
-  github: function (req, res) {
+  github(req, res) {
     if (req.session.authenticated) {
-      res.redirect("/")
+      res.redirect('/');
     } else {
-      passport.authenticate("github")(req, res, req.next)
+      passport.authenticate('github')(req, res, req.next);
     }
   },
 
-  callback: function (req, res) {
-    passport.callback(req, res)
+  callback(req, res) {
+    passport.callback(req, res);
   },
 };
 

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -40,9 +40,7 @@ passport.use(new GitHubStrategy(config.passport.github.options, githubVerifyCall
 
 passport.logout = (req, res) => {
   req.logout();
-  req.session.authenticated = false;
-  req.session.authenticatedAt = null;
-  req.session.save(() => {
+  req.session.destroy(() => {
     res.redirect('/');
   });
 };

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -77,8 +77,7 @@ describe('Authentication request', () => {
       })
       .then(() => sessionForCookie(cookie))
       .then((nonAuthSession) => {
-        expect(nonAuthSession.authenticated).to.equal(false);
-        expect(nonAuthSession.passport).to.be.empty;
+        expect(nonAuthSession).to.equal(null);
         done();
       })
       .catch(done);

--- a/test/api/unit/policies/sessionAuth.test.js
+++ b/test/api/unit/policies/sessionAuth.test.js
@@ -72,7 +72,8 @@ describe('sessionAuth', () => {
         expect(mockNext.calledOnce).to.equal(true);
         expect(mockReq.session.authRedirectPath).to.equal(undefined);
         done();
-      });
+      })
+      .catch(done);
   });
 
   it('revalidates the user if authenticatedAt is too old', (done) => {
@@ -84,7 +85,8 @@ describe('sessionAuth', () => {
         expect(mockNext.calledOnce).to.equal(true);
         expect(mockReq.session.authRedirectPath).to.equal(undefined);
         done();
-      });
+      })
+      .catch(done);
   });
 
   it('ends the session and calls res.forbidden if the user is no longer valid', (done) => {
@@ -99,6 +101,7 @@ describe('sessionAuth', () => {
         expect(mockNext.notCalled).to.equal(true);
         expect(mockRes.forbidden.calledOnce).to.equal(true);
         done();
-      });
+      })
+      .catch(done);
   });
 });


### PR DESCRIPTION
Rather than keeping the session around but with `authenticated=False` after a log out action, just destroy it completely. Ref #1130.