### PR TITLE
adjust front page buttons and note

### DIFF
--- a/frontend/sass/_text.scss
+++ b/frontend/sass/_text.scss
@@ -21,6 +21,10 @@ p {
   font-family: $serif;
   font-size: 16px;
   font-style: italic;
+
+  &.small {
+    font-size: 14px;
+  }
 }
 
 .center-text {

--- a/views/home.njk
+++ b/views/home.njk
@@ -132,10 +132,13 @@
       <div class="col-md-8 col-md-offset-2 center-text">
         <h2>Federalist is open for business!</h2>
         <p>We developed Federalist to help deliver high-quality websites for departments and agencies across the US federal government.</p>
-        <p>Are you responsible for a federal website and interested in learning more? (note: submision form is out of scope for our <a href="https://hackerone.com/tts">bug bounty program</a>)</p>
-        <p>
-          <a class="usa-button usa-button-primary-alt" href="https://federalist-docs.18f.gov" role="button">Documentation Site</a>
+        <p>Are you responsible for a federal website and interested in learning more?</p>
+        <div>
+          <a class="usa-button usa-button-primary-alt" href="https://federalist-docs.18f.gov" role="button">Documentation site</a>
           <a class="usa-button usa-button-primary" href="https://docs.google.com/forms/d/1iB8aW7c9r1QH3s8XElQCrnXRGjAiPUYpWG1CMeEqGIo/viewform" role="button">Sign up for more information</a>
+        </div>
+        <p class="small">
+           Note: Sign-up form is out of scope for our <a href="https://hackerone.com/tts">bug bounty program</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Follow-up edits to https://github.com/18F/federalist/commit/de0c8b5f581649e1cb401c4dd6e274be7147398ca#diff-d2d32307738e08558710ff29b2a05c7f

- moved bug bounty note below buttons, made note text smaller, fixed typo
- removed `<p>` tag surrounding the buttons so their text isn't italicized
- used title case in button text for consistency

Looks like this:

<img width="973" alt="screen shot 2017-09-11 at 11 35 01 am" src="https://user-images.githubusercontent.com/697848/30285888-437cef68-96e5-11e7-9c6b-83412892f381.png">
