### PR TITLE
Static content support

### DIFF
--- a/api/controllers/content.js
+++ b/api/controllers/content.js
@@ -36,15 +36,14 @@ function cleanRequestPath(reqPath) {
   return cleaned;
 }
 
-// get a list of all available content files upon this module being loaded
-const availableContentFiles = getDirectoryFiles(CONTENT_PATH)
-  .map(fp => path.relative(CONTENT_PATH, fp));
-
 let webpackAssets = loadAssetManifest();
 
 module.exports = {
   serve(req, res) {
     const reqPath = cleanRequestPath(req.path);
+
+    const availableContentFiles = getDirectoryFiles(CONTENT_PATH)
+      .map(fp => path.relative(CONTENT_PATH, fp));
 
     // try to find a content template file matching the requested path
     const contentFilePath = findContentFilePath(reqPath, availableContentFiles);

--- a/api/controllers/content.js
+++ b/api/controllers/content.js
@@ -37,13 +37,19 @@ function cleanRequestPath(reqPath) {
 }
 
 let webpackAssets = loadAssetManifest();
+let availableContentFiles;
 
 module.exports = {
   serve(req, res) {
     const reqPath = cleanRequestPath(req.path);
 
-    const availableContentFiles = getDirectoryFiles(CONTENT_PATH)
-      .map(fp => path.relative(CONTENT_PATH, fp));
+    if (!availableContentFiles) {
+      // Walk the content directory save the results the first time we get here.
+      // We do this within this handler in order to easily mock the fs
+      // during testing.
+      availableContentFiles = getDirectoryFiles(CONTENT_PATH)
+        .map(fp => path.relative(CONTENT_PATH, fp));
+    }
 
     // try to find a content template file matching the requested path
     const contentFilePath = findContentFilePath(reqPath, availableContentFiles);

--- a/api/controllers/content.js
+++ b/api/controllers/content.js
@@ -1,0 +1,71 @@
+const path = require('path');
+
+const { getDirectoryFiles, loadAssetManifest, getSiteDisplayEnv } = require('../utils');
+
+const CONTENT_DIR = 'content';
+const CONTENT_PATH = path.join('views', CONTENT_DIR);
+const TEMPLATE_EXT = 'njk';
+
+function findContentFilePath(requestedPath, availableContentFiles) {
+  return availableContentFiles.find((f) => {
+    // see if there is a template file that matches the path
+    if (f === `${requestedPath}.${TEMPLATE_EXT}`) {
+      return true;
+    }
+    // see if there is an index template file that matches
+    if (f === `${requestedPath}/index.${TEMPLATE_EXT}`) {
+      return true;
+    }
+    return false;
+  });
+}
+
+function cleanRequestPath(reqPath) {
+  // Strips the prefixed and suffixed '/' characters
+  // if they are present.
+  let cleaned = reqPath;
+
+  if (cleaned[0] === '/') {
+    cleaned = cleaned.substr(1);
+  }
+
+  if (cleaned[cleaned.length - 1] === '/') {
+    cleaned = cleaned.substr(0, cleaned.length - 1);
+  }
+
+  return cleaned;
+}
+
+// get a list of all available content files upon this module being loaded
+const availableContentFiles = getDirectoryFiles(CONTENT_PATH)
+  .map(fp => path.relative(CONTENT_PATH, fp));
+
+let webpackAssets = loadAssetManifest();
+
+module.exports = {
+  serve(req, res) {
+    const reqPath = cleanRequestPath(req.path);
+
+    // try to find a content template file matching the requested path
+    const contentFilePath = findContentFilePath(reqPath, availableContentFiles);
+
+    if (!contentFilePath) {
+      return res.status(404).send('Not Found');
+    }
+
+    if (process.env.NODE_ENV === 'development') {
+      // reload the webpack assets during development so we don't have to
+      // restart the server for front end changes
+      webpackAssets = loadAssetManifest();
+    }
+
+    const siteDisplayEnv = getSiteDisplayEnv();
+
+    const context = {
+      webpackAssets,
+      siteDisplayEnv,
+    };
+
+    return res.render(path.join(CONTENT_DIR, contentFilePath), context);
+  },
+};

--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -1,19 +1,7 @@
-const fs = require('fs');
-const path = require('path');
-const logger = require('winston');
-
 const BuildCounter = require('../services/BuildCounter');
 const SiteWideErrorLoader = require('../services/SiteWideErrorLoader');
 const config = require('../../config');
-
-function loadAssetManifest() {
-  const manifestPath = path.join(__dirname, '..', '..', 'webpack-manifest.json');
-  if (!fs.existsSync(manifestPath)) {
-    logger.error('webpack-manifest.json does not exist. Have you run webpack (`yarn build`)?');
-    throw new Error();
-  }
-  return JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-}
+const { loadAssetManifest, getSiteDisplayEnv } = require('../utils');
 
 let webpackAssets = loadAssetManifest();
 
@@ -24,7 +12,7 @@ function defaultContext(req) {
     webpackAssets = loadAssetManifest();
   }
 
-  const siteDisplayEnv = config.app.app_env !== 'production' ? config.app.app_env : null;
+  const siteDisplayEnv = getSiteDisplayEnv();
 
   const messages = {
     errors: req.flash('error'),

--- a/api/routers/content.js
+++ b/api/routers/content.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+
+const ContentController = require('../controllers/content');
+
+router.get('/*', ContentController.serve);
+
+module.exports = router;

--- a/api/routers/index.js
+++ b/api/routers/index.js
@@ -18,4 +18,8 @@ apiRouter.use(require('./site'));
 // prefix all api routes with "/v0"
 mainRouter.use('/v0', apiRouter);
 
+// this must come last since it contains a wildcard
+// catch-all route to serve content pages
+mainRouter.use(require('./content'));
+
 module.exports = mainRouter;

--- a/api/routers/index.js
+++ b/api/routers/index.js
@@ -18,8 +18,7 @@ apiRouter.use(require('./site'));
 // prefix all api routes with "/v0"
 mainRouter.use('/v0', apiRouter);
 
-// this must come last since it contains a wildcard
-// catch-all route to serve content pages
-mainRouter.use(require('./content'));
+// prefix all static content routes with "/content"
+mainRouter.use('/content', require('./content'));
 
 module.exports = mainRouter;

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -1,4 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+
 const moment = require('moment');
+const logger = require('winston');
 
 const config = require('../../config');
 
@@ -8,6 +12,35 @@ function isPastAuthThreshold(authDate) {
   );
 }
 
+function getDirectoryFiles(dir, existingFileList) {
+  let fileList = existingFileList || [];
+  fs.readdirSync(dir).forEach((file) => {
+    fileList = fs.statSync(path.join(dir, file)).isDirectory()
+      ? getDirectoryFiles(path.join(dir, file), fileList)
+      : fileList.concat(path.join(dir, file));
+  });
+  return fileList;
+}
+
+function loadAssetManifest() {
+  const manifestFile = 'webpack-manifest.json';
+  if (!fs.existsSync(manifestFile)) {
+    logger.error('webpack-manifest.json does not exist. Have you run webpack (`yarn build`)?');
+    throw new Error();
+  }
+  return JSON.parse(fs.readFileSync(manifestFile, 'utf-8'));
+}
+
+function getSiteDisplayEnv() {
+  if (config.app.app_env !== 'production') {
+    return config.app.app_env;
+  }
+  return null;
+}
+
 module.exports = {
+  getDirectoryFiles,
+  getSiteDisplayEnv,
   isPastAuthThreshold,
+  loadAssetManifest,
 };

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "json-schema-deref-sync": "^0.3.3",
     "jsonschema": "^1.1.1",
     "mocha": "2.3.4",
+    "mock-fs": "^4.4.2",
     "nock": "^9.0.2",
     "node-sass": "^4.5.3",
     "nodemon": "^1.3.7",

--- a/test/api/requests/content.test.js
+++ b/test/api/requests/content.test.js
@@ -1,0 +1,52 @@
+const request = require('supertest');
+const fsMock = require('mock-fs');
+
+const app = require('../../../app');
+
+describe('Content Pages', () => {
+  afterEach(() => {
+    fsMock.restore();
+  });
+
+  it('renders content templates', () => {
+    fsMock({
+      'views/content/mytemplate.njk': 'my template content',
+      'views/content/subdir/hi.njk': 'hi content',
+      'views/content/subdir/index.njk': 'index content',
+    });
+
+    request(app)
+      .get('/mytemplate')
+      .expect(200, 'my template content');
+
+    request(app)
+      .get('/subdir')
+      .expect(200, 'index content');
+
+    request(app)
+      .get('/subdir/')
+      .expect(200, 'index content');
+
+    request(app)
+      .get('/subdir/hi')
+      .expect(200, 'hi content');
+
+    request(app)
+      .get('/nonexisting')
+      .expect(404);
+  });
+
+  it('does not render non-njk files', () => {
+    fsMock({
+      'views/content/file.txt': 'a file',
+    });
+
+    request(app)
+      .get('/file')
+      .expect(404);
+
+    request(app)
+      .get('/file.txt')
+      .expect(404);
+  });
+});

--- a/test/api/requests/content.test.js
+++ b/test/api/requests/content.test.js
@@ -1,52 +1,80 @@
 const request = require('supertest');
 const fsMock = require('mock-fs');
+const expect = require('chai').expect;
 
 const app = require('../../../app');
 
 describe('Content Pages', () => {
-  afterEach(() => {
-    fsMock.restore();
-  });
-
-  it('renders content templates', () => {
+  before(() => {
     fsMock({
       'views/content/mytemplate.njk': 'my template content',
       'views/content/subdir/hi.njk': 'hi content',
       'views/content/subdir/index.njk': 'index content',
-    });
-
-    request(app)
-      .get('/mytemplate')
-      .expect(200, 'my template content');
-
-    request(app)
-      .get('/subdir')
-      .expect(200, 'index content');
-
-    request(app)
-      .get('/subdir/')
-      .expect(200, 'index content');
-
-    request(app)
-      .get('/subdir/hi')
-      .expect(200, 'hi content');
-
-    request(app)
-      .get('/nonexisting')
-      .expect(404);
-  });
-
-  it('does not render non-njk files', () => {
-    fsMock({
       'views/content/file.txt': 'a file',
     });
+  });
 
-    request(app)
-      .get('/file')
-      .expect(404);
+  after(() => {
+    fsMock.restore();
+  });
 
+  it('renders content request', (done) => {
     request(app)
-      .get('/file.txt')
-      .expect(404);
+      .get('/content/mytemplate')
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal('my template content');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('renders content request with trailing slash', (done) => {
+    request(app)
+      .get('/content/mytemplate/')
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal('my template content');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('renders an index template', (done) => {
+    request(app)
+      .get('/content/subdir')
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal('index content');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('renders subdirectory content', (done) => {
+    request(app)
+      .get('/content/subdir/hi')
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal('hi content');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('responds with a 404 if content not found', (done) => {
+    request(app)
+      .get('/content/nonexisting')
+      .expect(404)
+      .then(() => done())
+      .catch(done);
+  });
+
+  it('does not render non-njk files', (done) => {
+    request(app)
+      .get('/content/file')
+      .expect(404)
+      .then(() => done())
+      .catch(done);
   });
 });

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -1,8 +1,10 @@
 const expect = require('chai').expect;
 const moment = require('moment');
+const fsMock = require('mock-fs');
 
 const config = require('../../../../config');
 const utils = require('../../../../api/utils');
+
 
 describe('utils', () => {
   describe('.isPastAuthThreshold', () => {
@@ -18,6 +20,66 @@ describe('utils', () => {
       const goodAuthDate = moment().subtract(threshAmount - 5, 'minutes').toDate();
       expect(utils.isPastAuthThreshold(goodAuthDate)).to.equal(false);
       done();
+    });
+  });
+
+  describe('.getDirectoryFiles', () => {
+    afterEach(() => {
+      fsMock.restore();
+    });
+
+    it('returns a listing of all files in the given directory', () => {
+      fsMock({
+        mydir: {
+          'foobar.html': 'foobar content',
+          subdir: {
+            'beep.txt': 'beep content',
+            'boop.txt': 'boop content',
+          },
+        },
+      });
+
+      const result = utils.getDirectoryFiles('mydir');
+      expect(result).to.have.length(3);
+      expect(result).to.deep.equal([
+        'mydir/foobar.html',
+        'mydir/subdir/beep.txt',
+        'mydir/subdir/boop.txt',
+      ]);
+    });
+  });
+
+  describe('.loadAssetManifest', () => {
+    afterEach(() => {
+      fsMock.restore();
+    });
+
+    it('loads webpack-manifest.json', () => {
+      fsMock({
+        'webpack-manifest.json': JSON.stringify({ manifest: 'yay' }),
+      });
+
+      const result = utils.loadAssetManifest();
+      expect(result).to.deep.eq({ manifest: 'yay' });
+    });
+  });
+
+  describe('.getSiteDisplayEnv', () => {
+    const origAppEnv = config.app.app_env;
+
+    after(() => {
+      // restore the app_env
+      config.app.app_env = origAppEnv;
+    });
+
+    it('returns null when app_env is production', () => {
+      config.app.app_env = 'production';
+      expect(utils.getSiteDisplayEnv()).to.be.null;
+    });
+
+    it('returns the app_env when app_env is not production', () => {
+      config.app.app_env = 'development';
+      expect(utils.getSiteDisplayEnv()).to.equal('development');
     });
   });
 });

--- a/views/content/.gitkeep
+++ b/views/content/.gitkeep
@@ -1,0 +1,2 @@
+Put any semi-static content nunjucks (.njk) template files
+in this directory.

--- a/views/home.njk
+++ b/views/home.njk
@@ -50,5 +50,4 @@
         </div>
       </div>
   </div>
-  </div>
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4564,6 +4564,10 @@ mocha@2.3.4:
     mkdirp "0.5.0"
     supports-color "1.2.0"
 
+mock-fs@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.4.2.tgz#09dec5313f97095a450be6aa2ad8ab6738d63d6b"
+
 module-not-found-error@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"


### PR DESCRIPTION
ref #1337 

Static content templates (with extension `.njk`) and subfolders can be placed in the `views/content/` directory. They'll be visitable by going to `https://federalist.18f.gov/content/path/to/filename` (or with a trailing slash).