### PR TITLE
Specify default value of SelectSiteEngine in AddRepoSiteForm

### DIFF
--- a/frontend/components/AddSite/AddRepoSiteForm.jsx
+++ b/frontend/components/AddSite/AddRepoSiteForm.jsx
@@ -9,6 +9,9 @@ import SelectSiteEngine from '../SelectSiteEngine';
 const propTypes = {
   showAddNewSiteFields: PropTypes.bool,
 
+  initialValues: PropTypes.shape({
+    engine: PropTypes.string.isRequired,
+  }).isRequired,
   // the following props are from reduxForm:
   handleSubmit: PropTypes.func.isRequired,
   pristine: PropTypes.bool.isRequired,
@@ -18,7 +21,15 @@ const defaultProps = {
   showAddNewSiteFields: false,
 };
 
-export const AddRepoSiteForm = ({ pristine, handleSubmit, showAddNewSiteFields }) => (
+export const AddRepoSiteForm = ({
+  // even though initialValues is not directly used, it is used
+  // by reduxForm, and we want PropType validation on it, so we'll
+  // keep it here but disable the eslint rule below
+  initialValues, // eslint-disable-line no-unused-vars
+  pristine,
+  handleSubmit,
+  showAddNewSiteFields,
+}) => (
   <form onSubmit={handleSubmit}>
     <div className="usa-grid">
       <div className="usa-width-one-half">

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import TemplateSiteList from './TemplateSiteList';
 import AddRepoSiteForm from './AddRepoSiteForm';
 import AlertBanner from '../alertBanner';
+import { availableEngines } from '../SelectSiteEngine';
 
 import siteActions from '../../actions/siteActions';
 import addNewSiteFieldsActions from '../../actions/addNewSiteFieldsActions';
@@ -26,13 +27,21 @@ const defaultProps = {
   showAddNewSiteFields: false,
 };
 
+function getOwnerAndRepo(repoUrl) {
+  const owner = repoUrl.split('/')[3];
+  const repository = repoUrl.split('/')[4];
+
+  return { owner, repository };
+}
+
 export class AddSite extends React.Component {
   constructor(props) {
     super(props);
 
     autoBind(
       this,
-      'onAddRepoSiteSubmit',
+      'onAddUserSubmit',
+      'onCreateSiteSubmit',
       'onSubmitTemplate'
     );
   }
@@ -43,15 +52,14 @@ export class AddSite extends React.Component {
     addNewSiteFieldsActions.hideAddNewSiteFields();
   }
 
-  onAddRepoSiteSubmit({ repoUrl, engine, defaultBranch }) {
-    const owner = repoUrl.split('/')[3];
-    const repository = repoUrl.split('/')[4];
+  onAddUserSubmit({ repoUrl }) {
+    const { owner, repository } = getOwnerAndRepo(repoUrl);
+    siteActions.addUserToSite({ owner, repository });
+  }
 
-    if (!engine && !defaultBranch) {
-      siteActions.addUserToSite({ owner, repository });
-    } else {
-      siteActions.addSite({ owner, repository, engine, defaultBranch });
-    }
+  onCreateSiteSubmit({ repoUrl, engine, defaultBranch }) {
+    const { owner, repository } = getOwnerAndRepo(repoUrl);
+    siteActions.addSite({ owner, repository, engine, defaultBranch });
   }
 
   onSubmitTemplate(site) {
@@ -67,6 +75,11 @@ export class AddSite extends React.Component {
   }
 
   render() {
+    // select the function to use on form submit based on
+    // the showAddNewSiteFields flag
+    const formSubmitFunc = this.props.showAddNewSiteFields ?
+      this.onCreateSiteSubmit : this.onAddUserSubmit;
+
     return (
       <div>
         <AlertBanner message={this.props.storeState.error} />
@@ -94,8 +107,9 @@ export class AddSite extends React.Component {
         </div>
 
         <AddRepoSiteForm
+          initialValues={{ engine: availableEngines[0].value }}
           showAddNewSiteFields={this.props.showAddNewSiteFields}
-          onSubmit={this.onAddRepoSiteSubmit}
+          onSubmit={formSubmitFunc}
         />
       </div>
     );

--- a/frontend/components/GitHubRepoUrlField/index.jsx
+++ b/frontend/components/GitHubRepoUrlField/index.jsx
@@ -5,9 +5,8 @@ import RenderField from './RenderField';
 
 const githubUrlRegex = /^https:\/\/github\.com\/[a-zA-Z0-9_-]{2,}\/[a-zA-Z0-9_-]{2,}$/;
 
-export const required = value => (value && value.length ? undefined : 'Required');
 export const githubRepoUrl = (value) => {
-  if (!githubUrlRegex.test(value)) {
+  if (value && value.length && !githubUrlRegex.test(value)) {
     return 'URL is not formatted correctly';
   }
   return undefined;
@@ -17,7 +16,7 @@ const GitHubRepoUrlField = ({ id, ...props }) => (
   <Field
     id={id}
     component={RenderField}
-    validate={[required, githubRepoUrl]}
+    validate={[githubRepoUrl]}
     {...props}
   />
 );

--- a/frontend/components/SelectSiteEngine.jsx
+++ b/frontend/components/SelectSiteEngine.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const availableEngines = [
+export const availableEngines = [
   {
     label: 'Jekyll',
     value: 'jekyll',

--- a/test/frontend/components/GitHubRepoUrlField.test.jsx
+++ b/test/frontend/components/GitHubRepoUrlField.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
-import GitHubRepoUrlField, { required, githubRepoUrl } from '../../../frontend/components/GitHubRepoUrlField';
+import GitHubRepoUrlField, { githubRepoUrl } from '../../../frontend/components/GitHubRepoUrlField';
 import RenderField from '../../../frontend/components/GitHubRepoUrlField/RenderField';
 
 describe('<GitHubRepoUrlField />', () => {
@@ -25,24 +25,16 @@ describe('<GitHubRepoUrlField />', () => {
 
     const wrapper = shallow(<GitHubRepoUrlField {...props} />);
     const validateProp = wrapper.props().validate;
-    expect(validateProp.length).to.equal(2);
-    expect(validateProp.find(required)).to.not.be.null;
+    expect(validateProp.length).to.equal(1);
     expect(validateProp.find(githubRepoUrl)).to.not.be.null;
-  });
-
-  describe('required validator', () => {
-    it('validates', () => {
-      expect(required('')).to.equal('Required');
-      expect(required()).to.equal('Required');
-      expect(required('anything')).to.be.undefined;
-    });
   });
 
   describe('githubRepoUrl validator', () => {
     it('validates', () => {
       const msg = 'URL is not formatted correctly';
-      expect(githubRepoUrl()).to.equal(msg);
-      expect(githubRepoUrl('')).to.equal(msg);
+      expect(githubRepoUrl()).to.be.undefined;
+      expect(githubRepoUrl('')).to.be.undefined;
+
       expect(githubRepoUrl('anything')).to.equal(msg);
       expect(githubRepoUrl('https://example.com')).to.equal(msg);
 

--- a/test/frontend/components/addSite/addSite.test.js
+++ b/test/frontend/components/addSite/addSite.test.js
@@ -74,20 +74,36 @@ describe('<AddSite/>', () => {
       handleSubmitTemplate: wrapper.instance().onSubmitTemplate,
       defaultOwner: propsWithoutError.storeState.user.data.username,
     });
-    expect(formProps.onSubmit).to.equal(wrapper.instance().onAddRepoSiteSubmit);
+    expect(formProps.onSubmit).to.equal(wrapper.instance().onAddUserSubmit);
     expect(formProps.showAddNewSiteFields).to.equal(propsWithoutError.showAddNewSiteFields);
+    expect(formProps.initialValues).to.deep.equal({ engine: 'jekyll' });
   });
 
-  it('calls addUserToSite action when add site form is submitted without engine and defaultBranch', () => {
+  it('delivers onCreateSiteSubmit when showAddNewSiteFields is true', () => {
+    const props = Object.assign({}, propsWithoutError);
+    props.showAddNewSiteFields = true;
+
+    wrapper = shallow(<Fixture {...props} />);
+
+    const formProps = wrapper.find('ReduxForm').props();
+    expect(formProps.onSubmit).to.equal(wrapper.instance().onCreateSiteSubmit);
+  });
+
+  it('calls addUserToSite action when add site form is submitted', () => {
     const repoUrl = 'https://github.com/owner/repo';
     wrapper.find('ReduxForm').props().onSubmit({ repoUrl });
     expect(addUserToSite.calledWith({ owner: 'owner', repository: 'repo' })).to.be.true;
   });
 
-  it('calls addSite action when add site form is submitted with all fields', () => {
+  it('calls addSite action when add site form is submitted and showAddNewSiteFields is true', () => {
     const repoUrl = 'https://github.com/boop/beeper-v2';
     const engine = 'vrooooom';
     const defaultBranch = 'tree';
+
+    const props = Object.assign({}, propsWithoutError);
+    props.showAddNewSiteFields = true;
+    wrapper = shallow(<Fixture {...props} />);
+
     wrapper.find('ReduxForm').props().onSubmit({ repoUrl, engine, defaultBranch });
     expect(addSite.calledWith({ owner: 'boop', repository: 'beeper-v2', engine, defaultBranch })).to.be.true;
   });


### PR DESCRIPTION
Ref #1260. Fixes the issue by defaulting the `SelectSiteEngine` value in the `AddRepoSiteForm` to the first of its available options (ie, `jekyll`).

Also went ahead and made the fix for #1250 since nearby code.