### PR TITLE
Fixing hover color on top nav

### DIFF
--- a/frontend/sass/_header.scss
+++ b/frontend/sass/_header.scss
@@ -51,7 +51,8 @@ nav li {
 }
 
 nav li a,
-nav li a:visited {
+nav li a:visited,
+nav li a:hover {
   color: white;
 }
 


### PR DESCRIPTION
### Before 👎 link turned blue on hover
<img width="256" alt="screen shot 2017-12-05 at 11 58 56 am" src="https://user-images.githubusercontent.com/1449852/33619388-1e272556-d9b3-11e7-9d27-77c1dda70f96.png">

### After 👍 link stays white on hover
<img width="252" alt="screen shot 2017-12-05 at 11 59 14 am" src="https://user-images.githubusercontent.com/1449852/33619397-24a7d6f0-d9b3-11e7-87a2-3fa229e8cd67.png">
