### PR TITLE
remove unused `request` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "passport-github": "0.1.5",
     "pg": "^4.5.7",
     "rc": "~0.5.0",
-    "request": "^2.61.0",
     "sequelize": "^3.30.0",
     "underscore": "^1.8.3",
     "urlsafe-base64": "^1.0.0",


### PR DESCRIPTION
We are not actually directly using the `request` module, so this PR simply removes it from `package.json`.