### PR TITLE
Add explanatory text to Published Files table

### DIFF
--- a/frontend/components/site/sitePublishedFilesTable.js
+++ b/frontend/components/site/sitePublishedFilesTable.js
@@ -22,6 +22,7 @@ class SitePublishedFilesTable extends React.Component {
   renderPublishedFilesTable(files) {
     return (<div>
       <h3>{this.props.params.name}</h3>
+      <p>Use this screen to audit the files that Federalist has publicly published.</p>
       <table className="usa-table-borderless">
         <thead>
           <tr>


### PR DESCRIPTION
<img width="823" alt="screen shot 2017-10-27 at 9 11 42 am" src="https://user-images.githubusercontent.com/697848/32108392-272f2b60-baf7-11e7-88e1-4bdff3e97a4a.png">

ref #1234 