### PR TITLE
explantory text on pub branches page

### DIFF
--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -21,17 +21,23 @@ class SitePublishedBranchesTable extends React.Component {
 
   renderPublishedBranchesTable() {
     return (
-      <table className="usa-table-borderless published-branch-table">
-        <thead>
-          <tr>
-            <th>Branch</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          { this.publishedBranches().map(this.renderPublishedBranchRow.bind(this)) }
-        </tbody>
-      </table>
+      <div>
+        <p>
+          Use this page to see every version of your site&apos;s code published on
+          Federalist and to audit the specific files that Federalist has published.
+        </p>
+        <table className="usa-table-borderless published-branch-table">
+          <thead>
+            <tr>
+              <th>Branch</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            { this.publishedBranches().map(this.renderPublishedBranchRow.bind(this)) }
+          </tbody>
+        </table>
+      </div>
     );
   }
 

--- a/frontend/components/site/sitePublishedFilesTable.js
+++ b/frontend/components/site/sitePublishedFilesTable.js
@@ -22,7 +22,7 @@ class SitePublishedFilesTable extends React.Component {
   renderPublishedFilesTable(files) {
     return (<div>
       <h3>{this.props.params.name}</h3>
-      <p>Use this screen to audit the files that Federalist has publicly published.</p>
+      <p>Use this page to audit the files that Federalist has publicly published.</p>
       <table className="usa-table-borderless">
         <thead>
           <tr>


### PR DESCRIPTION
ref #1234

<img width="822" alt="screen shot 2017-10-27 at 10 13 21 am" src="https://user-images.githubusercontent.com/697848/32111304-bb81e282-baff-11e7-8e3a-eb024c4cf08f.png">

I also changed the word "screen" to "page" on the Published Files page to better match the wording shown above.