### PR TITLE
remove p tags surrounding branch names

### DIFF
--- a/frontend/components/site/siteGithubBranchesTable.js
+++ b/frontend/components/site/siteGithubBranchesTable.js
@@ -7,7 +7,7 @@ import { SITE, GITHUB_BRANCHES } from '../../propTypes';
 const branchRow = (branch, site) => (
   <tr key={branch.name}>
     <td>
-      <p>{branch.name}</p>
+      {branch.name}
     </td>
     <td>
       <BranchViewLink site={site} branchName={branch.name} />

--- a/frontend/sass/_labels.scss
+++ b/frontend/sass/_labels.scss
@@ -16,4 +16,8 @@
 
 h4.label {
   margin-bottom: 0;
+
+  + table {
+    margin-top: 0.2em;
+  }
 }


### PR DESCRIPTION
and also adjust the `margin-top` of the table to bring the associated `h4.label` closer to the table (and make it consistent with form element + label spacing).

ref #1142

Now looks like this:

<img width="739" alt="screen shot 2017-09-07 at 9 34 08 am" src="https://user-images.githubusercontent.com/697848/30168744-ecf47e96-93af-11e7-9fbe-4aae6cb63fe5.png">
