### PR TITLE
markup and linting fixes for user table text

### DIFF
--- a/frontend/components/site/SiteUsers.jsx
+++ b/frontend/components/site/SiteUsers.jsx
@@ -14,15 +14,14 @@ const SiteUsers = ({ site, user }) => {
 
   return (
     <div>
-      <div className="usa-grid">
-          <div className="usa-width-one-whole">
-            <p>
-              This user table is an incomplete feature. It does not allow you to add or remove users, but instead allows you to easily audit who else has access to Federalist settings for this site.
-              New users get access to Federalist by logging into Federalist and adding the site themselves.
-            </p>
-          </div>
-        </div>
-      <br/ >
+      <p>
+        This user table is an incomplete feature.
+        It does not allow you to add or remove users,
+        but instead allows you to easily audit who else has access
+        to Federalist settings for this site.
+        New users get access to Federalist by logging into Federalist
+        and adding the site themselves.
+      </p>
       <h4 className="label">Federalist users associated with this site</h4>
       <table className="usa-table-borderless">
         <thead>


### PR DESCRIPTION
Looks like this:

<img width="818" alt="screen shot 2017-10-03 at 4 37 13 pm" src="https://user-images.githubusercontent.com/697848/31150447-299c70ac-a859-11e7-8694-fbc3227087c1.png">
