### PR TITLE
Break SiteMembershipCreator off of SiteCreator

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -1,6 +1,7 @@
 const authorizer = require('../authorizers/site');
 const S3SiteRemover = require('../services/S3SiteRemover');
 const SiteCreator = require('../services/SiteCreator');
+const SiteMembershipCreator = require('../services/SiteMembershipCreator');
 const siteSerializer = require('../serializers/site');
 const { User, Site, Build } = require('../models');
 
@@ -76,15 +77,15 @@ module.exports = {
   addUser: (req, res) => {
     const body = req.body;
     if (!body.owner || !body.repository) {
-      throw 400;
+      res.error(400);
+      return;
     }
 
     authorizer.create(req.user, body)
-      .then(() => SiteCreator.addUserToSite(
-        body.owner.toLowerCase(),
-        body.repository.toLowerCase(),
-        req.user)
-      )
+      .then(() => SiteMembershipCreator.createSiteMembership({
+        user: req.user,
+        siteParams: body,
+      }))
       .then(site => siteSerializer.serialize(site))
       .then((siteJSON) => {
         res.json(siteJSON);

--- a/api/services/SiteMembershipCreator.js
+++ b/api/services/SiteMembershipCreator.js
@@ -1,0 +1,55 @@
+const GitHub = require('./GitHub');
+const { Site, User } = require('../models');
+
+const checkGithubRepository = ({ user, owner, repository }) =>
+  GitHub.getRepository(user, owner, repository).then((repo) => {
+    if (!repo) {
+      throw {
+        message: `The repository ${owner}/${repository} does not exist.`,
+        status: 400,
+      };
+    }
+    if (!repo.permissions.push) {
+      throw {
+        message: 'You do not have write access to this repository',
+        status: 400,
+      };
+    }
+    return true;
+  });
+
+const paramsForExistingSite = siteParams => ({
+  owner: siteParams.owner ? siteParams.owner.toLowerCase() : null,
+  repository: siteParams.repository ? siteParams.repository.toLowerCase() : null,
+});
+
+const throwExistingSiteErrors = ({ site, user }) => {
+  if (!site) {
+    const error = new Error('The site you are trying to add does not exist');
+    error.status = 404;
+    throw error;
+  }
+
+  const existingUser = site.Users.find(candidate => candidate.id === user.id);
+  if (existingUser) {
+    const error = new Error("You've already added this site to Federalist");
+    error.status = 400;
+    throw error;
+  }
+
+  return checkGithubRepository({ user, owner: site.owner, repository: site.repository });
+};
+
+const createSiteMembership = ({ user, siteParams }) => {
+  let site;
+
+  return Site.findOne({ where: paramsForExistingSite(siteParams), include: [User] })
+  .then((fetchedSite) => {
+    site = fetchedSite;
+    return throwExistingSiteErrors({ site, user });
+  }).then(() =>
+    site.addUser(user)
+  ).then(() => site);
+};
+
+module.exports = { createSiteMembership };

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -407,6 +407,38 @@ paths:
           description: Not authorized
           schema:
             $ref: "Error.json"
+  /site/user:
+    post:
+      summary: Add the current user to a site based on the owner and repository name
+      parameters:
+        - name: site
+          in: body
+          schema:
+            type: object
+            properties:
+              owner:
+                type: string
+                description: The owner of the GitHub repo for the site
+              repository:
+                type: string
+                description: The name of the GitHub repository for the site
+      responses:
+        200:
+          description: A site object representing the site the user was added to
+          schema:
+            $ref: "Site.json"
+        400:
+          description: Bad request
+          schema:
+            $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: The site the user is to be added to cannot be found
+          schema:
+            $ref: "Error.json"
   /me:
     get:
       summary: Fetch data for the current user

--- a/test/api/unit/services/SiteMembershipCreator.test.js
+++ b/test/api/unit/services/SiteMembershipCreator.test.js
@@ -1,0 +1,157 @@
+const expect = require('chai').expect;
+const nock = require('nock');
+const factory = require('../../support/factory');
+const githubAPINocks = require('../../support/githubAPINocks');
+const SiteMembershipCreator = require('../../../../api/services/SiteMembershipCreator');
+
+describe('SiteMembershipCreator', () => {
+  describe('.createSiteMembership({ siteParams, user })', () => {
+    beforeEach(() => {
+      githubAPINocks.repo({
+        response: [
+          200,
+          { permissions: { admin: false, push: true } },
+        ],
+      });
+    });
+
+    it('should add the user to the site', (done) => {
+      let site;
+      let user;
+
+      Promise.props({
+        userProm: factory.user(),
+        siteProm: factory.site(),
+      }).then(({ siteProm, userProm }) => {
+        user = userProm;
+        site = siteProm;
+
+        return SiteMembershipCreator.createSiteMembership({
+          user,
+          siteParams: { owner: site.owner, repository: site.repository },
+        });
+      })
+      .then(() =>
+        site.getUsers({ where: { id: user.id } })
+      ).then((users) => {
+        expect(users).to.have.lengthOf(1);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should reject with 404 if the site does not exist', (done) => {
+      factory.user().then(user =>
+        SiteMembershipCreator.createSiteMembership({
+          user,
+          siteParams: { owner: 'not-a', repository: 'real-site' },
+        })
+      ).catch((err) => {
+        expect(err.status).to.equal(404);
+        expect(err.message).to.equal('The site you are trying to add does not exist');
+        done();
+      }).catch(done);
+    });
+
+    it('should reject if the user does not have write access to the site', (done) => {
+      let site;
+      let user;
+
+      Promise.props({
+        userProm: factory.user(),
+        siteProm: factory.site(),
+      })
+      .then(({ siteProm, userProm }) => {
+        user = userProm;
+        site = siteProm;
+
+        nock.cleanAll();
+        githubAPINocks.repo({
+          accessToken: user.accessToken,
+          owner: site.owner,
+          repo: site.repository,
+          response: [200, { permissions: {
+            admin: false,
+            push: false,
+          } }],
+        });
+
+        return SiteMembershipCreator.createSiteMembership({
+          user,
+          siteParams: { owner: site.owner, repository: site.repository },
+        });
+      })
+      .catch((err) => {
+        expect(err.status).to.eq(400);
+        expect(err.message).to.equal('You do not have write access to this repository');
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should reject if the user has already added the site', (done) => {
+      const userProm = factory.user();
+      const siteProm = factory.site({ users: Promise.all([userProm]) });
+
+      Promise.props({ user: userProm, site: siteProm }).then(({ user, site }) =>
+        SiteMembershipCreator.createSiteMembership({
+          user,
+          siteParams: { owner: site.owner, repository: site.repository },
+        })
+      ).catch((err) => {
+        expect(err.status).to.equal(400);
+        expect(err.message).to.equal("You've already added this site to Federalist");
+        done();
+      }).catch(done);
+    });
+
+    it('should reject if the user has already added the site and the name is different case', (done) => {
+      const userProm = factory.user();
+      const siteProm = factory.site({ users: Promise.all([userProm]) });
+
+      Promise.props({ user: userProm, site: siteProm }).then(({ user, site }) =>
+        SiteMembershipCreator.createSiteMembership({
+          user,
+          siteParams: {
+            owner: site.owner.toUpperCase(),
+            repository: site.repository.toUpperCase(),
+          },
+        })
+      ).catch((err) => {
+        expect(err.status).to.equal(400);
+        expect(err.message).to.equal("You've already added this site to Federalist");
+        done();
+      }).catch(done);
+    });
+
+    it('should reject if the repository does not exist', (done) => {
+      let site;
+
+      Promise.props({
+        user: factory.user(),
+        site: factory.site(),
+      }).then((models) => {
+        site = models.site;
+
+        nock.cleanAll();
+        githubAPINocks.repo({
+          accessToken: models.user.accessToken,
+          owner: site.owner,
+          repo: site.repository,
+          response: [404, { message: 'Not Found' }],
+        });
+        return SiteMembershipCreator.createSiteMembership({
+          user: models.user,
+          siteParams: {
+            owner: site.owner.toUpperCase(),
+            repository: site.repository.toUpperCase(),
+          },
+        });
+      }).catch((err) => {
+        expect(err.status).to.eq(400);
+        expect(err.message).to.eq(`The repository ${site.owner}/${site.repository} does not exist.`);
+        done();
+      }).catch(done);
+    });
+  });
+});


### PR DESCRIPTION
The SiteCreator service was doing double duty, creating sites and adding
users to sites. This commit creates a new service and moves the code to
add a user to a site into that service.

One change in the API as a result of this is that now attempting to
create a site that already exists renders an error instead of adding a
user to the site. The addUser endpoint will need to be used now to add
users to a site.