### PR TITLE
Add CSRF protection 

### DIFF
--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -58,6 +58,7 @@ module.exports = {
     context.isAuthenticated = true;
     context.username = req.user.username;
     context.siteWideError = SiteWideErrorLoader.loadSiteWideError();
+    context.csrfToken = req.csrfToken();
 
     const frontendConfig = {
       TEMPLATES: config.templates,

--- a/api/policies/csrfProtection.js
+++ b/api/policies/csrfProtection.js
@@ -1,0 +1,5 @@
+const csurf = require('csurf');
+
+const csrfProtection = csurf();
+
+module.exports = csrfProtection;

--- a/api/routers/build.js
+++ b/api/routers/build.js
@@ -2,9 +2,10 @@ const router = require('express').Router();
 const BuildController = require('../controllers/build');
 const buildCallback = require('../policies/buildCallback');
 const sessionAuth = require('../policies/sessionAuth');
+const csrfProtection = require('../policies/csrfProtection');
 
 router.get('/site/:site_id/build', sessionAuth, BuildController.find);
-router.post('/build', sessionAuth, BuildController.create);
+router.post('/build', sessionAuth, csrfProtection, BuildController.create);
 router.get('/build/:id', sessionAuth, BuildController.findOne);
 router.post('/build/:id/status/:token', buildCallback, BuildController.status);
 

--- a/api/routers/index.js
+++ b/api/routers/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const csurf = require('csurf');
 
 const mainRouter = express.Router();
 
@@ -15,7 +16,9 @@ apiRouter.use(require('./site'));
 apiRouter.use(require('./user'));
 apiRouter.use(require('./published-file'));
 
-// prefix all api routes with "/v0"
-mainRouter.use('/v0', apiRouter);
+const csrfProtection = csurf();
+
+// prefix all api routes with "/v0" and add csrf protection
+mainRouter.use('/v0', csrfProtection, apiRouter);
 
 module.exports = mainRouter;

--- a/api/routers/index.js
+++ b/api/routers/index.js
@@ -1,12 +1,16 @@
 const express = require('express');
 const csurf = require('csurf');
 
+const csrfProtection = csurf();
 const mainRouter = express.Router();
 
 mainRouter.use(require('./auth'));
-mainRouter.use(require('./main'));
 mainRouter.use(require('./preview'));
 mainRouter.use(require('./webhook'));
+
+// add csrfProtection to main so that we can add it to
+// the response context in the main.js controller
+mainRouter.use(csrfProtection, require('./main'));
 
 const apiRouter = express.Router();
 apiRouter.use(require('./build-log'));
@@ -15,8 +19,6 @@ apiRouter.use(require('./published-branch'));
 apiRouter.use(require('./site'));
 apiRouter.use(require('./user'));
 apiRouter.use(require('./published-file'));
-
-const csrfProtection = csurf();
 
 // prefix all api routes with "/v0" and add csrf protection
 mainRouter.use('/v0', csrfProtection, apiRouter);

--- a/api/routers/index.js
+++ b/api/routers/index.js
@@ -1,26 +1,21 @@
 const express = require('express');
-const csurf = require('csurf');
 
-const csrfProtection = csurf();
 const mainRouter = express.Router();
 
 mainRouter.use(require('./auth'));
 mainRouter.use(require('./preview'));
 mainRouter.use(require('./webhook'));
-
-// add csrfProtection to main so that we can add it to
-// the response context in the main.js controller
-mainRouter.use(csrfProtection, require('./main'));
+mainRouter.use(require('./main'));
 
 const apiRouter = express.Router();
 apiRouter.use(require('./build-log'));
 apiRouter.use(require('./build'));
 apiRouter.use(require('./published-branch'));
-apiRouter.use(require('./site'));
 apiRouter.use(require('./user'));
 apiRouter.use(require('./published-file'));
+apiRouter.use(require('./site'));
 
-// prefix all api routes with "/v0" and add csrf protection
-mainRouter.use('/v0', csrfProtection, apiRouter);
+// prefix all api routes with "/v0"
+mainRouter.use('/v0', apiRouter);
 
 module.exports = mainRouter;

--- a/api/routers/main.js
+++ b/api/routers/main.js
@@ -1,9 +1,12 @@
 const router = require('express').Router();
+
 const MainController = require('../controllers/main');
+const csrfProtection = require('../policies/csrfProtection');
 
 router.get('/', MainController.home);
 
-router.get('/sites(/*)?', MainController.app);
+// add csrf middleware to app route so that we can use request.csrfToken()
+router.get('/sites(/*)?', csrfProtection, MainController.app);
 router.get('/robots.txt', MainController.robots);
 
 module.exports = router;

--- a/api/routers/site.js
+++ b/api/routers/site.js
@@ -1,6 +1,11 @@
 const router = require('express').Router();
 const SiteController = require('../controllers/site');
 const sessionAuth = require('../policies/sessionAuth');
+const csrfProtection = require('../policies/csrfProtection');
+
+// enable csrf protection for all site routes
+// note that this must come before the route definitions
+router.use(csrfProtection);
 
 router.get('/site', sessionAuth, SiteController.find);
 router.post('/site', sessionAuth, SiteController.create);

--- a/app.js
+++ b/app.js
@@ -65,7 +65,6 @@ app.use((req, res, next) => {
   next();
 });
 
-
 if (logger.levels[logger.level] >= 2) {
   app.use(expressWinston.logger({
     transports: [
@@ -84,5 +83,17 @@ const limiter = new RateLimit(config.rateLimiting);
 app.use(limiter); // must be set before router is added to app
 
 app.use(router);
+
+// error handler middleware for custom CSRF error responses
+// note that error handling middlewares must come last in the stack
+app.use((err, req, res, next) => {
+  if (err.code === 'EBADCSRFTOKEN') {
+    res.forbidden({ message: 'Invalid CSRF token' });
+    return;
+  }
+
+  next(err);
+});
+
 
 module.exports = app;

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -140,7 +140,7 @@ export class SiteSettings extends React.Component {
               <div className="well">
                 <h3 className="well-heading">Demo Site</h3>
                 <p className="well-text">
-                  Setup a branch to be deployed to a demo url.
+                  Setup a branch to be deployed to a demo URL.
                 </p>
                 <label htmlFor="demoBranchInput">Branch name:</label>
                 <input

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -1,14 +1,25 @@
+/* global window:true */
+
 import fetch from './fetch';
 import alertActions from '../actions/alertActions';
 
 export const API = '/v0';
 
+const csrfToken = typeof window !== 'undefined' ?
+  window.CSRF_TOKEN : global.CSRF_TOKEN;
+
+const defaultHeaders = {
+  'x-csrf-token': csrfToken,
+};
+
 export default {
-  fetch(endpoint, params) {
+  fetch(endpoint, params = {}) {
     const url = `${API}/${endpoint}`;
 
-    return fetch(url, params)
-      .then(data => data)
+    const headers = Object.assign({}, defaultHeaders, params.headers || {});
+    const finalParams = Object.assign({}, params, { headers });
+
+    return fetch(url, finalParams)
       .catch((error) => {
         alertActions.httpError(error.message);
       });

--- a/frontend/util/fetch.js
+++ b/frontend/util/fetch.js
@@ -1,22 +1,19 @@
-/* global window:true fetch:true */
+/* global fetch:true */
 
 import 'whatwg-fetch';
 
 const defaultMethod = 'GET';
 const credentials = 'same-origin';
-const csrfToken = typeof window !== 'undefined' ?
-  window.CSRF_TOKEN : global.CSRF_TOKEN;
 
 const defaultHeaders = {
   accept: 'application/json',
   'content-type': 'application/json',
-  'x-csrf-token': csrfToken,
 };
 
 function mergeParams(url, params) {
   return Object.keys(params).reduce((memo, param, index) => (
-    `${memo}${!index ? '?' : '&'}${param}=${params[param]}`), url
-  );
+    `${memo}${!index ? '?' : '&'}${param}=${params[param]}`)
+  , url);
 }
 
 function checkStatus(response) {

--- a/frontend/util/fetch.js
+++ b/frontend/util/fetch.js
@@ -1,18 +1,22 @@
+/* global window:true fetch:true */
+
 import 'whatwg-fetch';
 
 const defaultMethod = 'GET';
 const credentials = 'same-origin';
+const csrfToken = typeof window !== 'undefined' ?
+  window.CSRF_TOKEN : global.CSRF_TOKEN;
+
 const defaultHeaders = {
-  'Accept': 'application/json',
-  'Content-Type': 'application/json'
+  accept: 'application/json',
+  'content-type': 'application/json',
+  'x-csrf-token': csrfToken,
 };
 
 function mergeParams(url, params) {
-  return Object.keys(params).reduce((memo, param, index) => {
-    memo += ((!index ? '?' : '&') + `${param}=${params[param]}`);
-
-    return memo;
-  }, url);
+  return Object.keys(params).reduce((memo, param, index) => (
+    `${memo}${!index ? '?' : '&'}${param}=${params[param]}`), url
+  );
 }
 
 function checkStatus(response) {
@@ -26,7 +30,7 @@ function checkStatus(response) {
 
     try {
       formattedError = JSON.parse(errorText).message;
-    } catch(error) {
+    } catch (error) {
       formattedError = errorText;
     }
 
@@ -45,29 +49,28 @@ function parseJSON(response) {
   return response.json();
 }
 
-function _fetch(url, configs = {}) {
+function fetchWrapper(url, configs = {}) {
   const baseConfigs = {
     credentials: configs.credentials || credentials,
     headers: Object.assign({}, defaultHeaders, configs.headers || {}),
-    method: configs.method || defaultMethod
+    method: configs.method || defaultMethod,
   };
 
   let requestConfigs;
-  let requestUrl;
 
   if (configs.method && !(/get|delete/i).test(configs.method)) {
     requestConfigs = Object.assign(baseConfigs, {}, {
-      body: JSON.stringify(configs.data)
+      body: JSON.stringify(configs.data),
     });
   } else {
     requestConfigs = baseConfigs;
   }
 
-  requestUrl = configs.params ? mergeParams(url, configs.params) : url;
+  const requestUrl = configs.params ? mergeParams(url, configs.params) : url;
 
   return fetch(requestUrl, requestConfigs)
     .then(checkStatus)
     .then(parseJSON);
 }
 
-export default _fetch
+export default fetchWrapper;

--- a/frontend/util/githubApi.js
+++ b/frontend/util/githubApi.js
@@ -1,27 +1,19 @@
 import fetch from './fetch';
 
-import store from '../store';
-import alertActions from '../actions/alertActions';
-
 const API = 'https://api.github.com';
 
-const getRepoFor = (site) => {
-  return `repos/${site.owner}/${site.repository}`;
-};
+const getRepoFor = site => `repos/${site.owner}/${site.repository}`;
 
 const github = {
   fetch(path, params) {
     const url = `${API}/${path}`;
-
-    return fetch(url, params).then((data) => {
-      return data;
-    });
+    return fetch(url, params);
   },
 
   fetchBranches(site) {
     const url = `${getRepoFor(site)}/branches`;
     return this.fetch(url);
   },
-}
+};
 
 export default github;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "connect-flash": "^0.1.1",
     "connect-session-sequelize": "^4.1.0",
     "core-js": "^2.4.1",
+    "csurf": "^1.9.0",
     "db-migrate": "^0.10.0-beta.20",
     "db-migrate-pg": "^0.2.5",
     "deep-extend": "^0.4.1",

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -6,7 +6,7 @@ const request = require('supertest');
 const config = require('../../../config');
 const factory = require('../support/factory');
 const githubAPINocks = require('../support/githubAPINocks');
-const session = require('../support/session');
+const { authenticatedSession } = require('../support/session');
 const { sessionForCookie, sessionCookieFromResponse } = require('../support/cookieSession');
 const { User } = require('../../../api/models');
 
@@ -21,7 +21,7 @@ describe('Authentication request', () => {
     });
 
     it('should redirect to the root URL if the users is logged in', (done) => {
-      session().then((cookie) => {
+      authenticatedSession().then((cookie) => {
         request(app)
           .get('/auth/github')
           .set('Cookie', cookie)
@@ -37,7 +37,7 @@ describe('Authentication request', () => {
       let cookie;
 
       const userPromise = factory.user();
-      const sessionPromise = session(userPromise);
+      const sessionPromise = authenticatedSession(userPromise);
 
       Promise.props({
         user: userPromise,

--- a/test/api/requests/build-logs.test.js
+++ b/test/api/requests/build-logs.test.js
@@ -2,7 +2,7 @@ const expect = require('chai').expect;
 const request = require('supertest');
 const app = require('../../../app');
 const factory = require('../support/factory');
-const session = require('../support/session');
+const { authenticatedSession } = require('../support/session');
 const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
 const { BuildLog, Site, User } = require('../../../api/models');
 
@@ -115,7 +115,7 @@ describe('Build Log API', () => {
         return Promise.all(Array(3).fill(0).map(() => factory.buildLog({ build })));
       }).then(() => Site.findById(build.site, { include: [User] })).then((site) => {
         const user = site.Users[0];
-        return session(user);
+        return authenticatedSession(user);
       })
       .then(cookie => request(app)
         .get(`/v0/build/${build.id}/log`)
@@ -141,7 +141,7 @@ describe('Build Log API', () => {
       .then(() => Site.findById(build.site, { include: [User] }))
       .then((site) => {
         const user = site.Users[0];
-        return session(user);
+        return authenticatedSession(user);
       })
       .then(cookie => request(app)
         .get(`/v0/build/${build.id}/log?format=text`)
@@ -166,7 +166,7 @@ describe('Build Log API', () => {
 
         return Promise.all(Array(3).fill(0).map(() => factory.buildLog()));
       })
-      .then(() => factory.user()).then(user => session(user))
+      .then(() => factory.user()).then(user => authenticatedSession(user))
       .then(cookie => request(app)
         .get(`/v0/build/${build.id}/log`)
         .set('Cookie', cookie)
@@ -180,7 +180,7 @@ describe('Build Log API', () => {
     });
 
     it('should response with a 404 if the given build does not exist', (done) => {
-      session().then(cookie => request(app)
+      authenticatedSession().then(cookie => request(app)
           .get('/v0/build/fake-id/log')
           .set('Cookie', cookie)
           .expect(404)).then((response) => {

--- a/test/api/requests/published-branch.test.js
+++ b/test/api/requests/published-branch.test.js
@@ -4,7 +4,7 @@ const request = require('supertest');
 const app = require('../../../app');
 const config = require('../../../config');
 const factory = require('../support/factory');
-const session = require('../support/session');
+const { authenticatedSession } = require('../support/session');
 const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
 
 describe('Published Branches API', () => {
@@ -26,7 +26,7 @@ describe('Published Branches API', () => {
       let site;
       const userPromise = factory.user();
       const sitePromise = factory.site({ users: Promise.all([userPromise]) });
-      const cookiePromise = session(userPromise);
+      const cookiePromise = authenticatedSession(userPromise);
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
         expect(params.Bucket).to.equal(config.s3.bucket);
@@ -72,7 +72,7 @@ describe('Published Branches API', () => {
         users: Promise.all([userPromise]),
         demoBranch: 'demo',
       });
-      const cookiePromise = session(userPromise);
+      const cookiePromise = authenticatedSession(userPromise);
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
         expect(params.Bucket).to.equal(config.s3.bucket);
@@ -108,7 +108,7 @@ describe('Published Branches API', () => {
     it('should 403 if the user is not associated with the site', (done) => {
       const user = factory.user();
       const site = factory.site();
-      const cookie = session(user);
+      const cookie = authenticatedSession(user);
 
       Promise.props({ user, site, cookie }).then(promisedValues => request(app)
           .get(`/v0/site/${promisedValues.site.id}/published-branch`)
@@ -137,7 +137,7 @@ describe('Published Branches API', () => {
         defaultBranch: 'master',
         users: Promise.all([userPromise]),
       });
-      const cookiePromise = session(userPromise);
+      const cookiePromise = authenticatedSession(userPromise);
 
       Promise.props({
         user: userPromise,
@@ -161,7 +161,7 @@ describe('Published Branches API', () => {
     it('should 403 if the user is not associated with the site', (done) => {
       const user = factory.user();
       const site = factory.site({ defaultBranch: 'master' });
-      const cookie = session(user);
+      const cookie = authenticatedSession(user);
 
       Promise.props({ user, site, cookie }).then(promisedValues => request(app)
           .get(`/v0/site/${promisedValues.site.id}/published-branch/master`)

--- a/test/api/requests/published-file.test.js
+++ b/test/api/requests/published-file.test.js
@@ -1,85 +1,81 @@
-const AWSMocks = require("../support/aws-mocks")
-const expect = require("chai").expect
-const request = require("supertest")
-const app = require("../../../app")
-const config = require("../../../config")
-const factory = require("../support/factory")
-const session = require("../support/session")
-const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
+const AWSMocks = require('../support/aws-mocks');
+const expect = require('chai').expect;
+const request = require('supertest');
+const app = require('../../../app');
+const config = require('../../../config');
+const factory = require('../support/factory');
+const { authenticatedSession } = require('../support/session');
+const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
 
-describe("Published Files API", () => {
-  describe("GET /v0/site/:site_id/published-branch/:branch/file", () => {
-    it("should require authentication", done => {
-      factory.site().then(site => {
-        return request(app)
+describe('Published Files API', () => {
+  describe('GET /v0/site/:site_id/published-branch/:branch/file', () => {
+    it('should require authentication', (done) => {
+      factory.site().then(site => request(app)
           .get(`/v0/site/${site.id}/published-branch/${site.defaultBranch}`)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch/{branch}/published-file", 403, response.body)
-        done()
-      }).catch(done)
-    })
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch/{branch}/published-file', 403, response.body);
+            done();
+          }).catch(done);
+    });
 
-    it("should list the files published to the branch for the site", done => {
-      let site
-      const userPromise = factory.user()
+    it('should list the files published to the branch for the site', (done) => {
+      let site;
+      const userPromise = factory.user();
       const sitePromise = factory.site({
-        defaultBranch: "master",
+        defaultBranch: 'master',
         users: Promise.all([userPromise]),
-      })
-      const cookiePromise = session(userPromise)
+      });
+      const cookiePromise = authenticatedSession(userPromise);
 
       AWSMocks.mocks.S3.listObjects = (params, callback) => {
-        const prefix = `site/${site.owner}/${site.repository}`
-        expect(params.Bucket).to.equal(config.s3.bucket)
-        expect(params.Prefix).to.equal(prefix)
+        const prefix = `site/${site.owner}/${site.repository}`;
+        expect(params.Bucket).to.equal(config.s3.bucket);
+        expect(params.Prefix).to.equal(prefix);
 
         callback(null, {
           Contents: [
             { Key: `${prefix}/abc`, Size: 123 },
             { Key: `${prefix}/abc/def`, Size: 456 },
             { Key: `${prefix}/ghi`, Size: 789 },
-          ]
-        })
-      }
+          ],
+        });
+      };
 
       Promise.props({
         user: userPromise,
         site: sitePromise,
         cookie: cookiePromise,
-      }).then(promisedValues => {
-        site = promisedValues.site
+      }).then((promisedValues) => {
+        site = promisedValues.site;
 
         return request(app)
           .get(`/v0/site/${site.id}/published-branch/master/published-file`)
-          .set("Cookie", promisedValues.cookie)
-          .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch/{branch}/published-file", 200, response.body)
-        response.body.forEach(fileResponse => {
-          delete fileResponse.publishedBranch
-        })
-        expect(response.body).to.include({ name: "abc", size: 123 })
-        expect(response.body).to.include({ name: "abc/def", size: 456 })
-        expect(response.body).to.include({ name: "ghi", size: 789 })
-        done()
-      }).catch(done)
-    })
+          .set('Cookie', promisedValues.cookie)
+          .expect(200);
+      }).then((response) => {
+        validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch/{branch}/published-file', 200, response.body);
+        response.body.forEach((fileResponse) => {
+          delete fileResponse.publishedBranch; // eslint-disable-line no-param-reassign
+        });
+        expect(response.body).to.include({ name: 'abc', size: 123 });
+        expect(response.body).to.include({ name: 'abc/def', size: 456 });
+        expect(response.body).to.include({ name: 'ghi', size: 789 });
+        done();
+      }).catch(done);
+    });
 
-    it("should 403 if the user is not associated with the site", done => {
-      const user = factory.user()
-      const site = factory.site({ defaultBranch: "master" })
-      const cookie = session(user)
+    it('should 403 if the user is not associated with the site', (done) => {
+      const user = factory.user();
+      const site = factory.site({ defaultBranch: 'master' });
+      const cookie = authenticatedSession(user);
 
-      Promise.props({ user, site, cookie }).then(promisedValues => {
-        return request(app)
+      Promise.props({ user, site, cookie }).then(promisedValues => request(app)
           .get(`/v0/site/${promisedValues.site.id}/published-branch/master/published-file`)
-          .set("Cookie", promisedValues.cookie)
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/site/{site_id}/published-branch/{branch}/published-file", 403, response.body)
-        done()
-      }).catch(done)
-    })
-  })
-})
+          .set('Cookie', promisedValues.cookie)
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('GET', '/site/{site_id}/published-branch/{branch}/published-file', 403, response.body);
+            done();
+          }).catch(done);
+    });
+  });
+});

--- a/test/api/requests/user.test.js
+++ b/test/api/requests/user.test.js
@@ -1,51 +1,47 @@
-const crypto = require("crypto")
-const expect = require("chai").expect
-const nock = require("nock")
-const Promise = require("bluebird")
-const request = require("supertest")
-const sinon = require("sinon")
+const expect = require('chai').expect;
+const request = require('supertest');
 
-const app = require("../../../app")
-const factory = require("../support/factory")
-const githubAPINocks = require("../support/githubAPINocks")
-const session = require("../support/session")
-const validateAgainstJSONSchema = require("../support/validateAgainstJSONSchema")
+const app = require('../../../app');
+const factory = require('../support/factory');
+const { authenticatedSession } = require('../support/session');
+const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
 
-describe("User API", () => {
-  var userResponseExpectations = (response, user) => {
-    expect(response).to.have.property("id", user.id)
-    expect(response).to.have.property("username", user.username)
-    expect(response).to.have.property("email", user.email)
-  }
+describe('User API', () => {
+  const userResponseExpectations = (response, user) => {
+    expect(response).to.have.property('id', user.id);
+    expect(response).to.have.property('username', user.username);
+    expect(response).to.have.property('email', user.email);
+  };
 
-  describe("GET /v0/me", () => {
-    it("should require authentication", done => {
-      factory.user().then(user => {
-        return request(app)
-          .get("/v0/me")
-          .expect(403)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/me", 403, response.body)
-        done()
-      })
-    })
+  describe('GET /v0/me', () => {
+    it('should require authentication', (done) => {
+      factory.user().then(() => request(app)
+          .get('/v0/me')
+          .expect(403)).then((response) => {
+            validateAgainstJSONSchema('GET', '/me', 403, response.body);
+            done();
+          });
+    });
 
-    it("should render the current user", done => {
-      var user
+    it('should render the current user', (done) => {
+      let user;
 
-      factory.user().then(model => {
-        user = model
-        return session(user)
-      }).then(cookie => {
-        return request(app)
-          .get("/v0/me")
-          .set("Cookie", cookie)
+      factory.user()
+        .then((model) => {
+          user = model;
+          return authenticatedSession(user);
+        })
+        .then(cookie => request(app)
+          .get('/v0/me')
+          .set('Cookie', cookie)
           .expect(200)
-      }).then(response => {
-        validateAgainstJSONSchema("GET", "/me", 200, response.body)
-        userResponseExpectations(response.body, user)
-        done()
-      }).catch(done)
-    })
-  })
-})
+        )
+        .then((response) => {
+          validateAgainstJSONSchema('GET', '/me', 200, response.body);
+          userResponseExpectations(response.body, user);
+          done();
+        })
+        .catch(done);
+    });
+  });
+});

--- a/test/api/support/csrfToken.js
+++ b/test/api/support/csrfToken.js
@@ -1,0 +1,10 @@
+const Tokens = require('csrf');
+
+const tokens = new Tokens();
+
+const TEST_CSRF_SECRET = 'csrf-secret';
+
+module.exports = {
+  TEST_CSRF_SECRET,
+  getToken: () => tokens.create(TEST_CSRF_SECRET),
+};

--- a/test/api/support/factory/index.js
+++ b/test/api/support/factory/index.js
@@ -1,6 +1,11 @@
+const buildLog = require('./build-log');
+const build = require('./build');
+const site = require('./site');
+const user = require('./user');
+
 module.exports = {
-  buildLog: require("./build-log"),
-  build: require("./build"),
-  site: require("./site"),
-  user: require("./user"),
-}
+  buildLog,
+  build,
+  site,
+  user,
+};

--- a/test/api/support/session.js
+++ b/test/api/support/session.js
@@ -1,8 +1,35 @@
 const crypto = require('crypto');
 const factory = require('./factory');
+const csrfToken = require('./csrfToken');
 const config = require('../../../config');
 
-const session = (user) => {
+function unauthenticatedSession() {
+  const sessionKey = crypto.randomBytes(8).toString('hex');
+
+  const sessionBody = {
+    cookie: {
+      originalMaxAge: null,
+      expires: null,
+      httpOnly: true,
+      path: '/',
+    },
+    flash: {},
+    authenticated: false,
+    csrfSecret: csrfToken.TEST_CSRF_SECRET,
+  };
+
+  return config.session.store.set(sessionKey, sessionBody)
+    .then(() => {
+      const signedSessionKey = `${sessionKey}.${crypto
+        .createHmac('sha256', config.session.secret)
+        .update(sessionKey)
+        .digest('base64')
+        .replace(/=+$/, '')}`;
+      return `${config.session.key}=s%3A${signedSessionKey}`;
+    });
+}
+
+function authenticatedSession(user) {
   const sessionKey = crypto.randomBytes(8).toString('hex');
 
   return Promise.resolve(user || factory.user())
@@ -17,8 +44,10 @@ const session = (user) => {
         passport: {
           user: u.id,
         },
+        flash: {},
         authenticated: true,
         authenticatedAt: new Date(),
+        csrfSecret: csrfToken.TEST_CSRF_SECRET,
       };
       return config.session.store.set(sessionKey, sessionBody);
     })
@@ -30,6 +59,9 @@ const session = (user) => {
         .replace(/=+$/, '')}`;
       return `${config.session.key}=s%3A${signedSessionKey}`;
     });
-};
+}
 
-module.exports = session;
+module.exports = {
+  authenticatedSession,
+  unauthenticatedSession,
+};

--- a/test/api/support/validateAgainstJSONSchema.js
+++ b/test/api/support/validateAgainstJSONSchema.js
@@ -1,25 +1,27 @@
-const deref = require('json-schema-deref-sync')
-const validate = require('jsonschema').validate
-const YAML = require("yamljs")
+const deref = require('json-schema-deref-sync');
+const validate = require('jsonschema').validate;
+const YAML = require('yamljs');
 
-const swagger = YAML.load("public/swagger/index.yml")
+const swagger = YAML.load('public/swagger/index.yml');
 const schema = deref(swagger, {
-  baseFolder: process.cwd() + "/public/swagger",
+  baseFolder: `${process.cwd()}/public/swagger`,
   failOnMissing: true,
-})
+});
 
 const validateAgainstJSONSchema = (action, path, statusCode, response) => {
-  action = action.toLowerCase()
-  path = path.toLowerCase()
-  statusCode = parseInt(statusCode)
+  const actionLower = action.toLowerCase();
+  const pathLower = path.toLowerCase();
+  const statusCodeInt = parseInt(statusCode, 10);
 
-  const responseSchema = schema.paths[path][action].responses[statusCode].schema
-  const result = validate(response,responseSchema)
+  const responseSchema = schema.paths[pathLower][actionLower].responses[statusCodeInt].schema;
+  const result = validate(response, responseSchema);
 
   if (result.errors.length) {
-    console.error(result.errors)
-    throw new Error(`Failed to validate against definition: ${definition}`)
+    console.error(result.errors); // eslint-disable-line no-console
+    throw new Error(
+      `Failed to validate against definition: ${actionLower} ${pathLower} ${statusCodeInt}`
+    );
   }
-}
+};
 
-module.exports = validateAgainstJSONSchema
+module.exports = validateAgainstJSONSchema;

--- a/views/app.njk
+++ b/views/app.njk
@@ -25,5 +25,8 @@
 {% block main_content %}
   <div id="js-app"></div>
 
+  <script>
+    window.CSRF_TOKEN = "{{ csrfToken }}";
+  </script>
   <script src="/{{ webpackAssets['main.js'] }}"></script>
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,6 +1690,14 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
 
+csrf@~3.0.3:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/csrf/-/csrf-3.0.6.tgz#b61120ddceeafc91e76ed5313bb5c0b2667b710a"
+  dependencies:
+    rndm "1.2.0"
+    tsscmp "1.0.5"
+    uid-safe "2.1.4"
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -1781,6 +1789,15 @@ csso@~2.3.1:
   dependencies:
     clap "^1.0.9"
     source-map "^0.5.3"
+
+csurf@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/csurf/-/csurf-1.9.0.tgz#49d2c6925ffcec7b7de559597c153fa533364133"
+  dependencies:
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    csrf "~3.0.3"
+    http-errors "~1.5.0"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -3179,6 +3196,14 @@ htmlparser2@^3.9.1:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^2.0.2"
+
+http-errors@~1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.5.1.tgz#788c0d2c1de2c81b9e6e8c01843b6b97eb920750"
+  dependencies:
+    inherits "2.0.3"
+    setprototypeof "1.0.2"
+    statuses ">= 1.3.1 < 2"
 
 http-errors@~1.6.1:
   version "1.6.1"
@@ -5942,6 +5967,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+rndm@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/rndm/-/rndm-1.2.0.tgz#f33fe9cfb52bbfd520aa18323bc65db110a1b76c"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -6097,6 +6126,10 @@ set-immediate-shim@^1.0.1:
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+setprototypeof@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.2.tgz#81a552141ec104b88e89ce383103ad5c66564d08"
 
 setprototypeof@1.0.3:
   version "1.0.3"
@@ -6630,6 +6663,10 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
+tsscmp@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.5.tgz#7dc4a33af71581ab4337da91d85ca5427ebd9a97"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -6698,7 +6735,7 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
-uid-safe@~2.1.4:
+uid-safe@2.1.4, uid-safe@~2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/uid-safe/-/uid-safe-2.1.4.tgz#3ad6f38368c6d4c8c75ec17623fb79aa1d071d81"
   dependencies:


### PR DESCRIPTION
- Add express [`csurf` middleware](https://github.com/expressjs/csurf) and protect API routes:
  - all `sites` routes
  - `builds` `POST` route
- Adjust client requests to include csrf token in `x-csrf-token` header
- Modify test `support/session.js` so we can create both authenticated and unauthenticated sessions
- Lots of linting fixes

To Do:
- [x] determine if any other routes need csrf protection enabled
- [x] make sure new user can login for the first time -- possible bug here
- [x] remove `x-csrf-token` from front-end requests to GitHub. Their cors settings do not allow it.
- [x] test that requests fail with a specific csrf error if the token is invalid