### PR TITLE
use alert styling for gh branch fetch error

### DIFF
--- a/frontend/components/site/siteGithubBranchesTable.js
+++ b/frontend/components/site/siteGithubBranchesTable.js
@@ -32,10 +32,14 @@ const renderTable = (site, branches) => (
 const renderLoadingState = () => <LoadingIndicator />;
 
 const renderErrorState = () => (
-  <p>
-    An error occurred while downloading branch data from Github.
-    Often this is because the repo is private or has been deleted.
-  </p>
+  <div className="usa-alert usa-alert-error no-icon" role="alert">
+    <div className="usa-alert-body">
+      <p className="usa-alert-text">
+        An error occurred while downloading branch data from Github.
+        Often this is because the repo is private or has been deleted.
+      </p>
+    </div>
+  </div>
 );
 
 const SiteGithubBranchesTable = ({ site, branches }) => {

--- a/frontend/sass/_alerts.scss
+++ b/frontend/sass/_alerts.scss
@@ -14,6 +14,14 @@
   }
 }
 
+.usa-alert.no-icon {
+  background-image: none;
+
+  .usa-alert-body {
+    padding-left: 0;
+  }
+}
+
 /*
  * Borrowed from USWDS 1.2.1
  * TODO: remove once USWDS dependency is upgraded


### PR DESCRIPTION
Looks like this:

<img width="754" alt="screen shot 2017-09-14 at 11 36 57 am" src="https://user-images.githubusercontent.com/697848/30442163-3e56890a-9941-11e7-920d-93c5d9ccece0.png">

Ref #1156.
