### PR TITLE
expose docker db container port to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       context: .
     volumes:
       - db-data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
     environment:
       POSTGRES_DB: federalist
       POSTGRES_TEST_DB: federalist-test


### PR DESCRIPTION
Minor to change to expose the `db` container on localhost port `5433`. That way one could interact with the development db from their host machine.