### PR TITLE
Improve Add Site UX

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,6 +1,7 @@
 {
   "reporter": [
-    "lcov"
+    "lcov",
+    "html"
   ],
   "extension": [
     ".jsx"

--- a/api/authorizers/site.js
+++ b/api/authorizers/site.js
@@ -1,30 +1,24 @@
-const { User, Site } = require("../models")
+const { User, Site } = require('../models');
 
-const authorize = (user, site) => {
-  return User.findById(user.id, { include: [ Site ] }).then(user => {
-    for (candidateSite of user.Sites) {
-      if (site.id === candidateSite.id) {
-        return Promise.resolve()
+const authorize = ({ id }, site) => (
+  User.findById(id, { include: [Site] })
+    .then((user) => {
+      const hasSite = user.Sites.some(s => site.id === s.id);
+      if (hasSite) {
+        return Promise.resolve();
       }
-    }
-    return Promise.reject(403)
-  })
-}
 
-const create = (user, params) => {
-  return Promise.resolve()
-}
+      return Promise.reject(403);
+    })
+);
 
-const findOne = (user, site) => {
-  return authorize(user, site)
-}
+// create is allowed for all
+const create = () => Promise.resolve();
 
-const update = (user, site) => {
-  return authorize(user, site)
-}
+const findOne = (user, site) => authorize(user, site);
 
-const destroy = (user, site) => {
-  return authorize(user, site)
-}
+const update = (user, site) => authorize(user, site);
 
-module.exports = { create, findOne, update, destroy }
+const destroy = (user, site) => authorize(user, site);
+
+module.exports = { create, findOne, update, destroy };

--- a/api/authorizers/user.js
+++ b/api/authorizers/user.js
@@ -1,9 +1,8 @@
 const me = (currentUser, targetUser) => {
   if (currentUser.id === targetUser.id) {
-    return Promise.resolve()
-  } else {
-    return Promise.reject(403)
+    return Promise.resolve();
   }
-}
+  return Promise.reject(403);
+};
 
-module.exports = { me }
+module.exports = { me };

--- a/api/routers/site.js
+++ b/api/routers/site.js
@@ -7,9 +7,10 @@ const csrfProtection = require('../policies/csrfProtection');
 // note that this must come before the route definitions
 router.use(csrfProtection);
 
-router.get('/site', sessionAuth, SiteController.find);
+router.get('/site', sessionAuth, SiteController.findAllForUser);
+router.post('/site/user', sessionAuth, SiteController.addUser);
 router.post('/site', sessionAuth, SiteController.create);
-router.get('/site/:id', sessionAuth, SiteController.findOne);
+router.get('/site/:id', sessionAuth, SiteController.findById);
 router.put('/site/:id', sessionAuth, SiteController.update);
 router.delete('/site/:id', sessionAuth, SiteController.destroy);
 

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -1,152 +1,157 @@
-const GitHub = require("./GitHub")
-const config = require("../../config")
-const { Build, Site, User } = require("../models")
+const GitHub = require('./GitHub');
+const config = require('../../config');
+const { Build, Site, User } = require('../models');
 
-const createSite = ({ user, siteParams }) => {
-  const template = siteParams.template
-  siteParams = paramsForNewSite(siteParams)
+function paramsForNewSite(params) {
+  return {
+    owner: params.owner ? params.owner.toLowerCase() : null,
+    repository: params.repository ? params.repository.toLowerCase() : null,
+    defaultBranch: params.defaultBranch,
+    engine: params.engine,
+  };
+}
 
-  if (template) {
-    return createSiteFromTemplate({ siteParams, template, user })
-  } else {
-    return createSiteFromExistingRepo({ siteParams, user })
+function templateForTemplateName(templateName) {
+  const template = config.templates[templateName];
+  if (!template) {
+    throw new Error(`No such template: ${templateName}`);
   }
+  return template;
 }
 
-checkExistingGithubRepository = ({ user, owner, repository, site }) => {
-  return GitHub.getRepository(user, owner, repository).then(repo => {
-    if (!repo) {
-      throw {
-        message: `The repository ${owner}/${repository} does not exist.`,
-        status: 400,
-      }
-    }
-    if (!repo.permissions.admin && !site) {
-      throw {
-        message: "You do not have admin access to this repository",
-        status: 400,
-      }
-    }
-    if (!repo.permissions.push) {
-      throw {
-        message: "You do not have write access to this repository",
-        status: 400,
-      }
-    }
-    return true
-  })
+function paramsForNewBuildSource(templateName) {
+  if (templateName) {
+    const template = templateForTemplateName(templateName);
+    return { repository: template.repo, owner: template.owner };
+  }
+  return null;
 }
 
-checkForExistingSiteErrors = ({ site, user }) => {
-  const existingUser = site.Users.find(candidate => candidate.id === user.id)
+function paramsForNewBuild({ user, site, template }) {
+  return {
+    user: user.id,
+    site: site.id,
+    branch: site.defaultBranch,
+    source: paramsForNewBuildSource(template),
+  };
+}
+
+function checkExistingGithubRepository({ user, owner, repository, site }) {
+  return GitHub.getRepository(user, owner, repository)
+    .then((repo) => {
+      if (!repo) {
+        throw {
+          message: `The repository ${owner}/${repository} does not exist.`,
+          status: 400,
+        };
+      }
+      if (!repo.permissions.admin && !site) {
+        throw {
+          message: 'You do not have admin access to this repository',
+          status: 400,
+        };
+      }
+      if (!repo.permissions.push) {
+        throw {
+          message: 'You do not have write access to this repository',
+          status: 400,
+        };
+      }
+      return true;
+    });
+}
+
+function checkForExistingSiteErrors({ site, user }) {
+  const existingUser = site.Users.find(candidate => candidate.id === user.id);
   if (existingUser) {
     throw {
       message: "You've already added this site to Federalist",
-      status: 400
-    }
+      status: 400,
+    };
   }
-  return site
+  return site;
 }
 
-createAndBuildSite = ({ siteParams, user }) => {
-  let site = Site.build(siteParams)
+function createAndBuildSite({ siteParams, user }) {
+  let site = Site.build(siteParams);
 
-  return site.validate().then(error => {
-    if (error) {
-      throw error
-    }
-    return GitHub.setWebhook(site, user.id)
-  }).then(() => {
-    return site.save()
-  }).then(createdSite => {
-    site = createdSite
+  return site.validate()
+    .then((error) => {
+      if (error) {
+        throw error;
+      }
+      return GitHub.setWebhook(site, user.id);
+    })
+    .then(() => site.save()).then((createdSite) => {
+      site = createdSite;
 
-    const buildParams = paramsForNewBuild({ site, user })
-    return Build.create(buildParams)
-  }).then(() => {
-    return site
-  })
+      const buildParams = paramsForNewBuild({ site, user });
+      return Build.create(buildParams);
+    })
+    .then(() => site);
 }
 
-const createSiteFromExistingRepo = ({ siteParams, user }) => {
-  let site
-  const { owner, repository } = siteParams
+function createSiteFromExistingRepo({ siteParams, user }) {
+  let site;
+  const { owner, repository } = siteParams;
 
   return Site.findOne({
-    where: { owner: owner, repository: repository },
-    include: [ User ],
-  }).then(model => {
-    site = model
-    return checkExistingGithubRepository({ user, owner, repository, site })
-  }).then(() => {
-    if (site) {
-      return checkForExistingSiteErrors({ site, user })
-    } else {
-      return createAndBuildSite({ siteParams, user })
-    }
-  }).then(model => {
-    site = model
-    return site.addUser(user.id)
-  }).then(() => site)
+    where: { owner, repository },
+    include: [User],
+  })
+    .then((model) => {
+      site = model;
+      return checkExistingGithubRepository({ user, owner, repository, site });
+    })
+    .then(() => {
+      if (site) {
+        return checkForExistingSiteErrors({ site, user });
+      }
+      return createAndBuildSite({ siteParams, user });
+    })
+    .then((model) => {
+      site = model;
+      return site.addUser(user.id);
+    })
+    .then(() => site);
 }
 
-const createSiteFromTemplate = ({ siteParams, user, template }) => {
-  let site = Site.build(siteParams)
-  site.engine = "jekyll"
-  site.defaultBranch = templateForTemplateName(template).branch
-  const { owner, repository } = siteParams
+function createSiteFromTemplate({ siteParams, user, template }) {
+  let site = Site.build(siteParams);
+  site.engine = 'jekyll';
+  site.defaultBranch = templateForTemplateName(template).branch;
+  const { owner, repository } = siteParams;
 
-  return site.validate().then(error => {
-    if (error) {
-      throw error
-    }
-    return GitHub.createRepo(user, owner, repository)
-  }).then(() => {
-    return GitHub.setWebhook(site, user)
-  }).then(() => {
-    return site.save()
-  }).then(createdSite => {
-    site = createdSite
-    return site.addUser(user.id)
-  }).then(() => {
-    const buildParams = paramsForNewBuild({ user, site, template })
-    return Build.create(buildParams)
-  }).then(() => site)
+  return site.validate()
+    .then((error) => {
+      if (error) {
+        throw error;
+      }
+      return GitHub.createRepo(user, owner, repository);
+    })
+    .then(() => GitHub.setWebhook(site, user))
+    .then(() => site.save())
+    .then((createdSite) => {
+      site = createdSite;
+      return site.addUser(user.id);
+    })
+    .then(() => {
+      const buildParams = paramsForNewBuild({ user, site, template });
+      return Build.create(buildParams);
+    })
+    .then(() => site);
 }
 
-const paramsForNewBuild = ({ user, site, template }) => ({
-  user: user.id,
-  site: site.id,
-  branch: site.defaultBranch,
-  source: paramsForNewBuildSource(template),
-})
+function createSite({ user, siteParams }) {
+  const template = siteParams.template;
+  const newSiteParams = paramsForNewSite(siteParams);
 
-const paramsForNewBuildSource = (templateName) => {
-  if (templateName) {
-    const template = templateForTemplateName(templateName)
-    return { repository: template.repo, owner: template.owner }
+  if (template) {
+    return createSiteFromTemplate({ siteParams: newSiteParams, template, user });
   }
-}
-
-const paramsForNewSite = (params) => ({
-  owner: params.owner ? params.owner.toLowerCase() : undefined,
-  repository: params.repository ? params.repository.toLowerCase() : undefined,
-  defaultBranch: params.defaultBranch,
-  engine: params.engine,
-})
-
-const siteExists = ({ owner, repository }) => {
-  return Promise.resolve(false)
-}
-
-const templateForTemplateName = (templateName) => {
-  const template = config.templates[templateName]
-  if (!template) {
-    throw new Error(`No such template: ${templateName}`)
-  }
-  return template
+  return createSiteFromExistingRepo({ siteParams: newSiteParams, user });
 }
 
 module.exports = {
   createSite,
-}
+};

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -91,6 +91,31 @@ function createAndBuildSite({ siteParams, user }) {
     .then(() => site);
 }
 
+
+function addUserToSite(owner, repository, user) {
+  let site;
+
+  return Site.findOne({
+    where: { owner, repository },
+    include: [User],
+  })
+    .then((model) => {
+      if (!model) {
+        throw {
+          message: `Site for ${owner}/${repository} does not yet exist in Federalist`,
+          status: 404,
+        };
+      }
+      site = model;
+      return site;
+    })
+    .then(() => checkExistingGithubRepository({ user, owner, repository, site }))
+    .then(() => checkForExistingSiteErrors({ site, user }))
+    .then(() => site.addUser(user.id))
+    .then(() => site);
+}
+
+
 function createSiteFromExistingRepo({ siteParams, user }) {
   let site;
   const { owner, repository } = siteParams;
@@ -107,6 +132,7 @@ function createSiteFromExistingRepo({ siteParams, user }) {
       if (site) {
         return checkForExistingSiteErrors({ site, user });
       }
+
       return createAndBuildSite({ siteParams, user });
     })
     .then((model) => {
@@ -154,4 +180,5 @@ function createSite({ user, siteParams }) {
 
 module.exports = {
   createSite,
+  addUserToSite,
 };

--- a/frontend/actions/actionCreators/addNewSiteFieldsActions.js
+++ b/frontend/actions/actionCreators/addNewSiteFieldsActions.js
@@ -1,0 +1,16 @@
+
+const showAddNewSiteFieldsType = 'ADD_NEW_SITE_FIELDS_SHOW';
+const hideAddNewSiteFieldsType = 'ADD_NEW_SITE_FIELDS_HIDE';
+
+const showAddNewSiteFields = () => ({
+  type: showAddNewSiteFieldsType,
+});
+
+const hideAddNewSiteFields = () => ({
+  type: hideAddNewSiteFieldsType,
+});
+
+export {
+  showAddNewSiteFields, showAddNewSiteFieldsType,
+  hideAddNewSiteFields, hideAddNewSiteFieldsType,
+};

--- a/frontend/actions/actionCreators/alertActions.js
+++ b/frontend/actions/actionCreators/alertActions.js
@@ -1,31 +1,31 @@
-const authErrorType = "AUTH_ERROR";
-const httpErrorType = "HTTP_ERROR";
-const httpSuccessType = "HTTP_SUCCESS";
-const setStaleType = "SET_STALE";
-const clearType = "CLEAR";
+const authErrorType = 'AUTH_ERROR';
+const httpErrorType = 'HTTP_ERROR';
+const httpSuccessType = 'HTTP_SUCCESS';
+const setStaleType = 'SET_STALE';
+const clearType = 'CLEAR';
 
 const authError = () => ({
-  type: authErrorType
+  type: authErrorType,
 });
 
 const httpError = message => ({
   type: httpErrorType,
   status: 'error',
-  message
+  message,
 });
 
 const httpSuccess = message => ({
   type: httpSuccessType,
   status: 'info',
-  message
+  message,
 });
 
 const setStale = () => ({
-  type: setStaleType
+  type: setStaleType,
 });
 
 const clear = () => ({
-  type: clearType
+  type: clearType,
 });
 
 export {
@@ -33,5 +33,5 @@ export {
   httpError, httpErrorType,
   httpSuccess, httpSuccessType,
   setStale, setStaleType,
-  clear, clearType
+  clear, clearType,
 };

--- a/frontend/actions/actionCreators/siteActions.js
+++ b/frontend/actions/actionCreators/siteActions.js
@@ -1,32 +1,32 @@
-const sitesFetchStartedType = "SITES_FETCH_STARTED"
-const sitesReceivedType = "SITES_RECEIVED";
-const siteAddedType = "SITE_ADDED";
-const siteUpdatedType = "SITE_UPDATED";
-const siteDeletedType = "SITE_DELETED";
+const sitesFetchStartedType = 'SITES_FETCH_STARTED';
+const sitesReceivedType = 'SITES_RECEIVED';
+const siteAddedType = 'SITE_ADDED';
+const siteUpdatedType = 'SITE_UPDATED';
+const siteDeletedType = 'SITE_DELETED';
 
 const sitesFetchStarted = () => ({
   type: sitesFetchStartedType,
-})
+});
 
 const sitesReceived = sites => ({
   type: sitesReceivedType,
-  sites
+  sites,
 });
 
 const siteAdded = site => ({
   type: siteAddedType,
-  site
+  site,
 });
 
 const siteUpdated = site => ({
   type: siteUpdatedType,
   siteId: site.id,
-  site
+  site,
 });
 
 const siteDeleted = siteId => ({
   type: siteDeletedType,
-  siteId
+  siteId,
 });
 
 export {

--- a/frontend/actions/actionCreators/siteActions.js
+++ b/frontend/actions/actionCreators/siteActions.js
@@ -3,6 +3,7 @@ const sitesReceivedType = 'SITES_RECEIVED';
 const siteAddedType = 'SITE_ADDED';
 const siteUpdatedType = 'SITE_UPDATED';
 const siteDeletedType = 'SITE_DELETED';
+const siteUserAddedType = 'SITE_USER_ADDED';
 
 const sitesFetchStarted = () => ({
   type: sitesFetchStartedType,
@@ -29,10 +30,16 @@ const siteDeleted = siteId => ({
   siteId,
 });
 
+const siteUserAdded = site => ({
+  type: siteUserAddedType,
+  site,
+});
+
 export {
   sitesFetchStarted, sitesFetchStartedType,
   sitesReceived, sitesReceivedType,
   siteAdded, siteAddedType,
   siteUpdated, siteUpdatedType,
   siteDeleted, siteDeletedType,
+  siteUserAdded, siteUserAddedType,
 };

--- a/frontend/actions/actionCreators/userActions.js
+++ b/frontend/actions/actionCreators/userActions.js
@@ -1,14 +1,14 @@
-const userFetchStartedType = "USER_FETCH_STARTED"
-const userReceivedType = "USER_RECEIVED";
+const userFetchStartedType = 'USER_FETCH_STARTED';
+const userReceivedType = 'USER_RECEIVED';
 
 const userFetchStarted = () => ({
   type: userFetchStartedType,
-})
+});
 
 const userReceived = user => ({
   type: userReceivedType,
   user,
-})
+});
 
 export {
   userFetchStarted, userFetchStartedType,

--- a/frontend/actions/addNewSiteFieldsActions.js
+++ b/frontend/actions/addNewSiteFieldsActions.js
@@ -1,0 +1,9 @@
+import {
+  dispatchHideAddNewSiteFieldsAction,
+} from './dispatchActions';
+
+export default {
+  hideAddNewSiteFields() {
+    return dispatchHideAddNewSiteFieldsAction();
+  },
+};

--- a/frontend/actions/dispatchActions.js
+++ b/frontend/actions/dispatchActions.js
@@ -5,7 +5,14 @@ import {
   siteAdded as createSiteAddedAction,
   siteUpdated as createSiteUpdatedAction,
   siteDeleted as createSiteDeletedAction,
+  siteUserAdded as createSiteUserAddedAction,
 } from './actionCreators/siteActions';
+
+import {
+  showAddNewSiteFields as createShowAddNewSiteFieldsAction,
+  hideAddNewSiteFields as createHideAddNewSiteFieldsAction,
+} from './actionCreators/addNewSiteFieldsActions';
+
 import { pushHistory } from './routeActions';
 
 const updateRouterToSitesUri = () => {
@@ -32,6 +39,18 @@ const dispatchSiteDeletedAction = (siteId) => {
   dispatch(createSiteDeletedAction(siteId));
 };
 
+const dispatchUserAddedToSiteAction = (site) => {
+  dispatch(createSiteUserAddedAction(site));
+};
+
+const dispatchShowAddNewSiteFieldsAction = () => {
+  dispatch(createShowAddNewSiteFieldsAction());
+};
+
+const dispatchHideAddNewSiteFieldsAction = () => {
+  dispatch(createHideAddNewSiteFieldsAction());
+};
+
 export {
   updateRouterToSitesUri,
   dispatchSitesFetchStartedAction,
@@ -39,4 +58,7 @@ export {
   dispatchSiteAddedAction,
   dispatchSiteUpdatedAction,
   dispatchSiteDeletedAction,
+  dispatchUserAddedToSiteAction,
+  dispatchShowAddNewSiteFieldsAction,
+  dispatchHideAddNewSiteFieldsAction,
 };

--- a/frontend/actions/dispatchActions.js
+++ b/frontend/actions/dispatchActions.js
@@ -9,26 +9,26 @@ import {
 import { pushHistory } from './routeActions';
 
 const updateRouterToSitesUri = () => {
-  pushHistory(`/sites`);
+  pushHistory('/sites');
 };
 
 const dispatchSitesFetchStartedAction = () => {
-  dispatch(createSitesFetchStartedAction())
-}
+  dispatch(createSitesFetchStartedAction());
+};
 
-const dispatchSitesReceivedAction = sites => {
+const dispatchSitesReceivedAction = (sites) => {
   dispatch(createSitesReceivedAction(sites));
 };
 
-const dispatchSiteAddedAction = site => {
+const dispatchSiteAddedAction = (site) => {
   dispatch(createSiteAddedAction(site));
 };
 
-const dispatchSiteUpdatedAction = site => {
+const dispatchSiteUpdatedAction = (site) => {
   dispatch(createSiteUpdatedAction(site));
 };
 
-const dispatchSiteDeletedAction = siteId => {
+const dispatchSiteDeletedAction = (siteId) => {
   dispatch(createSiteDeletedAction(siteId));
 };
 

--- a/frontend/actions/routeActions.js
+++ b/frontend/actions/routeActions.js
@@ -1,8 +1,8 @@
 import { dispatch } from '../store';
 import {
   pushRouterHistory as createPushHistoryRouterAction,
-  replaceRouterHistory as createReplaceHistoryRouterAction
-} from "./actionCreators/navigationActions";
+  replaceRouterHistory as createReplaceHistoryRouterAction,
+} from './actionCreators/navigationActions';
 
 const pushHistory = (path) => {
   dispatch(createPushHistoryRouterAction(path));

--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -8,6 +8,8 @@ import {
   dispatchSiteAddedAction,
   dispatchSiteUpdatedAction,
   dispatchSiteDeletedAction,
+  dispatchUserAddedToSiteAction,
+  dispatchShowAddNewSiteFieldsAction,
 } from './dispatchActions';
 
 
@@ -29,6 +31,16 @@ export default {
       .then(dispatchSiteAddedAction)
       .then(updateRouterToSitesUri)
       .catch(alertError);
+  },
+
+  addUserToSite({ owner, repository }) {
+    return federalist.addUserToSite({ owner, repository })
+      .then(dispatchUserAddedToSiteAction)
+      .then(updateRouterToSitesUri)
+      // rather than display an alert error for this action
+      // we'll instead want to show the additional fields necessary
+      // for adding a completely new site to Federalist
+      .catch(dispatchShowAddNewSiteFieldsAction);
   },
 
   updateSite(site, data) {

--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -37,10 +37,19 @@ export default {
     return federalist.addUserToSite({ owner, repository })
       .then(dispatchUserAddedToSiteAction)
       .then(updateRouterToSitesUri)
-      // rather than display an alert error for this action
-      // we'll instead want to show the additional fields necessary
-      // for adding a completely new site to Federalist
-      .catch(dispatchShowAddNewSiteFieldsAction);
+      .catch((err) => {
+        // Getting a 404 here signals that the site does not
+        // yet exist in Federalist, so we want to show the
+        // additional Add New Site fields
+        if (err.response && err.response.status === 404) {
+          dispatchShowAddNewSiteFieldsAction(err);
+        } else {
+          // otherwise something else went wrong so redirect and
+          // show the error like in the other actions
+          updateRouterToSitesUri();
+          alertError(err);
+        }
+      });
   },
 
   updateSite(site, data) {

--- a/frontend/components/AddSite/AddRepoSiteForm.jsx
+++ b/frontend/components/AddSite/AddRepoSiteForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { Link } from 'react-router';
 
-import SelectSiteEngine from '../selectSiteEngine';
+import SelectSiteEngine from '../SelectSiteEngine';
 
 const propTypes = {
   showAddNewSiteFields: PropTypes.bool,
@@ -59,8 +59,10 @@ export const AddRepoSiteForm = ({ pristine, handleSubmit, showAddNewSiteFields }
               </div>
             </div>
             <div className="form-group">
+              <label htmlFor="engine">Static site engine</label>
               <Field
                 name="engine"
+                id="engine"
                 component={p =>
                   <SelectSiteEngine
                     value={p.input.value}

--- a/frontend/components/AddSite/AddRepoSiteForm.jsx
+++ b/frontend/components/AddSite/AddRepoSiteForm.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Field, reduxForm } from 'redux-form';
+import { Link } from 'react-router';
+
+import SelectSiteEngine from '../selectSiteEngine';
+
+const propTypes = {
+  showAddNewSiteFields: PropTypes.bool,
+
+  // the following props are from reduxForm:
+  handleSubmit: PropTypes.func.isRequired,
+  pristine: PropTypes.bool.isRequired,
+};
+
+const defaultProps = {
+  showAddNewSiteFields: false,
+};
+
+export const AddRepoSiteForm = ({ pristine, handleSubmit, showAddNewSiteFields }) => (
+  <form onSubmit={handleSubmit}>
+    <div className="usa-grid">
+      <div className="usa-width-one-half">
+        <div className="form-group">
+          <label htmlFor="owner">Repository Owner&#39;s Username or Org name</label>
+          <Field
+            component="input"
+            type="text"
+            id="owner"
+            className="form-control"
+            name="owner"
+            readOnly={showAddNewSiteFields}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="repository">Repository&#39;s Name</label>
+          <Field
+            component="input"
+            type="text"
+            className="form-control"
+            name="repository"
+            id="repository"
+            readOnly={showAddNewSiteFields}
+            required
+          />
+        </div>
+        {
+          showAddNewSiteFields && (
+          <div className="add-repo-site-additional-fields">
+            <div className="usa-alert usa-alert-info" role="alert">
+              <div className="usa-alert-body">
+                <h3 className="usa-alert-heading">New Site</h3>
+                <p className="usa-alert-text">
+                  Looks like this site is completely new to Federalist!
+                  <br />
+                  Please fill out these additional fields to complete the process.
+                </p>
+              </div>
+            </div>
+            <div className="form-group">
+              <Field
+                name="engine"
+                component={p =>
+                  <SelectSiteEngine
+                    value={p.input.value}
+                    onChange={p.input.onChange}
+                    className="form-control"
+                  />
+                }
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="defaultBranch">Primary branch</label>
+              <Field
+                component="input"
+                type="text"
+                id="defaultBranch"
+                className="form-control"
+                name="defaultBranch"
+                required
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+    <div className="usa-grid">
+      <div className="usa-width-one-whole">
+        <Link
+          role="button"
+          to="/sites"
+          className="usa-button usa-button-secondary"
+        >
+          Cancel
+        </Link>
+        <button
+          type="submit"
+          className="usa-button usa-button-primary"
+          style={{ display: 'inline-block' }}
+          disabled={pristine}
+        >
+          Submit repository-based site
+        </button>
+      </div>
+    </div>
+  </form>
+);
+
+AddRepoSiteForm.propTypes = propTypes;
+AddRepoSiteForm.defaultProps = defaultProps;
+
+// create a higher-order component with reduxForm and export that
+export default reduxForm({ form: 'addRepoSite' })(AddRepoSiteForm);

--- a/frontend/components/SelectSiteEngine.jsx
+++ b/frontend/components/SelectSiteEngine.jsx
@@ -22,19 +22,15 @@ function makeOptions(opts) {
   ));
 }
 
-const SelectSiteEngine = ({ value, onChange }) => (
-  <div>
-    <label htmlFor="engine">Static site engine</label>
-    <select
-      name="engine"
-      id="engine"
-      className="form-control"
-      value={value}
-      onChange={onChange}
-    >
-      {makeOptions(availableEngines)}
-    </select>
-  </div>
+const SelectSiteEngine = ({ value, onChange, ...props }) => (
+  <select
+    {...props}
+    className="form-control"
+    value={value}
+    onChange={onChange}
+  >
+    {makeOptions(availableEngines)}
+  </select>
 );
 
 

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 
-import SelectSiteEngine from '../../selectSiteEngine';
+import SelectSiteEngine from '../../SelectSiteEngine';
 
 const propTypes = {
   onDelete: PropTypes.func.isRequired,
@@ -36,8 +36,10 @@ export const AdvancedSiteSettings = ({
   <form className="settings-form settings-form-advanced" onSubmit={handleSubmit}>
     <div className="usa-grid">
       <div className="usa-width-one-whole">
+        <label htmlFor="engine">Static site engine</label>
         <Field
           name="engine"
+          id="engine"
           component={p =>
             <SelectSiteEngine
               value={p.input.value}

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -56,7 +56,7 @@ export const AdvancedSiteSettings = ({
           <h3 className="well-heading">Site configuration</h3>
           <p className="well-text">
             Add additional configuration in yaml to be added to your
-            <code>_config.yml</code> file when we build your site&apos;s default branch.
+            <code>_config.yml</code> file when we build your site&apos;s primary branch.
           </p>
           <Field
             component="textarea"
@@ -125,6 +125,7 @@ export const AdvancedSiteSettings = ({
     </div>
 
     <div className="usa-grid">
+      <h3>Danger Zone</h3>
       <div className="usa-alert usa-alert-delete" role="alert">
         Delete this site from Federalist?
         <button

--- a/frontend/reducers.js
+++ b/frontend/reducers.js
@@ -9,6 +9,7 @@ import sites from './reducers/sites';
 import builds from './reducers/builds';
 import user from './reducers/user';
 import githubBranches from './reducers/githubBranches';
+import showAddNewSiteFields from './reducers/showAddNewSiteFields';
 
 
 export default {
@@ -22,5 +23,6 @@ export default {
   githubBranches,
   notifications,
   form,
+  showAddNewSiteFields,
   FRONTEND_CONFIG: (state = {}) => state,
 };

--- a/frontend/reducers/showAddNewSiteFields.js
+++ b/frontend/reducers/showAddNewSiteFields.js
@@ -1,0 +1,18 @@
+
+import {
+  showAddNewSiteFieldsType as ADD_NEW_SITE_FIELDS_SHOW,
+  hideAddNewSiteFieldsType as ADD_NEW_SITE_FIELDS_HIDE,
+} from '../actions/actionCreators/addNewSiteFieldsActions';
+
+const initialState = false;
+
+export default function showAddNewSiteFields(state = initialState, action) {
+  switch (action.type) {
+    case ADD_NEW_SITE_FIELDS_SHOW:
+      return true;
+    case ADD_NEW_SITE_FIELDS_HIDE:
+      return false;
+    default:
+      return state;
+  }
+}

--- a/frontend/reducers/sites.js
+++ b/frontend/reducers/sites.js
@@ -9,52 +9,48 @@ import {
 
 const initialState = { isLoading: false };
 
+const mapPropertyToMatchingSite = (data, siteId, properties) => data.map((site) => {
+  if (site.id !== siteId) return site;
+  return Object.assign({}, site, properties);
+});
+
 export default function sites(state = initialState, action) {
   switch (action.type) {
 
-  case SITES_FETCH_STARTED:
-    return { isLoading: true }
+    case SITES_FETCH_STARTED:
+      return { isLoading: true };
 
-  case SITES_RECEIVED:
-    return { isLoading: false, data: action.sites || [] }
+    case SITES_RECEIVED:
+      return { isLoading: false, data: action.sites || [] };
 
-  case SITE_ADDED:
-    if (action.site) {
+    case SITE_ADDED:
+      if (action.site) {
+        return {
+          isLoading: false,
+          data: state.data.concat(action.site),
+        };
+      }
+      return state;
+
+    case SITE_UPDATED:
       return {
         isLoading: false,
-        data: state.data.concat(action.site),
-      }
-    } else {
-      return state
-    }
+        data: mapPropertyToMatchingSite(state.data, action.siteId, action.site),
+      };
 
-  case SITE_UPDATED:
-    return {
-      isLoading: false,
-      data: mapPropertyToMatchingSite(state.data, action.siteId, action.site),
-    }
+    case SITE_BRANCHES_RECEIVED:
+      return {
+        isLoading: false,
+        data: mapPropertyToMatchingSite(state.data, action.siteId, { branches: action.branches }),
+      };
 
-  case SITE_BRANCHES_RECEIVED:
-    const branches = action.branches;
-    return {
-      isLoading: false,
-      data: mapPropertyToMatchingSite(state.data, action.siteId, { branches }),
-    }
+    case SITE_DELETED:
+      return {
+        isLoading: false,
+        data: state.data.filter(site => site.id !== action.siteId),
+      };
 
-  case SITE_DELETED:
-    return {
-      isLoading: false,
-      data: state.data.filter((site) => site.id != action.siteId),
-    }
-
-  default:
-    return state;
+    default:
+      return state;
   }
 }
-
-const mapPropertyToMatchingSite = (data, siteId, properties) => {
-  return data.map((site) => {
-    if (site.id !== siteId) return site;
-    return Object.assign({}, site, properties);
-  });
-};

--- a/frontend/reducers/sites.js
+++ b/frontend/reducers/sites.js
@@ -5,6 +5,7 @@ import {
   siteUpdatedType as SITE_UPDATED,
   siteDeletedType as SITE_DELETED,
   siteBranchesReceivedType as SITE_BRANCHES_RECEIVED,
+  siteUserAddedType as SITE_USER_ADDED,
 } from '../actions/actionCreators/siteActions';
 
 const initialState = { isLoading: false };
@@ -49,6 +50,15 @@ export default function sites(state = initialState, action) {
         isLoading: false,
         data: state.data.filter(site => site.id !== action.siteId),
       };
+
+    case SITE_USER_ADDED:
+      if (action.site) {
+        return {
+          isLoading: false,
+          data: state.data.concat(action.site),
+        };
+      }
+      return state;
 
     default:
       return state;

--- a/frontend/reducers/user.js
+++ b/frontend/reducers/user.js
@@ -5,30 +5,32 @@ import {
 
 const initialState = {
   isLoading: false,
-}
+};
 
 export default function user(state = initialState, action) {
   switch (action.type) {
-  case USER_FETCH_STARTED:
-    return {
-      isLoading: true,
-    }
-  case USER_RECEIVED:
-    if (!action.user) {
-      return false
-    }
+    case USER_FETCH_STARTED:
+      return {
+        isLoading: true,
+      };
+    case USER_RECEIVED:
+      // TODO: When does this happen? Should this happen, or should
+      // an error be thrown instead?
+      if (!action.user) {
+        return false;
+      }
 
-    return {
-      isLoading: false,
-      data: {
-        id: action.user.id,
-        username: action.user.username,
-        email: action.user.email,
-        createdAt: action.user.createdAt,
-        updatedAt: action.user.updatedAt
-      },
-    }
-  default:
-    return state;
+      return {
+        isLoading: false,
+        data: {
+          id: action.user.id,
+          username: action.user.username,
+          email: action.user.email,
+          createdAt: action.user.createdAt,
+          updatedAt: action.user.updatedAt,
+        },
+      };
+    default:
+      return state;
   }
 }

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -6,7 +6,7 @@ import alertActions from '../actions/alertActions';
 export const API = '/v0';
 
 export default {
-  fetch(endpoint, params = {}) {
+  fetch(endpoint, params = {}, { handleHttpError = true } = {}) {
     const csrfToken = typeof window !== 'undefined' ?
       window.CSRF_TOKEN : global.CSRF_TOKEN;
 
@@ -21,7 +21,11 @@ export default {
 
     return fetch(url, finalParams)
       .catch((error) => {
-        alertActions.httpError(error.message);
+        if (handleHttpError) {
+          alertActions.httpError(error.message);
+        } else {
+          throw error;
+        }
       });
   },
 
@@ -47,6 +51,20 @@ export default {
 
   fetchUser() {
     return this.fetch('me');
+  },
+
+  addUserToSite({ owner, repository }) {
+    return this.fetch('site/user', {
+      method: 'POST',
+      data: {
+        owner,
+        repository,
+      },
+    }, {
+      // we want to handle the error elsewhere in order
+      // to show the additional AddSite fields
+      handleHttpError: false,
+    });
   },
 
   addSite(site) {

--- a/test/api/requests/webhook.test.js
+++ b/test/api/requests/webhook.test.js
@@ -1,239 +1,257 @@
-const crypto = require('crypto')
-const expect = require("chai").expect
-const nock = require("nock")
-const request = require("supertest")
-const app = require("../../../app")
-const config = require("../../../config")
-const factory = require("../support/factory")
-const githubAPINocks = require("../support/githubAPINocks")
-const { Build, Site, User } = require("../../../api/models")
+const crypto = require('crypto');
+const expect = require('chai').expect;
+const nock = require('nock');
+const request = require('supertest');
+const app = require('../../../app');
+const config = require('../../../config');
+const factory = require('../support/factory');
+const githubAPINocks = require('../support/githubAPINocks');
+const { Build, Site, User } = require('../../../api/models');
 
 
-describe("Webhook API", () => {
+describe('Webhook API', () => {
   const signWebhookPayload = (payload) => {
-    const secret = config.webhook.secret
-    const blob = JSON.stringify(payload)
-    return 'sha1=' + crypto.createHmac('sha1', secret).update(blob).digest('hex')
-  }
+    const secret = config.webhook.secret;
+    const blob = JSON.stringify(payload);
+    return `sha1=${crypto.createHmac('sha1', secret).update(blob).digest('hex')}`;
+  };
 
   const buildWebhookPayload = (user, site) => ({
-    ref: "refs/heads/master",
+    ref: 'refs/heads/master',
     commits: [{
-      id: "456def"
+      id: '456def',
     }],
-    after: "456def",
+    after: '456def',
     sender: {
       login: user.username,
     },
     repository: {
-      full_name: `${site.owner}/${site.repository}`
-    }
-  })
+      full_name: `${site.owner}/${site.repository}`,
+    },
+  });
 
-  describe("POST /webhook/github", () => {
+  describe('POST /webhook/github', () => {
     beforeEach(() => {
-      nock.cleanAll()
-      githubAPINocks.status()
-    })
+      nock.cleanAll();
+      githubAPINocks.status();
+    });
 
-    it("should create a new site build for the sender", done => {
-      let site, user, payload
+    it('should create a new site build for the sender', (done) => {
+      let site;
+      let user;
+      let payload;
 
-      factory.site().then(site => {
-        return Site.findById(site.id, { include: [ User ] })
-      }).then(model => {
-        site = model
-        user = site.Users[0]
-        return Build.findAll({ where: { site: site.id, user: user.id } })
-      }).then(builds => {
-        expect(builds).to.have.length(0)
+      factory.site()
+        .then(s => Site.findById(s.id, { include: [User] }))
+        .then((model) => {
+          site = model;
+          user = site.Users[0];
+          return Build.findAll({ where: { site: site.id, user: user.id } });
+        })
+        .then((builds) => {
+          expect(builds).to.have.length(0);
 
-        payload = buildWebhookPayload(user, site)
-        const signature = signWebhookPayload(payload)
+          payload = buildWebhookPayload(user, site);
+          const signature = signWebhookPayload(payload);
 
-        return request(app)
-          .post("/webhook/github")
-          .send(payload)
-          .set({
-            "X-GitHub-Event": "push",
-            "X-Hub-Signature": signature,
-            "X-GitHub-Delivery": "123abc"
-          })
-          .expect(200)
-      }).then(response => {
-        return Build.findAll({
+          return request(app)
+            .post('/webhook/github')
+            .send(payload)
+            .set({
+              'X-GitHub-Event': 'push',
+              'X-Hub-Signature': signature,
+              'X-GitHub-Delivery': '123abc',
+            })
+            .expect(200);
+        })
+        .then(() => Build.findAll({
           where: {
             site: site.id,
             user: user.id,
-            branch: payload.ref.split("/")[2],
+            branch: payload.ref.split('/')[2],
             commitSha: payload.after,
-          }
+          },
+        }))
+        .then((builds) => {
+          expect(builds).to.have.length(1);
+          done();
         })
-      }).then(builds => {
-        expect(builds).to.have.length(1)
-        done()
-      }).catch(done)
-    })
+        .catch(done);
+    });
 
-    it("should create a user associated with the site for the sender if no user exists", done => {
-      let site
-      const username = crypto.randomBytes(3).toString("hex")
+    it('should create a user associated with the site for the sender if no user exists', (done) => {
+      let site;
+      const username = crypto.randomBytes(3).toString('hex');
 
-      factory.site().then(model => {
-        site = model
+      factory.site()
+        .then((model) => {
+          site = model;
 
-        const payload = buildWebhookPayload({ username: username }, site)
-        const signature = signWebhookPayload(payload)
+          const payload = buildWebhookPayload({ username }, site);
+          const signature = signWebhookPayload(payload);
 
-        return request(app)
-          .post("/webhook/github")
-          .send(payload)
-          .set({
-            "X-GitHub-Event": "push",
-            "X-Hub-Signature": signature,
-            "X-GitHub-Delivery": "123abc"
-          })
-          .expect(200)
-      }).then(response => {
-        return Build.findById(response.body.id, { include: [ User ] })
-      }).then(build => {
-        expect(build.User.username).to.equal(username)
-        return User.findById(build.User.id, { include: [ Site ] })
-      }).then(user => {
-        expect(user.Sites).to.have.length(1)
-        expect(user.Sites[0].id).to.equal(site.id)
-        done()
-      }).catch(done)
-    })
+          return request(app)
+            .post('/webhook/github')
+            .send(payload)
+            .set({
+              'X-GitHub-Event': 'push',
+              'X-Hub-Signature': signature,
+              'X-GitHub-Delivery': '123abc',
+            })
+            .expect(200);
+        })
+        .then(response => Build.findById(response.body.id, { include: [User] }))
+        .then((build) => {
+          expect(build.User.username).to.equal(username);
+          return User.findById(build.User.id, { include: [Site] });
+        })
+        .then((user) => {
+          expect(user.Sites).to.have.length(1);
+          expect(user.Sites[0].id).to.equal(site.id);
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should find the site by the lowercased owner and repository", done => {
-      let site
-      const userPromise = factory.user()
-      const sitePromise = factory.site({ users: Promise.all([userPromise]) })
+    it('should find the site by the lowercased owner and repository', (done) => {
+      let site;
+      const userPromise = factory.user();
+      const sitePromise = factory.site({ users: Promise.all([userPromise]) });
 
-      Promise.props({ user: userPromise, site: sitePromise }).then(models => {
-        site = models.site
+      Promise.props({ user: userPromise, site: sitePromise })
+        .then((models) => {
+          site = models.site;
 
-        const payload = buildWebhookPayload(models.user, site)
-        payload.repository.full_name = `${site.owner.toUpperCase()}/${site.repository.toUpperCase()}`
-        const signature = signWebhookPayload(payload)
+          const payload = buildWebhookPayload(models.user, site);
+          payload.repository.full_name = `${site.owner.toUpperCase()}/${site.repository.toUpperCase()}`;
+          const signature = signWebhookPayload(payload);
 
-        return request(app)
-          .post("/webhook/github")
-          .send(payload)
-          .set({
-            "X-GitHub-Event": "push",
-            "X-Hub-Signature": signature,
-            "X-GitHub-Delivery": "123abc"
-          })
-          .expect(200)
-      }).then(response => {
-        expect(response.body.site.id).to.equal(site.id)
-        done()
-      }).catch(done)
-    })
+          return request(app)
+            .post('/webhook/github')
+            .send(payload)
+            .set({
+              'X-GitHub-Event': 'push',
+              'X-Hub-Signature': signature,
+              'X-GitHub-Delivery': '123abc',
+            })
+            .expect(200);
+        })
+        .then((response) => {
+          expect(response.body.site.id).to.equal(site.id);
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should report the status of the new build to GitHub", done => {
-      nock.cleanAll()
-      const statusNock = githubAPINocks.status({ state: "pending" })
+    it('should report the status of the new build to GitHub', (done) => {
+      nock.cleanAll();
+      const statusNock = githubAPINocks.status({ state: 'pending' });
 
-      const user = factory.user()
-      const site = factory.site({ users: Promise.all([user]) })
-      Promise.props({ user, site }).then(({ user, site }) => {
-        const payload = buildWebhookPayload(user, site)
-        payload.repository.full_name = `${site.owner.toUpperCase()}/${site.repository.toUpperCase()}`
-        const signature = signWebhookPayload(payload)
+      const userProm = factory.user();
+      const siteProm = factory.site({ users: Promise.all([userProm]) });
+      Promise.props({ user: userProm, site: siteProm })
+        .then(({ user, site }) => {
+          const payload = buildWebhookPayload(user, site);
+          payload.repository.full_name = `${site.owner.toUpperCase()}/${site.repository.toUpperCase()}`;
+          const signature = signWebhookPayload(payload);
 
-        return request(app)
-          .post("/webhook/github")
-          .send(payload)
-          .set({
-            "X-GitHub-Event": "push",
-            "X-Hub-Signature": signature,
-            "X-GitHub-Delivery": "123abc"
-          })
-          .expect(200)
-      }).then(() => {
-        expect(statusNock.isDone()).to.be.true
-        done()
-      }).catch(done)
-    })
+          return request(app)
+            .post('/webhook/github')
+            .send(payload)
+            .set({
+              'X-GitHub-Event': 'push',
+              'X-Hub-Signature': signature,
+              'X-GitHub-Delivery': '123abc',
+            })
+            .expect(200);
+        })
+        .then(() => {
+          expect(statusNock.isDone()).to.be.true;
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should not schedule a build if there are no new commits", done => {
-      let site, user
+    it('should not schedule a build if there are no new commits', (done) => {
+      let site;
+      let user;
 
-      factory.site().then(site => {
-        return Site.findById(site.id, { include: [User] })
-      }).then(model => {
-        site = model
-        user = site.Users[0]
-        return Build.findAll({ where: { site: site.id, user: user.id } })
-      }).then(builds => {
-        expect(builds).to.have.length(0)
+      factory.site()
+        .then(s => Site.findById(s.id, { include: [User] }))
+        .then((model) => {
+          site = model;
+          user = site.Users[0];
+          return Build.findAll({ where: { site: site.id, user: user.id } });
+        })
+        .then((builds) => {
+          expect(builds).to.have.length(0);
 
-        const payload = buildWebhookPayload(user, site)
-        payload.commits = []
-        const signature = signWebhookPayload(payload)
+          const payload = buildWebhookPayload(user, site);
+          payload.commits = [];
+          const signature = signWebhookPayload(payload);
 
-        return request(app)
-          .post("/webhook/github")
-          .send(payload)
-          .set({
-            "X-GitHub-Event": "push",
-            "X-Hub-Signature": signature,
-            "X-GitHub-Delivery": "123abc"
-          })
-          .expect(200)
-      }).then(response => {
-        return Build.findAll({ where: { site: site.id, user: user.id } })
-      }).then(builds => {
-        expect(builds).to.have.length(0)
-        done()
-      }).catch(done)
-    })
+          return request(app)
+            .post('/webhook/github')
+            .send(payload)
+            .set({
+              'X-GitHub-Event': 'push',
+              'X-Hub-Signature': signature,
+              'X-GitHub-Delivery': '123abc',
+            })
+            .expect(200);
+        })
+        .then(() => Build.findAll({ where: { site: site.id, user: user.id } }))
+        .then((builds) => {
+          expect(builds).to.have.length(0);
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should respond with a 400 if the site does not exist on Federalist", done => {
-      factory.user().then(user => {
+    it('should respond with a 400 if the site does not exist on Federalist', (done) => {
+      factory.user().then((user) => {
         const payload = buildWebhookPayload(user, {
           owner: user.username,
-          repository: "fake-repo-name"
+          repository: 'fake-repo-name',
+        });
+        const signature = signWebhookPayload(payload);
+
+        request(app)
+          .post('/webhook/github')
+          .send(payload)
+          .set({
+            'X-GitHub-Event': 'push',
+            'X-Hub-Signature': signature,
+            'X-GitHub-Delivery': '123abc',
+          })
+          .expect(400, done);
+      }).catch(done);
+    });
+
+    it('should respond with a 400 if the signature is invalid', (done) => {
+      let site;
+      let user;
+
+      factory.site()
+        .then(s => Site.findById(s.id, { include: [User] }))
+        .then((model) => {
+          site = model;
+          user = site.Users[0];
+
+          const payload = buildWebhookPayload(user, site);
+          const signature = '123abc';
+
+          request(app)
+            .post('/webhook/github')
+            .send(payload)
+            .set({
+              'X-GitHub-Event': 'push',
+              'X-Hub-Signature': signature,
+              'X-GitHub-Delivery': '123abc',
+            })
+            .expect(400, done);
         })
-        const signature = signWebhookPayload(payload)
-
-        request(app)
-          .post("/webhook/github")
-          .send(payload)
-          .set({
-            "X-GitHub-Event": "push",
-            "X-Hub-Signature": signature,
-            "X-GitHub-Delivery": "123abc"
-          })
-          .expect(400, done)
-      }).catch(done)
-    })
-
-    it("should respond with a 400 if the signature is invalid", done => {
-      let site, user
-
-      factory.site().then(site => {
-        return Site.findById(site.id, { include: [ User ] })
-      }).then(model => {
-        site = model
-        user = site.Users[0]
-
-        const payload = buildWebhookPayload(user, site)
-        const signature = "123abc"
-
-        request(app)
-          .post("/webhook/github")
-          .send(payload)
-          .set({
-            "X-GitHub-Event": "push",
-            "X-Hub-Signature": signature,
-            "X-GitHub-Delivery": "123abc"
-          })
-          .expect(400, done)
-      }).catch(done)
-    })
-  })
-})
+        .catch(done);
+    });
+  });
+});

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -1,444 +1,469 @@
-const crypto = require("crypto")
-const expect = require("chai").expect
-const nock = require("nock")
-const factory = require("../../support/factory")
-const githubAPINocks = require("../../support/githubAPINocks")
-const SiteCreator = require("../../../../api/services/SiteCreator")
-const { Build, Site, User } = require("../../../../api/models")
+const crypto = require('crypto');
+const expect = require('chai').expect;
+const nock = require('nock');
+const factory = require('../../support/factory');
+const githubAPINocks = require('../../support/githubAPINocks');
+const SiteCreator = require('../../../../api/services/SiteCreator');
+const { Build, Site, User } = require('../../../../api/models');
 
-describe("SiteCreator", () => {
-  describe(".createSite({ siteParams, user })", () => {
-    context("when the site does not exist in Federalist", () => {
-      it("should create a new site record for the given repository and add the user", done => {
-        let user
+describe('SiteCreator', () => {
+  describe('.createSite({ siteParams, user })', () => {
+    context('when the site does not exist in Federalist', () => {
+      it('should create a new site record for the given repository and add the user', (done) => {
+        let user;
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+        };
 
-        factory.user().then(model => {
-          user = model
-          githubAPINocks.repo()
-          githubAPINocks.webhook()
-          return SiteCreator.createSite({ user, siteParams })
-        }).then(site => {
-          expect(site).to.not.be.undefined
-          expect(site.owner).to.equal(siteParams.owner)
-          expect(site.repository).to.equal(siteParams.repository)
+        factory.user().then((model) => {
+          user = model;
+          githubAPINocks.repo();
+          githubAPINocks.webhook();
+          return SiteCreator.createSite({ user, siteParams });
+        }).then((site) => {
+          expect(site).to.not.be.undefined;
+          expect(site.owner).to.equal(siteParams.owner);
+          expect(site.repository).to.equal(siteParams.repository);
 
           return Site.findOne({
             where: {
               owner: siteParams.owner,
-              repository: siteParams.repository
+              repository: siteParams.repository,
             },
-            include: [ User ],
-          })
-        }).then(site => {
-          expect(site).to.not.be.undefined
-          expect(site.Users).to.have.length(1)
-          expect(site.Users[0].id).to.equal(user.id)
-          done()
-        }).catch(done)
-      })
+            include: [User],
+          });
+        }).then((site) => {
+          expect(site).to.not.be.undefined;
+          expect(site.Users).to.have.length(1);
+          expect(site.Users[0].id).to.equal(user.id);
+          done();
+        })
+        .catch(done);
+      });
 
-      it("should trigger a build for the new site", done => {
-        let user
+      it('should trigger a build for the new site', (done) => {
+        let user;
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+        };
 
-        factory.user().then(model => {
-          user = model
-          githubAPINocks.repo()
-          githubAPINocks.webhook()
-          return SiteCreator.createSite({ user, siteParams })
-        }).then(() => {
-          return Site.findOne({
-            where: {
-              owner: siteParams.owner,
-              repository: siteParams.repository
-            },
-            include: [ Build ]
-          })
-        }).then(site => {
-          expect(site.Builds).to.have.length(1)
-          expect(site.Builds[0].user).to.equal(user.id)
-          done()
-        }).catch(done)
-      })
+        factory.user().then((model) => {
+          user = model;
+          githubAPINocks.repo();
+          githubAPINocks.webhook();
+          return SiteCreator.createSite({ user, siteParams });
+        }).then(() => Site.findOne({
+          where: {
+            owner: siteParams.owner,
+            repository: siteParams.repository,
+          },
+          include: [Build],
+        })).then((site) => {
+          expect(site.Builds).to.have.length(1);
+          expect(site.Builds[0].user).to.equal(user.id);
+          done();
+        })
+        .catch(done);
+      });
 
-      it("should create a webhook for the new site", done => {
-        let webhookNock
+      it('should create a webhook for the new site', (done) => {
+        let webhookNock;
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+        };
 
-        factory.user().then(user => {
-          githubAPINocks.repo()
+        factory.user().then((user) => {
+          githubAPINocks.repo();
           webhookNock = githubAPINocks.webhook({
             accessToken: user.githubAccessToken,
             owner: siteParams.owner,
             repo: siteParams.repository,
-          })
+          });
 
-          return SiteCreator.createSite({ user, siteParams })
+          return SiteCreator.createSite({ user, siteParams });
         }).then(() => {
-          expect(webhookNock.isDone()).to.equal(true)
-          done()
-        }).catch(done)
-      })
+          expect(webhookNock.isDone()).to.equal(true);
+          done();
+        }).catch(done);
+      });
 
-      it("should reject if the user does not have admin access to the site", done => {
-        let repoNock
+      it('should reject if the user does not have admin access to the site', (done) => {
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+        };
 
-        factory.user().then(user => {
-          repoNock = githubAPINocks.repo({
+        factory.user().then((user) => {
+          githubAPINocks.repo({
             accessToken: user.accessToken,
             owner: siteParams.owner,
             repo: siteParams.repository,
             response: [200, { permissions: {
               admin: false,
               push: true,
-            }}],
-          })
-          return SiteCreator.createSite({ user, siteParams })
-        }).catch(err => {
-          expect(err.status).to.equal(400)
-          expect(err.message).to.equal("You do not have admin access to this repository")
-          done()
-        })
-      })
+            } }],
+          });
+          return SiteCreator.createSite({ user, siteParams });
+        }).catch((err) => {
+          expect(err.status).to.equal(400);
+          expect(err.message).to.equal('You do not have admin access to this repository');
+          done();
+        });
+      });
 
-      it("should reject if the user does not have write access to the site", done => {
-        let repoNock
+      it('should reject if the user does not have write access to the site', (done) => {
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+        };
 
-        factory.user().then(user => {
-          repoNock = githubAPINocks.repo({
+        factory.user().then((user) => {
+          githubAPINocks.repo({
             accessToken: user.accessToken,
             owner: siteParams.owner,
             repo: siteParams.repository,
             response: [200, { permissions: {
               admin: false,
               push: false,
-            }}],
-          })
-          return SiteCreator.createSite({ user, siteParams })
-        }).catch(err => {
-          expect(err.status).to.equal(400)
-          expect(err.message).to.equal("You do not have admin access to this repository")
-          done()
-        })
-      })
-    })
+            } }],
+          });
+          return SiteCreator.createSite({ user, siteParams });
+        }).catch((err) => {
+          expect(err.status).to.equal(400);
+          expect(err.message).to.equal('You do not have admin access to this repository');
+          done();
+        });
+      });
+    });
 
-    context("when the site exists in Federalist", () => {
-      it("should not create a new site record", done => {
-        let site
-        let sitePromise = factory.site()
-        let userPromise = factory.user()
+    context('when the site exists in Federalist', () => {
+      it('should not create a new site record', (done) => {
+        let site;
+        const sitePromise = factory.site();
+        const userPromise = factory.user();
 
-        Promise.props({ site: sitePromise, user: userPromise }).then(models => {
-          site = models.site
-          githubAPINocks.repo()
-          return SiteCreator.createSite({ user: models.user, siteParams: {
-            owner: site.owner,
-            repository: site.repository,
-          }})
-        }).then(createdSite => {
-          expect(createdSite.id).to.equal(site.id)
+        Promise.props({ site: sitePromise, user: userPromise }).then((models) => {
+          site = models.site;
+          githubAPINocks.repo();
+          return SiteCreator.createSite({ user: models.user,
+            siteParams: {
+              owner: site.owner,
+              repository: site.repository,
+            } });
+        }).then((createdSite) => {
+          expect(createdSite.id).to.equal(site.id);
 
           return Site.findAll({
             where: {
               owner: site.owner,
-              repository: site.repository
+              repository: site.repository,
             },
+          });
+        }).then((sites) => {
+          expect(sites).to.have.length(1);
+          done();
+        })
+        .catch(done);
+      });
+
+      it('should not trigger a build for the existing site', (done) => {
+        let site;
+        let user;
+        const sitePromise = factory.site();
+        const userPromise = factory.user();
+
+        Promise.props({ site: sitePromise, user: userPromise })
+        .then((models) => {
+          site = models.site;
+          user = models.user;
+          githubAPINocks.repo();
+          return SiteCreator.createSite({ user,
+            siteParams: {
+              owner: site.owner,
+              repository: site.repository,
+            } });
+        })
+        .then(() => Site.findById(site.id, { include: [Build] }))
+        .then((s) => {
+          expect(s.Builds).to.have.length(0);
+          done();
+        })
+        .catch(done);
+      });
+
+      it('should add the user to the existing site', (done) => {
+        let site;
+        let user;
+        const sitePromise = factory.site();
+        const userPromise = factory.user();
+
+        Promise.props({ site: sitePromise, user: userPromise }).then((models) => {
+          site = models.site;
+          user = models.user;
+          githubAPINocks.repo();
+          return SiteCreator.createSite({ user,
+            siteParams: {
+              owner: site.owner,
+              repository: site.repository,
+            } });
+        })
+        .then(() => Site.findById(site.id, { include: [User] }))
+        .then((s) => {
+          const addedUser = s.Users.find(candidate => candidate.id === user.id);
+          expect(addedUser).to.not.be.undefined;
+          done();
+        })
+        .catch(done);
+      });
+
+      it('should not attempt to add a webhook for the site', (done) => {
+        let webhookNock;
+        const siteProm = factory.site();
+        const userProm = factory.user();
+
+        Promise.props({ user: userProm, site: siteProm })
+          .then(({ user, site }) => {
+            githubAPINocks.repo();
+            webhookNock = githubAPINocks.webhook();
+            return SiteCreator.createSite({ user,
+              siteParams: {
+                owner: site.owner,
+                repository: site.repository,
+              } });
           })
-        }).then(sites => {
-          expect(sites).to.have.length(1)
-          done()
-        }).catch(done)
-      })
-
-      it("should not trigger a build for the existing site", done => {
-        let site, user
-        let sitePromise = factory.site()
-        let userPromise = factory.user()
-
-        Promise.props({ site: sitePromise, user: userPromise }).then(models => {
-          site = models.site
-          user = models.user
-          githubAPINocks.repo()
-          return SiteCreator.createSite({ user, siteParams: {
-            owner: site.owner,
-            repository: site.repository,
-          }})
-        }).then(() => {
-          return Site.findById(site.id, { include: [ Build ]})
-        }).then(site => {
-          expect(site.Builds).to.have.length(0)
-          done()
-        }).catch(done)
-      })
-
-      it("should add the user to the existing site", done => {
-        let site, user
-        let sitePromise = factory.site()
-        let userPromise = factory.user()
-
-        Promise.props({ site: sitePromise, user: userPromise }).then(models => {
-          site = models.site
-          user = models.user
-          githubAPINocks.repo()
-          return SiteCreator.createSite({ user, siteParams: {
-            owner: site.owner,
-            repository: site.repository,
-          }})
-        }).then(() => {
-          return Site.findById(site.id, { include: [ User ]})
-        }).then(site => {
-          const addedUser = site.Users.find((candidate) => {
-            return candidate.id === user.id
+          .then(() => {
+            expect(webhookNock.isDone()).to.equal(false);
+            nock.cleanAll();
+            done();
           })
-          expect(addedUser).to.not.be.undefined
-          done()
-        }).catch(done)
-      })
+          .catch(done);
+      });
 
-      it("should not attempt to add a webhook for the site", done => {
-        let webhookNock
-        const site = factory.site()
-        const user = factory.user()
+      it('should not reject if the user does not have admin access to the site', (done) => {
+        const userProm = factory.user();
+        const siteProm = factory.site();
 
-        Promise.props({ user, site }).then(({ user, site }) => {
-          githubAPINocks.repo()
-          webhookNock = githubAPINocks.webhook()
-          return SiteCreator.createSite({ user, siteParams: {
-            owner: site.owner,
-            repository: site.repository,
-          }})
-        }).then(() => {
-          expect(webhookNock.isDone()).to.equal(false)
-          nock.cleanAll()
-          done()
-        }).catch(done)
-      })
-
-      it("should not reject if the user does not have admin access to the site", done => {
-        const user = factory.user()
-        const site = factory.site()
-
-        Promise.props({ user, site }).then(({ user, site }) => {
-          githubAPINocks.repo({
-            accessToken: user.accessToken,
-            owner: site.owner,
-            repo: site.repository,
-            response: [200, { permissions: {
-              admin: false,
-              push: true,
-            }}],
+        Promise.props({ user: userProm, site: siteProm })
+          .then(({ user, site }) => {
+            githubAPINocks.repo({
+              accessToken: user.accessToken,
+              owner: site.owner,
+              repo: site.repository,
+              response: [200, { permissions: {
+                admin: false,
+                push: true,
+              } }],
+            });
+            return SiteCreator.createSite({ user,
+              siteParams: {
+                owner: site.owner,
+                repository: site.repository,
+              } });
           })
-          return SiteCreator.createSite({ user, siteParams: {
-            owner: site.owner,
-            repository: site.repository,
-          }})
-        }).then(() => {
-          done()
-        }).catch(done)
-      })
-
-      it("should reject if the user does not have write access to the site", done => {
-        const user = factory.user()
-        const site = factory.site()
-
-        Promise.props({ user, site }).then(({ user, site }) => {
-          githubAPINocks.repo({
-            accessToken: user.accessToken,
-            owner: site.owner,
-            repo: site.repository,
-            response: [200, { permissions: {
-              admin: false,
-              push: false,
-            }}],
+          .then(() => {
+            done();
           })
-          return SiteCreator.createSite({ user, siteParams: {
-            owner: site.owner,
-            repository: site.repository,
-          }})
-        }).catch(err => {
-          expect(err.status).to.equal(400)
-          expect(err.message).to.equal("You do not have write access to this repository")
-          done()
-        }).catch(done)
-      })
+          .catch(done);
+      });
 
-      it("should reject if the user has already added the site", done => {
-        const user = factory.user()
-        const site = factory.site({ users: Promise.all([user]) })
+      it('should reject if the user does not have write access to the site', (done) => {
+        const userProm = factory.user();
+        const siteProm = factory.site();
 
-        Promise.props({ user, site }).then(({ user, site }) => {
-          githubAPINocks.repo()
-          return SiteCreator.createSite({ user, siteParams: {
-            owner: site.owner,
-            repository: site.repository,
-          }})
-        }).catch(err => {
-          expect(err.status).to.equal(400)
-          expect(err.message).to.equal("You've already added this site to Federalist")
-          done()
-        }).catch(done)
-      })
+        Promise.props({ user: userProm, site: siteProm })
+          .then(({ user, site }) => {
+            githubAPINocks.repo({
+              accessToken: user.accessToken,
+              owner: site.owner,
+              repo: site.repository,
+              response: [200, { permissions: {
+                admin: false,
+                push: false,
+              } }],
+            });
+            return SiteCreator.createSite({ user,
+              siteParams: {
+                owner: site.owner,
+                repository: site.repository,
+              } });
+          })
+          .catch((err) => {
+            expect(err.status).to.equal(400);
+            expect(err.message).to.equal('You do not have write access to this repository');
+            done();
+          })
+          .catch(done);
+      });
 
-      it("should reject if the user has already added the site and the site name is a different case", done => {
-        const user = factory.user()
-        const site = factory.site({ users: Promise.all([user]) })
+      it('should reject if the user has already added the site', (done) => {
+        const userProm = factory.user();
+        const siteProm = factory.site({ users: Promise.all([userProm]) });
 
-        Promise.props({ user, site }).then(({ user, site }) => {
-          githubAPINocks.repo()
-          return SiteCreator.createSite({ user, siteParams: {
-            owner: site.owner.toUpperCase(),
-            repository: site.repository.toUpperCase(),
-          }})
-        }).catch(err => {
-          expect(err.status).to.equal(400)
-          expect(err.message).to.equal("You've already added this site to Federalist")
-          done()
-        }).catch(done)
-      })
-    })
+        Promise.props({ user: userProm, site: siteProm })
+          .then(({ user, site }) => {
+            githubAPINocks.repo();
+            return SiteCreator.createSite({ user,
+              siteParams: {
+                owner: site.owner,
+                repository: site.repository,
+              } });
+          })
+          .catch((err) => {
+            expect(err.status).to.equal(400);
+            expect(err.message).to.equal("You've already added this site to Federalist");
+            done();
+          })
+          .catch(done);
+      });
 
-    context("when the site is created from a template", () => {
-      it("should create a new site record for the given repository and add the user", done => {
-        let user
+      it('should reject if the user has already added the site and the site name is a different case', (done) => {
+        const userProm = factory.user();
+        const siteProm = factory.site({ users: Promise.all([userProm]) });
+
+        Promise.props({ user: userProm, site: siteProm })
+          .then(({ user, site }) => {
+            githubAPINocks.repo();
+            return SiteCreator.createSite({ user,
+              siteParams: {
+                owner: site.owner.toUpperCase(),
+                repository: site.repository.toUpperCase(),
+              } });
+          })
+          .catch((err) => {
+            expect(err.status).to.equal(400);
+            expect(err.message).to.equal("You've already added this site to Federalist");
+            done();
+          })
+          .catch(done);
+      });
+    });
+
+    context('when the site is created from a template', () => {
+      it('should create a new site record for the given repository and add the user', (done) => {
+        let user;
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-          template: "team",
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+          template: 'team',
+        };
 
-        factory.user().then(model => {
-          user = model
-          githubAPINocks.createRepoForOrg()
-          githubAPINocks.webhook()
-          return SiteCreator.createSite({ user, siteParams })
-        }).then(site => {
-          expect(site).to.not.be.undefined
-          expect(site.owner).to.equal(siteParams.owner)
-          expect(site.repository).to.equal(siteParams.repository)
+        factory.user().then((model) => {
+          user = model;
+          githubAPINocks.createRepoForOrg();
+          githubAPINocks.webhook();
+          return SiteCreator.createSite({ user, siteParams });
+        }).then((site) => {
+          expect(site).to.not.be.undefined;
+          expect(site.owner).to.equal(siteParams.owner);
+          expect(site.repository).to.equal(siteParams.repository);
 
           return Site.findOne({
             where: {
               owner: siteParams.owner,
-              repository: siteParams.repository
+              repository: siteParams.repository,
             },
-            include: [ User ],
-          })
-        }).then(site => {
-          expect(site).to.not.be.undefined
-          expect(site.Users).to.have.length(1)
-          expect(site.Users[0].id).to.equal(user.id)
-          done()
-        }).catch(done)
-      })
+            include: [User],
+          });
+        }).then((site) => {
+          expect(site).to.not.be.undefined;
+          expect(site.Users).to.have.length(1);
+          expect(site.Users[0].id).to.equal(user.id);
+          done();
+        })
+        .catch(done);
+      });
 
-      it("should use jekyll as the build engine", done => {
+      it('should use jekyll as the build engine', (done) => {
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-          template: "team",
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+          template: 'team',
+        };
 
-        factory.user().then(user => {
-          githubAPINocks.createRepoForOrg()
-          githubAPINocks.webhook()
-          return SiteCreator.createSite({ siteParams, user })
-        }).then(site => {
-          expect(site.engine).to.equal("jekyll")
-          done()
-        }).catch(done)
-      })
+        factory.user().then((user) => {
+          githubAPINocks.createRepoForOrg();
+          githubAPINocks.webhook();
+          return SiteCreator.createSite({ siteParams, user });
+        }).then((site) => {
+          expect(site.engine).to.equal('jekyll');
+          done();
+        }).catch(done);
+      });
 
-      it("should trigger a build that pushes the source repo to the destiantion repo", done => {
-        let user
+      it('should trigger a build that pushes the source repo to the destiantion repo', (done) => {
+        let user;
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-          template: "team",
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+          template: 'team',
+        };
 
-        factory.user().then(model => {
-          user = model
-          githubAPINocks.createRepoForOrg()
-          githubAPINocks.webhook()
-          return SiteCreator.createSite({ siteParams, user })
-        }).then(site => {
-          return Site.findById(site.id, { include: [ Build ] })
-        }).then(site => {
-          expect(site.Builds).to.have.length(1)
-          expect(site.Builds[0].user).to.equal(user.id)
-          expect(site.Builds[0].branch).to.equal("master")
+        factory.user().then((model) => {
+          user = model;
+          githubAPINocks.createRepoForOrg();
+          githubAPINocks.webhook();
+          return SiteCreator.createSite({ siteParams, user });
+        }).then(site => Site.findById(site.id, { include: [Build] })).then((site) => {
+          expect(site.Builds).to.have.length(1);
+          expect(site.Builds[0].user).to.equal(user.id);
+          expect(site.Builds[0].branch).to.equal('master');
           expect(site.Builds[0].source).to.deep.equal({
-            repository: "federalist-modern-team-template",
-            owner: "18f",
-          })
-          done()
-        }).catch(done)
-      })
+            repository: 'federalist-modern-team-template',
+            owner: '18f',
+          });
+          done();
+        })
+        .catch(done);
+      });
 
-      it("should create a webhook for the new site", done => {
-        let webhookNock
+      it('should create a webhook for the new site', (done) => {
+        let webhookNock;
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-          template: "team",
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+          template: 'team',
+        };
 
-        factory.user().then(user => {
-          githubAPINocks.createRepoForOrg()
+        factory.user().then((user) => {
+          githubAPINocks.createRepoForOrg();
           webhookNock = githubAPINocks.webhook({
             accessToken: user.githubAccessToken,
             owner: siteParams.owner,
             repo: siteParams.repository,
-          })
-          return SiteCreator.createSite({ user, siteParams })
+          });
+          return SiteCreator.createSite({ user, siteParams });
         }).then(() => {
-          expect(webhookNock.isDone()).to.equal(true)
-          done()
-        }).catch(done)
-      })
+          expect(webhookNock.isDone()).to.equal(true);
+          done();
+        }).catch(done);
+      });
 
-      it("should reject if the repo already exists on GitHub", done => {
+      it('should reject if the repo already exists on GitHub', (done) => {
         const siteParams = {
-          owner: crypto.randomBytes(3).toString("hex"),
-          repository: crypto.randomBytes(3).toString("hex"),
-          template: "team",
-        }
+          owner: crypto.randomBytes(3).toString('hex'),
+          repository: crypto.randomBytes(3).toString('hex'),
+          template: 'team',
+        };
 
-        factory.user().then(user => {
+        factory.user().then((user) => {
           githubAPINocks.createRepoForOrg({
             accessToken: user.accessToken,
             org: siteParams.owner,
             repo: siteParams.repository,
             response: [422, {
-              "errors": [{ "message":"name already exists on this account" }]
-            }]
-          })
-          return SiteCreator.createSite({ user, siteParams })
-        }).catch(err => {
-          expect(err.status).to.equal(400)
-          expect(err.message).to.equal("A repo with that name already exists.")
-          done()
-        }).catch(done)
-      })
-    })
-  })
-})
+              errors: [{ message: 'name already exists on this account' }],
+            }],
+          });
+          return SiteCreator.createSite({ user, siteParams });
+        }).catch((err) => {
+          expect(err.status).to.equal(400);
+          expect(err.message).to.equal('A repo with that name already exists.');
+          done();
+        }).catch(done);
+      });
+    });
+  });
+});

--- a/test/frontend/actions/actionCreators/addNewSiteFieldsActions.test.js
+++ b/test/frontend/actions/actionCreators/addNewSiteFieldsActions.test.js
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+
+import {
+  showAddNewSiteFields,
+  showAddNewSiteFieldsType,
+  hideAddNewSiteFields,
+  hideAddNewSiteFieldsType,
+} from '../../../../frontend/actions/actionCreators/addNewSiteFieldsActions';
+
+describe('addNewSiteFieldsActions actionCreators', () => {
+  it('showAddNewSiteFields()', () => {
+    const action = showAddNewSiteFields();
+    expect(showAddNewSiteFieldsType).to.be.defined;
+    expect(action.type).to.equal(showAddNewSiteFieldsType);
+  });
+
+  it('hideAddNewSiteFields()', () => {
+    const action = hideAddNewSiteFields();
+    expect(hideAddNewSiteFieldsType).to.be.defined;
+    expect(action.type).to.equal(hideAddNewSiteFieldsType);
+  });
+});

--- a/test/frontend/actions/actionCreators/siteActionsTest.js
+++ b/test/frontend/actions/actionCreators/siteActionsTest.js
@@ -1,71 +1,71 @@
-import { expect } from "chai";
+import { expect } from 'chai';
 import {
   sitesFetchStarted, sitesFetchStartedType,
   sitesReceived, sitesReceivedType,
   siteAdded, siteAddedType,
   siteUpdated, siteUpdatedType,
   siteDeleted, siteDeletedType,
-  siteBranchesReceived, siteBranchesReceivedType,
-} from "../../../../frontend/actions/actionCreators/siteActions";
+  siteUserAdded, siteUserAddedType,
+} from '../../../../frontend/actions/actionCreators/siteActions';
 
-describe("siteActions actionCreators", () => {
-  describe("sitesFetchStarted", () => {
-    it("constructs propery", () => {
-      const actual = sitesFetchStarted()
+describe('siteActions actionCreators', () => {
+  describe('sitesFetchStarted', () => {
+    it('constructs properly', () => {
+      const actual = sitesFetchStarted();
       expect(actual).to.deep.equal({
         type: sitesFetchStartedType,
-      })
-    })
+      });
+    });
 
-    it("exports its type", () => {
-      expect(sitesFetchStartedType).to.equal("SITES_FETCH_STARTED")
-    })
-  })
+    it('exports its type', () => {
+      expect(sitesFetchStartedType).to.equal('SITES_FETCH_STARTED');
+    });
+  });
 
-  describe("sitesReceived", () => {
-    it("constructs properly", () => {
+  describe('sitesReceived', () => {
+    it('constructs properly', () => {
       const sites = [{
-        something: "here"
+        something: 'here',
       }];
 
       const actual = sitesReceived(sites);
 
       expect(actual).to.deep.equal({
         type: sitesReceivedType,
-        sites
+        sites,
       });
     });
 
-    it("exports its type", () => {
-      expect(sitesReceivedType).to.equal("SITES_RECEIVED");
+    it('exports its type', () => {
+      expect(sitesReceivedType).to.equal('SITES_RECEIVED');
     });
   });
 
-  describe("siteAdded", () => {
-    it("constructs properly", () => {
+  describe('siteAdded', () => {
+    it('constructs properly', () => {
       const site = {
-        something: "here"
+        something: 'here',
       };
 
       const actual = siteAdded(site);
 
       expect(actual).to.deep.equal({
         type: siteAddedType,
-        site
+        site,
       });
     });
 
-    it("exports its type", () => {
-      expect(siteAddedType).to.equal("SITE_ADDED");
+    it('exports its type', () => {
+      expect(siteAddedType).to.equal('SITE_ADDED');
     });
   });
 
-  describe("siteUpdated", () => {
-    it("constructs properly", () => {
-      const id = "tk421";
+  describe('siteUpdated', () => {
+    it('constructs properly', () => {
+      const id = 'tk421';
       const site = {
-        something: "here",
-        id: id
+        something: 'here',
+        id,
       };
 
       const actual = siteUpdated(site);
@@ -73,29 +73,47 @@ describe("siteActions actionCreators", () => {
       expect(actual).to.deep.equal({
         type: siteUpdatedType,
         siteId: id,
-        site
+        site,
       });
     });
 
-    it("exports its type", () => {
-      expect(siteUpdatedType).to.equal("SITE_UPDATED");
+    it('exports its type', () => {
+      expect(siteUpdatedType).to.equal('SITE_UPDATED');
     });
   });
 
-  describe("siteDeleted", () => {
-    it("constructs properly", () => {
-      const siteId = "tk421";
+  describe('siteDeleted', () => {
+    it('constructs properly', () => {
+      const siteId = 'tk421';
 
       const actual = siteDeleted(siteId);
 
       expect(actual).to.deep.equal({
         type: siteDeletedType,
-        siteId
+        siteId,
       });
     });
 
-    it("exports its type", () => {
-      expect(siteDeletedType).to.equal("SITE_DELETED");
+    it('exports its type', () => {
+      expect(siteDeletedType).to.equal('SITE_DELETED');
+    });
+  });
+
+  describe('siteUserAdded', () => {
+    it('constructs properly', () => {
+      const site = {
+        id: 123,
+        owner: 'owner',
+        repository: 'a-repo',
+      };
+
+      const action = siteUserAdded(site);
+      expect(action.type).to.equal(siteUserAddedType);
+      expect(action.site).to.equal(site);
+    });
+
+    it('exports its type', () => {
+      expect(siteUserAddedType).to.equal('SITE_USER_ADDED');
     });
   });
 });

--- a/test/frontend/actions/actionCreators/userActionsTest.js
+++ b/test/frontend/actions/actionCreators/userActionsTest.js
@@ -1,26 +1,40 @@
-import { expect } from "chai";
+import { expect } from 'chai';
 import {
   userReceived, userReceivedType,
-  userLogout, userLogoutType
-} from "../../../../frontend/actions/actionCreators/userActions";
+  userFetchStarted, userFetchStartedType,
+} from '../../../../frontend/actions/actionCreators/userActions';
 
-describe("userActions actionCreators", () => {
-  describe("userReceived", () => {
-    it("constructs properly", () => {
+describe('userActions actionCreators', () => {
+  describe('userReceived', () => {
+    it('constructs properly', () => {
       const user = {
-        bongo: "drum"
+        bongo: 'drum',
       };
 
       const actual = userReceived(user);
 
       expect(actual).to.deep.equal({
         type: userReceivedType,
-        user
+        user,
       });
     });
 
-    it("exports its type", () => {
-      expect(userReceivedType).to.equal("USER_RECEIVED");
+    it('exports its type', () => {
+      expect(userReceivedType).to.equal('USER_RECEIVED');
+    });
+  });
+
+  describe('userFetchStarted', () => {
+    it('constructs properly', () => {
+      const actual = userFetchStarted();
+
+      expect(actual).to.deep.equal({
+        type: userFetchStartedType,
+      });
+    });
+
+    it('exports its type', () => {
+      expect(userFetchStartedType).to.equal('USER_FETCH_STARTED');
     });
   });
 });

--- a/test/frontend/actions/addNewSiteFieldsActions.test.js
+++ b/test/frontend/actions/addNewSiteFieldsActions.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import proxyquire from 'proxyquire';
+
+proxyquire.noCallThru();
+
+const dispatchHideAddNewSiteFieldsAction = spy();
+
+const actions = proxyquire(
+  '../../../frontend/actions/addNewSiteFieldsActions', {
+    './dispatchActions': {
+      dispatchHideAddNewSiteFieldsAction,
+    },
+  }).default;
+
+describe('addNewSiteFieldsActions', () => {
+  it('hideAddNewSiteFields()', () => {
+    actions.hideAddNewSiteFields();
+    expect(dispatchHideAddNewSiteFieldsAction.calledOnce).to.be.true;
+  });
+});

--- a/test/frontend/actions/dispatchActionsTest.js
+++ b/test/frontend/actions/dispatchActionsTest.js
@@ -1,63 +1,75 @@
-import { expect } from "chai";
-import { spy, stub } from "sinon";
-import proxyquire from "proxyquire";
+import { expect } from 'chai';
+import { spy, stub } from 'sinon';
+import proxyquire from 'proxyquire';
 
 proxyquire.noCallThru();
 
-describe("dispatchActions", () => {
+describe('dispatchActions', () => {
   let fixture;
   let dispatch;
-  let sitesFetchStartedActionCreator, sitesReceivedActionCreator,
-      siteAddedActionCreator, siteDeletedActionCreator,
-      siteUpdatedActionCreator, siteBranchesReceivedActionCreator,
-      updateRouterActionCreator, pushHistory;
+  let sitesFetchStartedActionCreator;
+  let sitesReceivedActionCreator;
+  let siteAddedActionCreator;
+  let siteDeletedActionCreator;
+  let siteUpdatedActionCreator;
+  let pushHistory;
+  let userAddedToSiteActionCreator;
+  let showAddNewSiteFieldsActionCreator;
+  let hideAddNewSiteFieldsActionCreator;
 
-  const action = { whatever: "bub" };
-  const site = { site: "site1" };
-  const siteId = "42";
+  const action = { whatever: 'bub' };
+  const site = { site: 'site1' };
+
 
   beforeEach(() => {
     dispatch = spy();
     sitesFetchStartedActionCreator = stub();
     sitesReceivedActionCreator = stub();
-    updateRouterActionCreator = stub();
     siteAddedActionCreator = stub();
     siteUpdatedActionCreator = stub();
     siteDeletedActionCreator = stub();
+    userAddedToSiteActionCreator = stub();
+    showAddNewSiteFieldsActionCreator = stub();
+    hideAddNewSiteFieldsActionCreator = stub();
     pushHistory = stub();
 
-    fixture = proxyquire("../../../frontend/actions/dispatchActions", {
-      "./actionCreators/siteActions": {
+    fixture = proxyquire('../../../frontend/actions/dispatchActions', {
+      './actionCreators/siteActions': {
         sitesFetchStarted: sitesFetchStartedActionCreator,
         sitesReceived: sitesReceivedActionCreator,
         siteAdded: siteAddedActionCreator,
         siteUpdated: siteUpdatedActionCreator,
         siteDeleted: siteDeletedActionCreator,
+        siteUserAdded: userAddedToSiteActionCreator,
       },
-      "./routeActions": {
-        pushHistory: pushHistory
+      './actionCreators/addNewSiteFieldsActions': {
+        showAddNewSiteFields: showAddNewSiteFieldsActionCreator,
+        hideAddNewSiteFields: hideAddNewSiteFieldsActionCreator,
       },
-      "../store": {
-        dispatch: dispatch
-      }
+      './routeActions': {
+        pushHistory,
+      },
+      '../store': {
+        dispatch,
+      },
     });
   });
 
-  it("updateRouterToSitesUri", () => {
+  it('updateRouterToSitesUri', () => {
     fixture.updateRouterToSitesUri();
-    expect(pushHistory.calledWith("/sites")).to.be.true;
+    expect(pushHistory.calledWith('/sites')).to.be.true;
   });
 
-  it("dispatchSitesFetchStartedAction", () => {
-    sitesFetchStartedActionCreator.returns(action)
+  it('dispatchSitesFetchStartedAction', () => {
+    sitesFetchStartedActionCreator.returns(action);
 
-    fixture.dispatchSitesFetchStartedAction()
+    fixture.dispatchSitesFetchStartedAction();
 
-    expect(dispatch.calledWith(action)).to.be.true
-  })
+    expect(dispatch.calledWith(action)).to.be.true;
+  });
 
-  it("dispatchSitesReceivedAction", () => {
-    const sites = [ site ];
+  it('dispatchSitesReceivedAction', () => {
+    const sites = [site];
     sitesReceivedActionCreator.withArgs(sites).returns(action);
 
     fixture.dispatchSitesReceivedAction(sites);
@@ -65,7 +77,7 @@ describe("dispatchActions", () => {
     expect(dispatch.calledWith(action)).to.be.true;
   });
 
-  it("dispatchSiteAddedAction", () => {
+  it('dispatchSiteAddedAction', () => {
     siteAddedActionCreator.withArgs(site).returns(action);
 
     fixture.dispatchSiteAddedAction(site);
@@ -73,7 +85,7 @@ describe("dispatchActions", () => {
     expect(dispatch.calledWith(action)).to.be.true;
   });
 
-  it("dispatchSiteUpdatedAction", () => {
+  it('dispatchSiteUpdatedAction', () => {
     siteUpdatedActionCreator.withArgs(site).returns(action);
 
     fixture.dispatchSiteUpdatedAction(site);
@@ -81,11 +93,35 @@ describe("dispatchActions", () => {
     expect(dispatch.calledWith(action)).to.be.true;
   });
 
-  it("dispatchSiteDeletedAction", () => {
+  it('dispatchSiteDeletedAction', () => {
     siteDeletedActionCreator.withArgs(site).returns(action);
 
     fixture.dispatchSiteDeletedAction(site);
 
     expect(dispatch.calledWith(action)).to.be.true;
+  });
+
+  it('dispatchUserAddedToSiteAction', () => {
+    userAddedToSiteActionCreator.withArgs(site).returns(action);
+
+    fixture.dispatchUserAddedToSiteAction(site);
+
+    expect(dispatch.calledWith(action)).to.be.true;
+  });
+
+  it('dispatchShowAddNewSiteFieldsAction', () => {
+    showAddNewSiteFieldsActionCreator.withArgs(site).returns(action);
+
+    fixture.dispatchShowAddNewSiteFieldsAction(site);
+
+    expect(dispatch.calledOnce).to.be.true;
+  });
+
+  it('dispatchHideAddNewSiteFieldsAction', () => {
+    hideAddNewSiteFieldsActionCreator.withArgs(site).returns(action);
+
+    fixture.dispatchHideAddNewSiteFieldsAction();
+
+    expect(dispatch.calledOnce).to.be.true;
   });
 });

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -227,18 +227,36 @@ describe('siteActions', () => {
       });
     });
 
-    it('triggers showing additional add site fields when adding the user fails', () => {
+    it('triggers showing additional add site fields when adding the user fails with 404', () => {
       const repoToAdd = {
         owner: 'owner',
         repository: 'a-repo',
       };
-      addUserToSite.withArgs(repoToAdd).returns(rejectedWithErrorPromise);
+
+      const rejectWith404Error = Promise.reject({
+        response: { status: 404 },
+        message: 'Not found',
+      });
+
+      addUserToSite.withArgs(repoToAdd).returns(rejectWith404Error);
 
       const actual = fixture.addUserToSite(repoToAdd);
 
       return actual.then(() => {
         expect(dispatchShowAddNewSiteFieldsAction.calledOnce).to.be.true;
       });
+    });
+
+    it('triggers an http alert error when adding the user fails with other than 404', () => {
+      const repoToAdd = {
+        owner: 'owner',
+        repository: 'a-repo',
+      };
+
+      addUserToSite.withArgs(repoToAdd).returns(rejectedWithErrorPromise);
+
+      const actual = fixture.addUserToSite(repoToAdd);
+      return validateResultDispatchesHttpAlertError(actual, errorMessage);
     });
   });
 });

--- a/test/frontend/components/SelectSiteEngine.test.jsx
+++ b/test/frontend/components/SelectSiteEngine.test.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { spy } from 'sinon';
 
-import SelectSiteEngine from '../../../frontend/components/selectSiteEngine';
+import SelectSiteEngine from '../../../frontend/components/SelectSiteEngine';
 
 const expectedEngineValues = ['jekyll', 'hugo', 'static'];
 
@@ -20,7 +20,7 @@ describe('<SelectSiteEngine />', () => {
   });
 
   it('renders a select element with expect options', () => {
-    const select = wrapper.find('select#engine');
+    const select = wrapper.find('select');
     expect(select).to.have.length(1);
     expect(select.props().value).to.equal(props.value);
 
@@ -30,7 +30,7 @@ describe('<SelectSiteEngine />', () => {
   });
 
   it('calls props.onChange when a new option is selected', () => {
-    const select = wrapper.find('select#engine');
+    const select = wrapper.find('select');
     expect(props.onChange.notCalled).to.be.true;
     select.simulate('change', { target: { value: expectedEngineValues[2] } });
     expect(props.onChange.calledOnce).to.be.true;

--- a/test/frontend/components/addSite/AddRepoSiteForm.test.jsx
+++ b/test/frontend/components/addSite/AddRepoSiteForm.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+import ReduxFormAddRepoSiteForm, { AddRepoSiteForm } from '../../../../frontend/components/AddSite/AddRepoSiteForm';
+
+describe('ReduxForm-enhanced <AddRepoSiteForm />', () => {
+  it('exports a Connect\'d ReduxForm-enhanced component', () => {
+    const props = {
+      showAddNewSiteFields: false,
+      onSubmit: spy(),
+    };
+    const wrapper = shallow(<ReduxFormAddRepoSiteForm {...props} />);
+    expect(wrapper.exists()).to.be.true;
+    expect(wrapper.find('Connect(Form(AddRepoSiteForm))')).to.have.length(1);
+  });
+});
+
+describe('<AddRepoSiteForm />', () => {
+  it('renders', () => {
+    const props = {
+      showAddNewSiteFields: false,
+      handleSubmit: () => {},
+      pristine: true,
+    };
+
+    const wrapper = shallow(<AddRepoSiteForm {...props} />);
+    expect(wrapper).to.be.defined;
+
+    expect(wrapper.find('Field[name="owner"]')).to.have.length(1);
+    expect(wrapper.find('Field[name="owner"]').props().required).to.be.true;
+    expect(wrapper.find('Field[name="repository"]')).to.have.length(1);
+    expect(wrapper.find('Field[name="repository"]').props().required).to.be.true;
+  });
+
+  it('renders additional fields when showAddNewSiteFields is true', () => {
+    const props = {
+      showAddNewSiteFields: false,
+      handleSubmit: () => {},
+      pristine: true,
+    };
+
+    let wrapper = shallow(<AddRepoSiteForm {...props} />);
+    expect(wrapper.find('Field[name="engine"]')).to.have.length(0);
+    expect(wrapper.find('Field[name="defaultBranch"]')).to.have.length(0);
+
+    props.showAddNewSiteFields = true;
+    wrapper = shallow(<AddRepoSiteForm {...props} />);
+    expect(wrapper.find('Field[name="engine"]')).to.have.length(1);
+    expect(wrapper.find('Field[name="defaultBranch"]').props().required).to.be.true;
+  });
+
+  it('makes owner and repository readOnly showAddNewSiteFields is true', () => {
+    const props = {
+      showAddNewSiteFields: false,
+      handleSubmit: () => {},
+      pristine: true,
+    };
+
+    let wrapper = shallow(<AddRepoSiteForm {...props} />);
+    expect(wrapper.find('Field[name="owner"]').props().readOnly).to.be.false;
+    expect(wrapper.find('Field[name="repository"]').props().readOnly).to.be.false;
+
+    props.showAddNewSiteFields = true;
+    wrapper = shallow(<AddRepoSiteForm {...props} />);
+    expect(wrapper.find('Field[name="owner"]').props().readOnly).to.be.true;
+    expect(wrapper.find('Field[name="repository"]').props().readOnly).to.be.true;
+  });
+
+  it('disables submit when pristine is true', () => {
+    const props = {
+      showAddNewSiteFields: false,
+      handleSubmit: () => {},
+      pristine: true,
+    };
+
+    let wrapper = shallow(<AddRepoSiteForm {...props} />);
+    expect(wrapper.find('button[type="submit"]').props().disabled).to.be.true;
+
+    props.pristine = false;
+    wrapper = shallow(<AddRepoSiteForm {...props} />);
+    expect(wrapper.find('button[type="submit"]').props().disabled).to.be.false;
+  });
+
+  it('calls handleSubmit when submitted', () => {
+    const props = {
+      showAddNewSiteFields: false,
+      handleSubmit: spy(),
+      pristine: false,
+    };
+
+    const wrapper = shallow(<AddRepoSiteForm {...props} />);
+    wrapper.find('form').simulate('submit');
+    expect(props.handleSubmit.calledOnce).to.be.true;
+  });
+
+  it('links back to /sites from the Cancel button', () => {
+    const props = {
+      showAddNewSiteFields: false,
+      handleSubmit: () => {},
+      pristine: true,
+    };
+
+    const wrapper = shallow(<AddRepoSiteForm {...props} />);
+    expect(wrapper.find('Link.usa-button-secondary[to="/sites"]')).to.have.length(1);
+  });
+});

--- a/test/frontend/components/addSite/addSite.test.js
+++ b/test/frontend/components/addSite/addSite.test.js
@@ -12,6 +12,8 @@ const TemplateSiteList = mock();
 const AlertBanner = mock();
 
 const addSite = stub();
+const hideAddNewSiteFields = stub();
+const addUserToSite = stub();
 
 const user = {
   isLoading: false,
@@ -23,13 +25,15 @@ const user = {
 
 const propsWithoutError = {
   storeState: { user, error: '' },
+  showAddNewSiteFields: false,
 };
 
 const Fixture = proxyquire('../../../../frontend/components/AddSite', {
   './TemplateSiteList': TemplateSiteList,
   '../alertBanner': AlertBanner,
-  '../../actions/siteActions': { addSite },
-}).default;
+  '../../actions/siteActions': { addSite, addUserToSite },
+  '../../actions/addNewSiteFieldsActions': { hideAddNewSiteFields },
+}).AddSite;
 
 describe('<AddSite/>', () => {
   let wrapper;
@@ -38,32 +42,16 @@ describe('<AddSite/>', () => {
     wrapper = shallow(<Fixture {...propsWithoutError} />);
   });
 
-  it('has expected default state based on supplied props', () => {
-    const actualState = wrapper.state();
-    const expectedState = {
-      owner: user.data.username,
-      engine: 'jekyll',
-      defaultBranch: 'master',
-      repository: '',
-    };
-
-    expect(actualState).to.deep.equal(expectedState);
-  });
-
-  it('renders form input elements with the correct initial values', () => {
-    const { owner, repository, engine, defaultBranch } = wrapper.state();
-
-    expect(wrapper.find('input[name="owner"]').props().value).to.equal(owner);
-    expect(wrapper.find('input[name="repository"]').props().value).to.equal(repository);
-    expect(wrapper.find('SelectSiteEngine').props().value).to.equal(engine);
-    expect(wrapper.find('input[name="defaultBranch"]').props().value).to.equal(defaultBranch);
+  it('calls addNewSiteFieldsActions.hideAddNewSiteFields on unmount', () => {
+    expect(hideAddNewSiteFields.calledOnce).to.be.false;
+    wrapper.unmount();
+    expect(hideAddNewSiteFields.calledOnce).to.be.true;
   });
 
   it('renders its children', () => {
     expect(wrapper.find(TemplateSiteList)).to.have.length(1);
     expect(wrapper.find(AlertBanner)).to.have.length(1);
-    expect(wrapper.find('Link')).to.have.length(1);
-    expect(wrapper.find('form')).to.have.length(1);
+    expect(wrapper.find('ReduxForm')).to.have.length(1);
   });
 
   it('calls the add site action when a template is selected', () => {
@@ -79,26 +67,30 @@ describe('<AddSite/>', () => {
   it('delivers the correct props to its children', () => {
     const bannerProps = wrapper.find(AlertBanner).props();
     const templateListProps = wrapper.find(TemplateSiteList).props();
-    const formProps = wrapper.find('form').props();
+    const formProps = wrapper.find('ReduxForm').props();
 
     expect(bannerProps).to.deep.equal({ message: propsWithoutError.storeState.error });
     expect(templateListProps).to.deep.equal({
       handleSubmitTemplate: wrapper.instance().onSubmitTemplate,
       defaultOwner: propsWithoutError.storeState.user.data.username,
     });
-    expect(formProps.onSubmit).to.equal(wrapper.instance().onSubmit);
+    expect(formProps.onSubmit).to.equal(wrapper.instance().onAddRepoSiteSubmit);
+    expect(formProps.showAddNewSiteFields).to.equal(propsWithoutError.showAddNewSiteFields);
   });
 
-  it('calls addSite action when add site form is submitted', () => {
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} });
-    expect(addSite.called).to.be.true;
+  it('calls addUserToSite action when add site form is submitted without engine and defaultBranch', () => {
+    const owner = 'boop';
+    const repository = 'beeper-beta-v2';
+    wrapper.find('ReduxForm').props().onSubmit({ owner, repository });
+    expect(addUserToSite.calledWith({ owner, repository })).to.be.true;
   });
 
-  it('updates its state when form fields are changed', () => {
-    const repoInput = wrapper.find('input[name="repository"]');
-    const newValue = 'ohyeah';
-
-    repoInput.simulate('change', { target: { name: 'repository', value: newValue } });
-    expect(wrapper.state().repository).to.equal(newValue);
+  it('calls addSite action when add site form is submitted with all fields', () => {
+    const owner = 'boop';
+    const repository = 'beeper-beta-v2';
+    const engine = 'vrooooom';
+    const defaultBranch = 'tree';
+    wrapper.find('ReduxForm').props().onSubmit({ owner, repository, engine, defaultBranch });
+    expect(addSite.calledWith({ owner, repository, engine, defaultBranch })).to.be.true;
   });
 });

--- a/test/frontend/components/site/SiteGitHubBranches.test.jsx
+++ b/test/frontend/components/site/SiteGitHubBranches.test.jsx
@@ -127,7 +127,9 @@ describe('<SiteGitHubBranches />', () => {
         owner: 'owner',
         repository: 'repo',
       },
-      githubBranches: {},
+      githubBranches: {
+        isLoading: false,
+      },
     };
 
     const wrapper = shallow(<SiteGitHubBranches {...props} />);

--- a/test/frontend/reducers/showAddNewSiteFields.test.js
+++ b/test/frontend/reducers/showAddNewSiteFields.test.js
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+
+import reducer from '../../../frontend/reducers/showAddNewSiteFields';
+
+import {
+  showAddNewSiteFieldsType as ADD_NEW_SITE_FIELDS_SHOW,
+  hideAddNewSiteFieldsType as ADD_NEW_SITE_FIELDS_HIDE,
+} from '../../../frontend/actions/actionCreators/addNewSiteFieldsActions';
+
+describe('showAddNewSiteFields reducer', () => {
+  it('has an initial state of "false"', () => {
+    const state = reducer(undefined, { type: 'bloop' });
+    expect(state).to.be.false;
+  });
+
+  it('returns true when action is ADD_NEW_SITE_FIELDS_SHOW', () => {
+    let state = reducer(undefined, { type: ADD_NEW_SITE_FIELDS_SHOW });
+    expect(state).to.be.true;
+
+    state = reducer(false, { type: ADD_NEW_SITE_FIELDS_SHOW });
+    expect(state).to.be.true;
+  });
+
+  it('returns false when action is ADD_NEW_SITE_FIELDS_HIDE', () => {
+    let state = reducer(undefined, { type: ADD_NEW_SITE_FIELDS_HIDE });
+    expect(state).to.be.false;
+
+    state = reducer(true, { type: ADD_NEW_SITE_FIELDS_HIDE });
+    expect(state).to.be.false;
+  });
+
+  it('ignores other actions', () => {
+    const state = reducer('do not change', { type: 'coffee cup' });
+    expect(state).to.equal('do not change');
+  });
+});

--- a/test/frontend/reducers/sitesTest.js
+++ b/test/frontend/reducers/sitesTest.js
@@ -9,8 +9,10 @@ describe('sitesReducer', () => {
   const SITE_ADDED = 'hey, new site!';
   const SITE_DELETED = 'bye, site.';
   const SITE_UPDATED = 'change the site, please';
+  const SITE_BRANCHES_RECEIVED = 'branches received';
   const SITES_RECEIVED = 'hey, sites!';
   const BUILD_RESTARTED = 'build restarted!';
+  const SITE_USER_ADDED = 'site user added';
 
   beforeEach(() => {
     fixture = proxyquire('../../../frontend/reducers/sites', {
@@ -19,7 +21,9 @@ describe('sitesReducer', () => {
         sitesReceivedType: SITES_RECEIVED,
         siteAddedType: SITE_ADDED,
         siteUpdatedType: SITE_UPDATED,
+        siteBranchesReceivedType: SITE_BRANCHES_RECEIVED,
         siteDeletedType: SITE_DELETED,
+        siteUserAddedType: SITE_USER_ADDED,
       },
       '../actions/actionCreators/buildActions': {
         buildRestartedType: BUILD_RESTARTED,
@@ -136,6 +140,27 @@ describe('sitesReducer', () => {
     expect(actual.data).to.deep.equal([newSite, siteTwo]);
   });
 
+  it('sets existing site branches when SITE_BRANCHES_RECEIVED', () => {
+    const site = {
+      id: 23,
+      branches: ['flower'],
+    };
+
+    const newBranches = ['pencil', 'beer'];
+    const actual = fixture({ isLoading: false, data: [site] }, {
+      type: SITE_BRANCHES_RECEIVED,
+      siteId: site.id,
+      branches: newBranches,
+    });
+
+    expect(actual.data).to.deep.equal([
+      {
+        id: site.id,
+        branches: newBranches,
+      },
+    ]);
+  });
+
   it('ignores delete request if site id is not found', () => {
     const siteOne = {
       id: 'siteToKeep',
@@ -178,5 +203,25 @@ describe('sitesReducer', () => {
     });
 
     expect(actual.data).to.deep.equal([siteOne]);
+  });
+
+  it('adds site to state\'s data when SITE_USER_ADDED', () => {
+    const siteAdded = { id: 55 };
+    const actual = fixture({ isLoading: false, data: [] }, {
+      type: SITE_USER_ADDED,
+      site: siteAdded,
+    });
+
+    expect(actual.isLoading).to.be.false;
+    expect(actual.data).to.deep.equal([siteAdded]);
+  });
+
+  it('returns existing state when SITE_USER_ADDED if action has no site', () => {
+    const actual = fixture({ isLoading: false, data: [] }, {
+      type: SITE_USER_ADDED,
+    });
+
+    expect(actual.isLoading).to.be.false;
+    expect(actual.data).to.deep.equal([]);
   });
 });

--- a/test/frontend/reducers/sitesTest.js
+++ b/test/frontend/reducers/sitesTest.js
@@ -1,36 +1,36 @@
-import { expect } from "chai";
-import proxyquire from "proxyquire";
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
 
 proxyquire.noCallThru();
 
-describe("sitesReducer", () => {
+describe('sitesReducer', () => {
   let fixture;
-  const SITES_FETCH_STARTED = "🐶⚾️"
-  const SITE_ADDED = "hey, new site!";
-  const SITE_DELETED = "bye, site.";
-  const SITE_UPDATED = "change the site, please";
-  const SITES_RECEIVED = "hey, sites!";
-  const BUILD_RESTARTED = "build restarted!"
+  const SITES_FETCH_STARTED = '🐶⚾️';
+  const SITE_ADDED = 'hey, new site!';
+  const SITE_DELETED = 'bye, site.';
+  const SITE_UPDATED = 'change the site, please';
+  const SITES_RECEIVED = 'hey, sites!';
+  const BUILD_RESTARTED = 'build restarted!';
 
   beforeEach(() => {
-    fixture = proxyquire("../../../frontend/reducers/sites", {
-      "../actions/actionCreators/siteActions": {
+    fixture = proxyquire('../../../frontend/reducers/sites', {
+      '../actions/actionCreators/siteActions': {
         sitesFetchStartedType: SITES_FETCH_STARTED,
         sitesReceivedType: SITES_RECEIVED,
         siteAddedType: SITE_ADDED,
         siteUpdatedType: SITE_UPDATED,
         siteDeletedType: SITE_DELETED,
       },
-      "../actions/actionCreators/buildActions": {
+      '../actions/actionCreators/buildActions': {
         buildRestartedType: BUILD_RESTARTED,
       },
     }).default;
   });
 
-  it("defaults to an initial state and ignores other actions", () => {
+  it('defaults to an initial state and ignores other actions', () => {
     const actual = fixture(undefined, {
       type: "not what you're looking for",
-      hello: "alijasfjir"
+      hello: 'alijasfjir',
     });
 
     expect(actual).to.deep.equal({ isLoading: false });
@@ -39,17 +39,17 @@ describe("sitesReducer", () => {
   it("marks the state as loading when it gets a 'sites fetch started' action", () => {
     const actual = fixture({ isLoading: false }, {
       type: SITES_FETCH_STARTED,
-    })
+    });
 
-    expect(actual).to.deep.equal({ isLoading: true })
-  })
+    expect(actual).to.deep.equal({ isLoading: true });
+  });
 
   it("replaces anything it has when it gets a 'sites received' action", () => {
-    const sites = [{ hello: "world"}, { how: "are you?" }];
+    const sites = [{ hello: 'world' }, { how: 'are you?' }];
 
-    const actual = fixture({ isLoading: false, data: [{ oldData: "to be lost" }] }, {
+    const actual = fixture({ isLoading: false, data: [{ oldData: 'to be lost' }] }, {
       type: SITES_RECEIVED,
-      sites: sites
+      sites,
     });
 
     expect(actual).to.deep.equal({
@@ -60,8 +60,8 @@ describe("sitesReducer", () => {
 
 
   it("ignores a malformed 'sites received' action", () => {
-    const actual = fixture([{ oldData: "to be lost" }], {
-      type: SITES_RECEIVED
+    const actual = fixture([{ oldData: 'to be lost' }], {
+      type: SITES_RECEIVED,
     });
 
     expect(actual).to.deep.equal({
@@ -70,24 +70,23 @@ describe("sitesReducer", () => {
     });
   });
 
-  it("adds a site if action has a site", () => {
-    const existingSites = [{ existing: "siteToKeep" }];
-    const site = { hereIs: "something" };
+  it('adds a site if action has a site', () => {
+    const existingSites = [{ existing: 'siteToKeep' }];
+    const site = { hereIs: 'something' };
 
     const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_ADDED,
-      site: site
+      site,
     });
 
     expect(actual.data).to.deep.equal(existingSites.concat(site));
   });
 
-  it("does not add a site if action has no site", () => {
-    const existingSites = [{ existing: "siteToKeep" }];
-    const site = { hereIs: "something" };
+  it('does not add a site if action has no site', () => {
+    const existingSites = [{ existing: 'siteToKeep' }];
 
     const actual = fixture({ isLoading: false, data: existingSites }, {
-      type: SITE_ADDED
+      type: SITE_ADDED,
     });
 
     expect(actual.data).to.deep.equal(existingSites);
@@ -95,19 +94,19 @@ describe("sitesReducer", () => {
 
   it("ignores when given an update action and the new site's id is not found", () => {
     const existingSites = [{
-      id: "siteToKeep",
-      oldData: true
+      id: 'siteToKeep',
+      oldData: true,
     }, {
-      id: "anotherSiteToKeep",
-      oldData: true
+      id: 'anotherSiteToKeep',
+      oldData: true,
     }];
 
-    const site = { id: "something", oldData: false };
+    const site = { id: 'something', oldData: false };
 
     const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_UPDATED,
-      siteId: "something",
-      site: site
+      siteId: 'something',
+      site,
     });
 
     expect(actual.data).to.deep.equal(existingSites);
@@ -115,69 +114,69 @@ describe("sitesReducer", () => {
 
   it("updates existing site data when given an update action and the new site's id is found", () => {
     const siteOne = {
-      id: "siteToKeep",
-      oldData: true
+      id: 'siteToKeep',
+      oldData: true,
     };
 
     const siteTwo = {
-      id: "anotherSiteToKeep",
-      oldData: true
+      id: 'anotherSiteToKeep',
+      oldData: true,
     };
 
-    const existingSites = [ siteOne, siteTwo ];
+    const existingSites = [siteOne, siteTwo];
 
-    const newSite = { id: "siteToKeep", oldData: false, hi: "there" };
+    const newSite = { id: 'siteToKeep', oldData: false, hi: 'there' };
 
     const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_UPDATED,
-      siteId: "siteToKeep",
-      site: newSite
+      siteId: 'siteToKeep',
+      site: newSite,
     });
 
-    expect(actual.data).to.deep.equal([ newSite, siteTwo ]);
+    expect(actual.data).to.deep.equal([newSite, siteTwo]);
   });
 
-  it("ignores delete request if site id is not found", () => {
+  it('ignores delete request if site id is not found', () => {
     const siteOne = {
-      id: "siteToKeep",
-      oldData: true
+      id: 'siteToKeep',
+      oldData: true,
     };
 
     const siteTwo = {
-      id: "anotherSiteToKeep",
-      oldData: true
+      id: 'anotherSiteToKeep',
+      oldData: true,
     };
 
-    const existingSites = [ siteOne, siteTwo ];
+    const existingSites = [siteOne, siteTwo];
 
     const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_DELETED,
-      siteId: "i'm not here."
+      siteId: "i'm not here.",
     });
 
     expect(actual.data).to.deep.equal(existingSites);
   });
 
-  it("deletes site if site id is found", () => {
-    const siteToLoseId = "site to lose";
+  it('deletes site if site id is found', () => {
+    const siteToLoseId = 'site to lose';
 
     const siteOne = {
-      id: "siteToKeep",
-      oldData: true
+      id: 'siteToKeep',
+      oldData: true,
     };
 
     const siteTwo = {
       id: siteToLoseId,
-      oldData: true
+      oldData: true,
     };
 
-    const existingSites = [ siteOne, siteTwo ];
+    const existingSites = [siteOne, siteTwo];
 
     const actual = fixture({ isLoading: false, data: existingSites }, {
       type: SITE_DELETED,
-      siteId: siteToLoseId
+      siteId: siteToLoseId,
     });
 
-    expect(actual.data).to.deep.equal([ siteOne ]);
+    expect(actual.data).to.deep.equal([siteOne]);
   });
 });

--- a/test/frontend/reducers/userTest.js
+++ b/test/frontend/reducers/userTest.js
@@ -1,41 +1,59 @@
-import { expect } from "chai";
-import proxyquire from "proxyquire";
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
 
 proxyquire.noCallThru();
 
-describe("userReducer", () => {
+describe('userReducer', () => {
   let fixture;
-  const USER_RECEIVED = "hi, user!";
+  const USER_RECEIVED = 'hi, user!';
+  const USER_FETCH_STARTED = 'fetch started';
 
   beforeEach(() => {
-    fixture = proxyquire("../../../frontend/reducers/user", {
-      "../actions/actionCreators/userActions": {
-        userReceivedType: USER_RECEIVED
-      }
+    fixture = proxyquire('../../../frontend/reducers/user', {
+      '../actions/actionCreators/userActions': {
+        userReceivedType: USER_RECEIVED,
+        userFetchStartedType: USER_FETCH_STARTED,
+      },
     }).default;
   });
 
-  it("has a default and ignores other actions", () => {
+  it('has a default and ignores other actions', () => {
     const actual = fixture(undefined, {
       type: "not what you're looking for",
-      hello: "alijasfjir"
+      hello: 'alijasfjir',
     });
 
     expect(actual).to.deep.equal({ isLoading: false });
   });
 
-  it("records lots of data from the user received action and sets isLoading", () => {
+  it('sets isLoading to true when USER_FETCH_STARTED', () => {
+    const actual = fixture({ isLoading: false, data: {} }, {
+      type: USER_FETCH_STARTED,
+    });
+
+    expect(actual).to.deep.equal({ isLoading: true });
+  });
+
+  it('returns false when USER_RECEIVED with no user', () => {
+    const actual = fixture(undefined, {
+      type: USER_RECEIVED,
+    });
+
+    expect(actual).to.be.false;
+  });
+
+  it('records lots of data and sets isLoading when USER_RECEIVED', () => {
     const user = {
       id: 12,
-      username: "bob",
-      email: "no-email@nothingtoseeheresopleasego.org",
-      createdAt: "Monday morning.",
-      updatedAt: "Thursday, late in the afternoon."
+      username: 'bob',
+      email: 'no-email@nothingtoseeheresopleasego.org',
+      createdAt: 'Monday morning.',
+      updatedAt: 'Thursday, late in the afternoon.',
     };
 
-    const actual = fixture({ anything: "goes here" }, {
+    const actual = fixture({ anything: 'goes here' }, {
       type: USER_RECEIVED,
-      user: user
+      user,
     });
 
     expect(actual).to.deep.equal({

--- a/test/frontend/util/federalistApi.test.js
+++ b/test/frontend/util/federalistApi.test.js
@@ -52,10 +52,37 @@ describe('federalistApi', () => {
     fetchMock.post(`${API}/site`, {}, { name: 'postSite' });
     fetchMock.delete(`${API}/site/2`, {}, { name: 'deleteSite' });
     fetchMock.post(`${API}/build/`, {}, { name: 'postBuild' });
+    fetchMock.post(`${API}/site/user`, {}, { name: 'postSiteUser' });
+    fetchMock.put(`${API}/site/3`, {}, { name: 'putSite' });
+    fetchMock.put(`${API}/site/5`, 400, { name: 'putSiteError' });
   });
 
   after(() => {
     fetchMock.restore();
+  });
+
+  describe('handles errors', () => {
+    it('does not throw error by default', (done) => {
+      federalistApi.fetch('site/5', { method: 'PUT', data: {} })
+        .then(() => {
+          expect(true).to.be.true;
+          done();
+        })
+        .catch(() => {
+          // should never get here
+          expect(false).to.be.true;
+          done();
+        });
+    });
+
+    it('throws an error if handleHttpError is false', (done) => {
+      federalistApi.fetch('site/5', { method: 'PUT', data: {} }, { handleHttpError: false })
+        .catch((err) => {
+          expect(err).to.be.defined;
+          expect(err.response.status).to.equal(400);
+          done();
+        });
+    });
   });
 
   it('defines fetchBuilds', () => {
@@ -97,6 +124,19 @@ describe('federalistApi', () => {
   it('defines deleteSite', () => {
     federalistApi.deleteSite(2);
     testRouteCalled('deleteSite', { method: 'DELETE' });
+  });
+
+  it('defines addUserToSite', () => {
+    const body = { owner: 'hamburger', repository: 'taco' };
+    federalistApi.addUserToSite(body);
+    testRouteCalled('postSiteUser', { method: 'POST', body });
+  });
+
+  it('defines updateSite', () => {
+    const site = { id: 3 };
+    const body = { defaultBranch: 'paperclip' };
+    federalistApi.updateSite(site, body);
+    testRouteCalled('putSite', { method: 'PUT', body });
   });
 
   describe('restartBuild', () => {


### PR DESCRIPTION
First show the owner and repository fields in the Add Site flow.
If a site exists in Federalist (that the user can access), then add the current
user to that site.
Otherwise, present the user with the engine and primary branch fields so
that a completely new site will be added to Federalist.

also:
- extract AddRepoSiteForm and use redux-form for it
- create new back end method to add a user to a Federalist site based on owner/repo
- lots of linting and tests

To Do:
- [x] BUG: Site engine selection does not seem to be saved. Ie, "jekyll" is selected during add but "static" shows up in the added site's settings.
- [x] specifically look for a `404` in https://github.com/18F/federalist/pull/1221#discussion-diff-144615332R43

ref #1115