### PR TITLE
(WIP)Autofill github url so user doesnt have to type so much

### DIFF
--- a/frontend/components/AddSite/AddRepoSiteForm.jsx
+++ b/frontend/components/AddSite/AddRepoSiteForm.jsx
@@ -11,6 +11,7 @@ const propTypes = {
 
   initialValues: PropTypes.shape({
     engine: PropTypes.string.isRequired,
+    repoUrl: PropTypes.string.isRequired
   }).isRequired,
   // the following props are from reduxForm:
   handleSubmit: PropTypes.func.isRequired,

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -107,7 +107,10 @@ export class AddSite extends React.Component {
         </div>
 
         <AddRepoSiteForm
-          initialValues={{ engine: availableEngines[0].value }}
+          initialValues={{
+            engine: availableEngines[0].value,
+            repoUrl: 'https://github.com/'
+          }}
           showAddNewSiteFields={this.props.showAddNewSiteFields}
           onSubmit={formSubmitFunc}
         />

--- a/frontend/components/GitHubRepoUrlField/index.jsx
+++ b/frontend/components/GitHubRepoUrlField/index.jsx
@@ -4,6 +4,7 @@ import { Field } from 'redux-form';
 import RenderField from './RenderField';
 
 const githubUrlRegex = /^https:\/\/github\.com\/[a-zA-Z0-9._-]{2,}\/[a-zA-Z0-9._-]{2,}$/;
+const githubBaseUrl = 'https://github.com/';
 
 export const githubRepoUrl = (value) => {
   if (value && value.length && !githubUrlRegex.test(value)) {
@@ -12,11 +13,24 @@ export const githubRepoUrl = (value) => {
   return undefined;
 };
 
+const prefixGitHubUrl = (value, previousValue, allValues) => {
+  if (!value || value === githubBaseUrl || value.length < githubBaseUrl.length) {
+    return githubBaseUrl;
+  }
+
+  if (!previousValue) {
+    return githubBaseUrl + value
+  }
+
+  return value;
+};
+
 const GitHubRepoUrlField = ({ id, ...props }) => (
   <Field
     id={id}
     component={RenderField}
     validate={[githubRepoUrl]}
+    normalize={prefixGitHubUrl}
     {...props}
   />
 );


### PR DESCRIPTION
This is just a work in progress I put together because I was getting tired of typing the entire github URL every time I added a test site. Let me know if this seems useful and I will write some tests!

![auto-fill-form](https://user-images.githubusercontent.com/1421848/33688409-47adad54-daa9-11e7-91b5-066f933896ef.gif)


Alternatively, it might be nice to make the user only type their `username/reponame`, and we can just prepend the github url automatically