### PR TITLE
Modify CodeClimate rules/engines

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,7 @@
 ---
 engines:
+  duplication:
+    enabled: false
   eslint:
     enabled: true
     channel: "eslint-3"


### PR DESCRIPTION
ref #1315

Disable the "duplication" engine. It wasn't really identifying anything very relevant from my scan of the errors it caught. Most of the "duplicated" code was in tests.