### PR TITLE
Create view of site users and associated back end changes

### DIFF
--- a/api/models/site.js
+++ b/api/models/site.js
@@ -61,6 +61,8 @@ function toJSON() {
     plain: true,
   }));
 
+  delete object.site_users__user_sites;
+
   object.createdAt = object.createdAt.toISOString();
   object.updatedAt = object.updatedAt.toISOString();
 

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -17,6 +17,7 @@ function toJSON() {
   delete object.githubAccessToken;
   delete object.githubUserId;
   delete object.signedInAt;
+  delete object.site_users__user_sites;
 
   object.createdAt = object.createdAt.toISOString();
   object.updatedAt = object.updatedAt.toISOString();

--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -12,9 +12,6 @@ const serializeObject = (site) => {
 };
 
 const serialize = (serializable) => {
-  // TODO: Why does this (and every other serializer) re-query for the model?
-  // In addition to seeming unnecessary, it also
-  // removes the loaded associations if any were specified
   const include = [User];
 
   if (serializable.length !== undefined) {

--- a/api/serializers/user.js
+++ b/api/serializers/user.js
@@ -1,30 +1,26 @@
-const { Build, User, Site } = require("../models")
+const { Build, User, Site } = require('../models');
+
+const serializeObject = (user) => {
+  const json = user.toJSON();
+  json.sites = user.Sites.map(site => site.toJSON());
+  json.builds = user.Builds.map(build => build.toJSON());
+  delete json.Sites;
+  delete json.Builds;
+  return json;
+};
 
 const serialize = (serializable) => {
   if (serializable.length !== undefined) {
-    const userIds = serializable.map(user => user.id)
-    const query = User.findAll({ where: { id: userIds }, include: [ Site, Build ] })
+    const userIds = serializable.map(user => user.id);
+    const query = User.findAll({ where: { id: userIds }, include: [Site, Build] });
 
-    return query.then(users => {
-      return users.map(user => serializeObject(user))
-    })
-  } else {
-    const user = serializable
-    const query = User.findById(user.id, { include: [ Site, Build ] })
-
-    return query.then(user => {
-      return serializeObject(user)
-    })
+    return query.then(users => users.map(serializeObject));
   }
-}
+  const user = serializable;
+  const query = User.findById(user.id, { include: [Site, Build] });
 
-const serializeObject = (user) => {
-  const json = user.toJSON()
-  json.sites = user.Sites.map(site => site.toJSON())
-  json.builds = user.Builds.map(build => build.toJSON())
-  delete json.Sites
-  delete json.Builds
-  return json
-}
+  return query.then(serializeObject);
+};
 
-module.exports = { serialize }
+
+module.exports = { serialize };

--- a/frontend/components/site/SiteUsers.jsx
+++ b/frontend/components/site/SiteUsers.jsx
@@ -14,7 +14,7 @@ const SiteUsers = ({ site }) => {
 
   return (
     <div>
-      <p>Users associated with {site.owner}/{site.repository}:</p>
+      <h4 className="label">Federalist users associated with this site</h4>
       <table className="usa-table-borderless">
         <thead>
           <tr>
@@ -33,6 +33,7 @@ const SiteUsers = ({ site }) => {
                 >
                   {user.username}
                 </a>
+                {' '}
                 {user.username.toLowerCase() === site.owner.toLowerCase() ? '(owner)' : ''}
               </td>
             </tr>)

--- a/frontend/components/site/SiteUsers.jsx
+++ b/frontend/components/site/SiteUsers.jsx
@@ -33,7 +33,7 @@ const SiteUsers = ({ site }) => {
                 >
                   {user.username}
                 </a>
-                {user.username === site.owner ? '(you)' : ''}
+                {user.username.toLowerCase() === site.owner.toLowerCase() ? '(owner)' : ''}
               </td>
             </tr>)
           )}

--- a/frontend/components/site/SiteUsers.jsx
+++ b/frontend/components/site/SiteUsers.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { SITE } from '../../propTypes';
+
+
+const SiteUsers = ({ site }) => {
+  // sort users by lower-cased usernames
+  const users = site.users.slice().sort((a, b) => {
+    const aName = a.username.toLowerCase();
+    const bName = b.username.toLowerCase();
+    if (aName === bName) { return 0; }
+    if (aName > bName) { return 1; }
+    return -1;
+  });
+
+  return (
+    <div>
+      <p>Users associated with {site.owner}/{site.repository}:</p>
+      <table className="usa-table-borderless">
+        <thead>
+          <tr>
+            <th>User</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map(user =>
+            (<tr key={user.username}>
+              <td>
+                <a
+                  href={`https://github.com/${user.username}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={`Visit GitHub profile for ${user.username}`}
+                >
+                  {user.username}
+                </a>
+                {user.username === site.owner ? '(you)' : ''}
+              </td>
+            </tr>)
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+SiteUsers.propTypes = {
+  site: SITE,
+};
+
+SiteUsers.defaultProps = {
+  site: null,
+};
+
+export default SiteUsers;

--- a/frontend/components/site/SiteUsers.jsx
+++ b/frontend/components/site/SiteUsers.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { SITE } from '../../propTypes';
+import { SITE, USER } from '../../propTypes';
 
 
-const SiteUsers = ({ site }) => {
+const SiteUsers = ({ site, user }) => {
   // sort users by lower-cased usernames
   const users = site.users.slice().sort((a, b) => {
     const aName = a.username.toLowerCase();
@@ -22,19 +22,19 @@ const SiteUsers = ({ site }) => {
           </tr>
         </thead>
         <tbody>
-          {users.map(user =>
-            (<tr key={user.username}>
+          {users.map(u =>
+            (<tr key={u.username}>
               <td>
                 <a
-                  href={`https://github.com/${user.username}`}
+                  href={`https://github.com/${u.username}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  title={`Visit GitHub profile for ${user.username}`}
+                  title={`Visit GitHub profile for ${u.username}`}
                 >
-                  {user.username}
+                  {u.username}
                 </a>
                 {' '}
-                {user.username.toLowerCase() === site.owner.toLowerCase() ? '(owner)' : ''}
+                {u.username.toLowerCase() === user.username.toLowerCase() ? '(you)' : ''}
               </td>
             </tr>)
           )}
@@ -46,10 +46,12 @@ const SiteUsers = ({ site }) => {
 
 SiteUsers.propTypes = {
   site: SITE,
+  user: USER,
 };
 
 SiteUsers.defaultProps = {
   site: null,
+  user: null,
 };
 
 export default SiteUsers;

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -84,6 +84,7 @@ export class SiteContainer extends React.Component {
     const publishedBranches = storeState.publishedBranches;
     const publishedFiles = storeState.publishedFiles;
     const githubBranches = storeState.githubBranches;
+    const user = storeState.user.data;
 
     const childConfigs = {
       site,
@@ -92,6 +93,7 @@ export class SiteContainer extends React.Component {
       publishedBranches,
       publishedFiles,
       githubBranches,
+      user,
     };
 
     return (

--- a/frontend/propTypes.js
+++ b/frontend/propTypes.js
@@ -1,6 +1,14 @@
 import PropTypes from 'prop-types';
 
+export const USER = PropTypes.shape({
+  id: PropTypes.number,
+  email: PropTypes.string,
+  username: PropTypes.string,
+});
+
 export const SITE = PropTypes.shape({
+  owner: PropTypes.string,
+  repository: PropTypes.string,
   demoBranch: PropTypes.string,
   demoDomain: PropTypes.string,
   config: PropTypes.string,
@@ -9,6 +17,7 @@ export const SITE = PropTypes.shape({
   defaultBranch: PropTypes.string,
   domain: PropTypes.string,
   engine: PropTypes.string,
+  users: PropTypes.arrayOf(USER),
 });
 
 export const GITHUB_BRANCHES = PropTypes.shape({

--- a/frontend/routes.js
+++ b/frontend/routes.js
@@ -6,6 +6,7 @@ import SiteList from './components/siteList/siteList';
 import SiteContainer from './components/siteContainer';
 import SiteBuilds from './components/site/siteBuilds';
 import SiteBuildLogs from './components/site/siteBuildLogs';
+import SiteUsers from './components/site/SiteUsers';
 import SitePublishedBranchesTable from './components/site/sitePublishedBranchesTable';
 import SitePublishedFilesTable from './components/site/sitePublishedFilesTable';
 import SiteSettings from './components/site/siteSettings';
@@ -28,6 +29,7 @@ export default (
           <IndexRoute component={SiteBuilds} />
           <Route path=":buildId/logs" component={SiteBuildLogs} />
         </Route>
+        <Route path="users" component={SiteUsers} />
       </Route>
       <Redirect from="*" to="/not-found" />
     </Route>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:prepare": "NODE_ENV=test yarn migrate:up && yarn build",
     "test:server": "NODE_ENV=test nyc mocha --timeout 1500 test/api/bootstrap.test.js test/api/unit/**/*.test.js test/api/requests/**/*.test.js",
     "test:client": "nyc mocha --compilers js:babel-register,jsx:babel-register --recursive ./test/frontend",
+    "test:server:watch": "watch 'yarn test:server' ./api ./test/api",
     "test:client:watch": "watch 'yarn test:client' ./frontend ./test/frontend",
     "lint": "eslint ./api/**/*.js ./config/**/*.js ./frontend/**/*.js ./migration/**/*.js ./script/**/*.js ./services/**/*.js",
     "lint:diff": "./scripts/lint-diff.sh",

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -6,7 +6,8 @@
     "engine",
     "owner",
     "repository",
-    "viewLink"
+    "viewLink",
+    "users"
   ],
   "properties": {
     "id": {
@@ -52,6 +53,16 @@
     },
     "viewLink": {
       "type": "string"
+    },
+    "users": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "username", "email"],
+        "not": {
+          "required": ["githubAccessToken", "githubUserId"]
+        }
+      }
     }
   }
 }

--- a/test/api/unit/serializers/site.test.js
+++ b/test/api/unit/serializers/site.test.js
@@ -6,6 +6,8 @@ const factory = require('../../support/factory');
 
 const SiteSerializer = require('../../../../api/serializers/site');
 
+// TODO: amend scheme to include user array
+
 describe('SiteSerializer', () => {
   describe('.serialize(serializable)', () => {
     it('should serialize an object correctly', (done) => {

--- a/test/api/unit/serializers/site.test.js
+++ b/test/api/unit/serializers/site.test.js
@@ -6,8 +6,6 @@ const factory = require('../../support/factory');
 
 const SiteSerializer = require('../../../../api/serializers/site');
 
-// TODO: amend scheme to include user array
-
 describe('SiteSerializer', () => {
   describe('.serialize(serializable)', () => {
     it('should serialize an object correctly', (done) => {

--- a/test/frontend/components/site/SiteUsers.test.jsx
+++ b/test/frontend/components/site/SiteUsers.test.jsx
@@ -9,21 +9,56 @@ describe('<SiteUsers/>', () => {
       site: {
         owner: 'test-owner',
         repository: 'test-repo',
+        users: [],
+      },
+    };
+    const wrapper = shallow(<SiteUsers {...props} />);
+    expect(wrapper.find('table')).to.have.length(1);
+  });
+
+  it('renders rows of users in order of username', () => {
+    const props = {
+      site: {
+        owner: 'test-owner',
+        repository: 'test-repo',
         users: [
-          { id: 1, email: 'boop1@beep.gov', username: 'user1' },
-          { id: 2, email: 'boop2@beep.gov', username: 'user2' },
           { id: 3, email: 'zboop@beep.gov', username: 'Zuser' },
-          { id: 4, email: 'boop4@beep.gov', username: 'user4' },
+          { id: 4, email: 'test-owner@beep.gov', username: 'test-owner' },
+          { id: 1, email: 'aboop@beep.gov', username: 'Auser' },
         ],
       },
     };
 
     const wrapper = shallow(<SiteUsers {...props} />);
-    console.log("------->")
-    console.log(wrapper);
     expect(wrapper.find('table')).to.have.length(1);
-    props.site.users.forEach((u) => {
-      expect(wrapper.find(`tr key=${u.username}`)).to.have.length(1);
+
+    const rows = wrapper.find('tbody tr');
+    expect(rows).to.have.length(3);
+
+    const expectedOrder = ['Auser', 'test-owner', 'Zuser'];
+    rows.forEach((row, i) => {
+      expect(row.find('a').prop('href')).to.equal(
+        `https://github.com/${expectedOrder[i]}`
+      );
     });
+  });
+
+  it('notes the site repository owner', () => {
+    const props = {
+      site: {
+        owner: 'test-owner',
+        repository: 'test-repo',
+        users: [
+          { id: 1, email: 'not-owner@beep.gov', username: 'not-owner' },
+          { id: 2, email: 'owner@beep.gov', username: 'test-owner' },
+        ],
+      },
+    };
+
+    const wrapper = shallow(<SiteUsers {...props} />);
+    const rows = wrapper.find('tbody tr');
+    expect(rows).to.have.length(2);
+    expect(rows.at(0).find('td').contains('(owner)')).to.be.false;
+    expect(rows.at(1).find('td').contains('(owner)')).to.be.true;
   });
 });

--- a/test/frontend/components/site/SiteUsers.test.jsx
+++ b/test/frontend/components/site/SiteUsers.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import SiteUsers from '../../../../frontend/components/site/SiteUsers';
+
+describe('<SiteUsers/>', () => {
+  it('should render', () => {
+    const props = {
+      site: {
+        owner: 'test-owner',
+        repository: 'test-repo',
+        users: [
+          { id: 1, email: 'boop1@beep.gov', username: 'user1' },
+          { id: 2, email: 'boop2@beep.gov', username: 'user2' },
+          { id: 3, email: 'zboop@beep.gov', username: 'Zuser' },
+          { id: 4, email: 'boop4@beep.gov', username: 'user4' },
+        ],
+      },
+    };
+
+    const wrapper = shallow(<SiteUsers {...props} />);
+    console.log("------->")
+    console.log(wrapper);
+    expect(wrapper.find('table')).to.have.length(1);
+    props.site.users.forEach((u) => {
+      expect(wrapper.find(`tr key=${u.username}`)).to.have.length(1);
+    });
+  });
+});

--- a/test/frontend/components/site/SiteUsers.test.jsx
+++ b/test/frontend/components/site/SiteUsers.test.jsx
@@ -18,6 +18,11 @@ describe('<SiteUsers/>', () => {
 
   it('renders rows of users in order of username', () => {
     const props = {
+      user: {
+        username: 'test-owner',
+        id: 4,
+        email: 'test-owner@beep.gov',
+      },
       site: {
         owner: 'test-owner',
         repository: 'test-repo',
@@ -43,8 +48,13 @@ describe('<SiteUsers/>', () => {
     });
   });
 
-  it('notes the site repository owner', () => {
+  it('notes the current user as "you"', () => {
     const props = {
+      user: {
+        username: 'test-owner',
+        id: 4,
+        email: 'owner@beep.gov',
+      },
       site: {
         owner: 'test-owner',
         repository: 'test-repo',
@@ -58,7 +68,7 @@ describe('<SiteUsers/>', () => {
     const wrapper = shallow(<SiteUsers {...props} />);
     const rows = wrapper.find('tbody tr');
     expect(rows).to.have.length(2);
-    expect(rows.at(0).find('td').contains('(owner)')).to.be.false;
-    expect(rows.at(1).find('td').contains('(owner)')).to.be.true;
+    expect(rows.at(0).find('td').contains('(you)')).to.be.false;
+    expect(rows.at(1).find('td').contains('(you)')).to.be.true;
   });
 });

--- a/test/frontend/components/siteContainer.test.js
+++ b/test/frontend/components/siteContainer.test.js
@@ -11,6 +11,14 @@ describe('<SiteContainer/>', () => {
     props = {
       storeState: {
         alert: {},
+        user: {
+          isLoading: false,
+          data: {
+            id: 1,
+            username: 'aUser',
+            email: 'aUser@example.gov',
+          },
+        },
         sites: {
           isLoading: false,
           data: [{


### PR DESCRIPTION
- Include array of associated `User` models in `Site` responses
- Create front end view for users associated with the targeted site.

Looks like:

<img width="1015" alt="screen shot 2017-09-25 at 8 06 51 am" src="https://user-images.githubusercontent.com/697848/30818630-863d6178-a1c8-11e7-9110-222f9beb3bc8.png">


Note that there is not currently a UI link to the new user table -- that will come in a separate PR as part of the navigation changes for #1027. It can be visited directly at `/sites/<id>/users` though.

ref #1181.