### PR TITLE
only bind necessary methods

### DIFF
--- a/frontend/components/site/refreshBuildLogsButton.jsx
+++ b/frontend/components/site/refreshBuildLogsButton.jsx
@@ -8,7 +8,7 @@ import buildLogActions from '../../actions/buildLogActions';
 class RefreshBuildLogsButton extends React.Component {
   constructor(props) {
     super(props);
-    autoBind(this);
+    autoBind(this, 'refreshBuildLogs');
   }
 
   refreshBuildLogs() {

--- a/frontend/components/site/refreshBuildsButton.jsx
+++ b/frontend/components/site/refreshBuildsButton.jsx
@@ -8,7 +8,7 @@ import buildActions from '../../actions/buildActions';
 class RefreshBuildsButton extends React.Component {
   constructor(props) {
     super(props);
-    autoBind(this);
+    autoBind(this, 'refreshBuilds');
   }
 
   refreshBuilds() {

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import autoBind from 'react-autobind';
 import { Link } from 'react-router';
 
 import buildActions from '../../actions/buildActions';
@@ -42,11 +41,6 @@ class SiteBuilds extends React.Component {
       </a>
     );
     /* eslint-enable jsx-a11y/href-no-hash */
-  }
-
-  constructor(props) {
-    super(props);
-    autoBind(this);
   }
 
   componentDidMount() {

--- a/frontend/components/site/siteSettings.js
+++ b/frontend/components/site/siteSettings.js
@@ -43,7 +43,7 @@ export class SiteSettings extends React.Component {
       engine: site.engine,
     };
 
-    autoBind(this);
+    autoBind(this, 'onChange', 'onSubmit');
   }
 
   componentDidMount() {


### PR DESCRIPTION
Assuages #1163 by only binding necessary methods.

At this point `react-autobind` is just used as a slightly nicer helper to bind functions instead of having to use `this.somefunc = this.somefunc.bind(this);`.