### PR TITLE
dispatch siteUpdated only when site is returned

### DIFF
--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -54,7 +54,11 @@ export default {
 
   updateSite(site, data) {
     return federalist.updateSite(site, data)
-      .then(dispatchSiteUpdatedAction)
+      .then((updatedSite) => {
+        if (updatedSite) {
+          dispatchSiteUpdatedAction(updatedSite);
+        }
+      })
       .catch(alertError);
   },
 

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -181,7 +181,10 @@ describe('siteActions', () => {
 
       const actual = fixture.updateSite(siteToUpdate, data);
 
-      return validateResultDispatchesHttpAlertError(actual, errorMessage);
+      return actual.then(() => {
+        expect(dispatchSiteUpdatedAction.called).to.be.false;
+        validateResultDispatchesHttpAlertError(actual, errorMessage);
+      });
     });
   });
 


### PR DESCRIPTION
ref #1123 

This turned out to be improperly issued action getting fired after the server-side validation error response. It did take a while to track down though.

I didn't end up needing to do anything with the Site Settings forms at all to fix this, so #1307 is still outstanding.