### PR TITLE
increase bodyParser json size limit to 2mb

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,7 +55,7 @@ app.use((req, res, next) => {
 
 app.use(express.static('public'));
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: '2mb' }));
 app.use(methodOverride());
 app.use(flash());
 app.use(responses);


### PR DESCRIPTION
to mitigate nearly silent github webhook failures due to payloads being larger than the default size [limit of 100kb](https://github.com/expressjs/body-parser/blob/master/README.md#limit-1)

cc @konklone 

ref https://github.com/18F/federalist/issues/866