### PR TITLE
Use GitHubIconLink over direct use of GitHubRepoLink

### DIFF
--- a/frontend/components/siteList/siteListItem.js
+++ b/frontend/components/siteList/siteListItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 import PublishedState from './publishedState';
-import GitHubRepoLink from '../GitHubLink/GitHubRepoLink';
+import GitHubIconLink from '../GitHubLink/GitHubIconLink';
 
 const propTypes = {
   site: PropTypes.shape({
@@ -36,7 +36,7 @@ const SiteListItem = ({ site }) =>
           { site.owner }/{ site.repository }
         </Link>
         {' '}
-        <GitHubRepoLink owner={site.owner} repository={site.repository} />
+        <GitHubIconLink owner={site.owner} repository={site.repository} />
       </h3>
       <PublishedState site={site} />
     </div>

--- a/test/frontend/components/siteList/siteListItem.test.js
+++ b/test/frontend/components/siteList/siteListItem.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import proxyquire from 'proxyquire';
+import GitHubIconLink from '../../../../frontend/components/GitHubLink/GitHubIconLink';
 
 proxyquire.noCallThru();
 
@@ -60,10 +61,13 @@ describe('<SiteListItem />', () => {
     });
   });
 
-  it('outputs a GitHubRepoLink', () => {
-    const repoLink = wrapper.find('GitHubRepoLink');
+  it('outputs a GitHubIconLink', () => {
+    const iconLink = wrapper.find(GitHubIconLink).shallow().first();
+    const repoLink = iconLink.shallow().find('GitHubRepoLink');
+
+    expect(iconLink).to.have.length(1);
+    expect(iconLink.prop('baseHref')).to.be.defined;
     expect(repoLink).to.have.length(1);
-    expect(repoLink.prop('owner')).to.equal('someone');
-    expect(repoLink.prop('repository')).to.equal('something');
+    expect(repoLink.children().find('GitHubMark')).to.have.length(1);
   });
 });


### PR DESCRIPTION
Handy-dandy screenshot

![screen shot 2017-12-12 at 10 58 27 am](https://user-images.githubusercontent.com/1421848/33894265-89b4451a-df2b-11e7-95ae-da880183838f.png)
