### PR TITLE
Install git in app container

### DIFF
--- a/Dockerfile-app
+++ b/Dockerfile-app
@@ -1,5 +1,7 @@
 FROM node:6.12-slim
 
+RUN apt-get update && apt-get install -y git
+
 RUN mkdir -p /app
 
 WORKDIR /app


### PR DESCRIPTION
without it, we are not able to run our `yarn lint:diff` command within the `app` container