### PR TITLE
Adding alert styling for alerts

### DIFF
--- a/frontend/components/alertBanner.js
+++ b/frontend/components/alertBanner.js
@@ -1,35 +1,50 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
-  message: React.PropTypes.string,
-  status: React.PropTypes.string,
+  message: PropTypes.string,
+  status: PropTypes.string,
+  header: PropTypes.string,
+  children: PropTypes.node,
 };
 
 const defaultProps = {
   message: null,
   status: 'info',
+  children: null,
 };
 
-const AlertBanner = ({ message, status = 'info' }) => {
+const renderHeader = (text) => {
+  if (!text) {
+    return null;
+  }
+
+  return (
+    <h3 className="usa-alert-header">
+      { text }
+    </h3>
+  );
+};
+
+const AlertBanner = ({ children, header, message, status }) => {
   if (!message) {
     return null;
   }
 
   return (
-    <div className="usa-grid">
-      <div className="alert-container container">
-        <div
-          className={`usa-alert usa-alert-${status}`}
-          role="alert"
-        >
-          <div className="usa-alert-body">
-            <p className="usa-alert-text">
-              { message }
-            </p>
-          </div>
-        </div>
+    <div
+      className={`usa-alert usa-alert-${status}`}
+      role="alert"
+    >
+      <div className="usa-alert-body">
+        { renderHeader(header) }
+        <p className="usa-alert-text">
+          { message }
+        </p>
+        { children }
       </div>
-    </div>);
+    </div>
+  );
 };
 
 AlertBanner.propTypes = propTypes;

--- a/frontend/components/site/SiteGitHubBranches.jsx
+++ b/frontend/components/site/SiteGitHubBranches.jsx
@@ -27,9 +27,9 @@ export class SiteGitHubBranches extends React.Component {
             <h3 className="usa-alert-header">No branches were found for this repository.</h3>
             <p className="usa-alert-text">
               Often this is because the repository is private or has been deleted.
-          </p>
+            </p>
+          </div>
         </div>
-      </div>
       );
     }
 

--- a/frontend/components/site/SiteGitHubBranches.jsx
+++ b/frontend/components/site/SiteGitHubBranches.jsx
@@ -6,6 +6,7 @@ import LoadingIndicator from '../LoadingIndicator';
 import GitHubIconLink from '../GitHubLink/GitHubIconLink';
 import BranchViewLink from '../branchViewLink';
 import githubBranchActions from '../../actions/githubBranchActions';
+import AlertBanner from '../alertBanner';
 
 export class SiteGitHubBranches extends React.Component {
   componentDidMount() {
@@ -22,14 +23,11 @@ export class SiteGitHubBranches extends React.Component {
 
     if (githubBranches.error || !githubBranches.data || !githubBranches.data.length) {
       return (
-        <div className="usa-alert usa-alert-info" role="alert">
-          <div className="usa-alert-body">
-            <h3 className="usa-alert-header">No branches were found for this repository.</h3>
-            <p className="usa-alert-text">
-              Often this is because the repository is private or has been deleted.
-            </p>
-          </div>
-        </div>
+        <AlertBanner
+          status="info"
+          header="No branches were found for this repository."
+          message="Often this is because the repository is private or has been deleted."
+        />
       );
     }
 

--- a/frontend/components/site/SiteGitHubBranches.jsx
+++ b/frontend/components/site/SiteGitHubBranches.jsx
@@ -22,10 +22,14 @@ export class SiteGitHubBranches extends React.Component {
 
     if (githubBranches.error || !githubBranches.data || !githubBranches.data.length) {
       return (
-        <p>
-          No branches were found for this repository.
-          Often this is because the repository is private or has been deleted.
-        </p>
+        <div className="usa-alert usa-alert-info" role="alert">
+          <div className="usa-alert-body">
+            <h3 className="usa-alert-header">No branches were found for this repository.</h3>
+            <p className="usa-alert-text">
+              Often this is because the repository is private or has been deleted.
+          </p>
+      </div>
+    </div>
       );
     }
 

--- a/frontend/components/site/SiteGitHubBranches.jsx
+++ b/frontend/components/site/SiteGitHubBranches.jsx
@@ -28,8 +28,8 @@ export class SiteGitHubBranches extends React.Component {
             <p className="usa-alert-text">
               Often this is because the repository is private or has been deleted.
           </p>
+        </div>
       </div>
-    </div>
       );
     }
 

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -52,7 +52,13 @@ class SitePublishedFilesTable extends React.Component {
   }
 
   renderEmptyState() {
-    return (<p>No published branch files available.</p>);
+    return (
+      <div className="usa-alert usa-alert-info" role="alert">
+        <div className="usa-alert-body">
+          <p className="usa-alert-text">No published branch files available.</p>
+        </div>
+      </div>
+    );
   }
 
   render() {

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import publishedFileActions from '../../actions/publishedFileActions';
 import LoadingIndicator from '../LoadingIndicator';
+import AlertBanner from '../alertBanner';
 
 class SitePublishedFilesTable extends React.Component {
   componentDidMount() {
@@ -53,11 +54,10 @@ class SitePublishedFilesTable extends React.Component {
 
   renderEmptyState() {
     return (
-      <div className="usa-alert usa-alert-info" role="alert">
-        <div className="usa-alert-body">
-          <p className="usa-alert-text">No published branch files available.</p>
-        </div>
-      </div>
+      <AlertBanner
+        status="info"
+        message="No published branch files available."
+      />
     );
   }
 

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -61,6 +61,7 @@ class SiteSettings extends React.Component {
       <div>
         <p>
           See our doucmentation site for more about
+          { ' ' }
           <a
             target="_blank"
             rel="noopener noreferrer"
@@ -69,7 +70,9 @@ class SiteSettings extends React.Component {
           >
             these settings
           </a>
+          { ' ' }
           or
+          { ' ' }
           <a
             target="_blank"
             rel="noopener noreferrer"

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -8,7 +8,7 @@ import buildActions from '../../actions/buildActions';
 import LoadingIndicator from '../LoadingIndicator';
 import RefreshBuildsButton from './refreshBuildsButton';
 import { duration, timeFrom } from '../../util/datetime';
-
+import AlertBanner from '../alertBanner';
 
 class SiteBuilds extends React.Component {
   static getUsername(build) {
@@ -80,16 +80,15 @@ class SiteBuilds extends React.Component {
 
   renderEmptyState() {
     return (
-      <div className="usa-alert usa-alert-info" role="alert">
-        <div className="usa-alert-body">
-          <h3 className="usa-alert-header">This site does not yet have any builds.</h3>
-          <p className="usa-alert-text">
-            If this site was just added, the first build should be available
-            within a few minutes.
-          </p>
-          <RefreshBuildsButton site={this.props.site} />
-        </div>
-      </div>
+      <AlertBanner
+        status="info"
+        header="This site does not yet have any builds."
+        message="If this site was just added, the first build should be available
+          within a few minutes."
+      >
+        <RefreshBuildsButton site={this.props.site} />
+      </AlertBanner>
+
     );
   }
 

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -80,14 +80,16 @@ class SiteBuilds extends React.Component {
 
   renderEmptyState() {
     return (
-      <div>
-        <p>This site does not yet have any builds.</p>
-        <p>
-          If this site was just added, the first build should be available
-          within a few minutes.
-        </p>
+      <div class="usa-alert usa-alert-info" role="alert">
+        <div class="usa-alert-body">
+          <h3 class="usa-alert-header">This site does not yet have any builds.</h3>
+          <p class="usa-alert-text">
+            If this site was just added, the first build should be available
+            within a few minutes.
+          </p>
         <RefreshBuildsButton site={this.props.site} />
       </div>
+    </div>
     );
   }
 

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -80,14 +80,14 @@ class SiteBuilds extends React.Component {
 
   renderEmptyState() {
     return (
-      <div class="usa-alert usa-alert-info" role="alert">
-        <div class="usa-alert-body">
-          <h3 class="usa-alert-header">This site does not yet have any builds.</h3>
-          <p class="usa-alert-text">
+      <div className="usa-alert usa-alert-info" role="alert">
+        <div className="usa-alert-body">
+          <h3 className="usa-alert-header">This site does not yet have any builds.</h3>
+          <p className="usa-alert-text">
             If this site was just added, the first build should be available
             within a few minutes.
           </p>
-        <RefreshBuildsButton site={this.props.site} />
+          <RefreshBuildsButton site={this.props.site} />
       </div>
     </div>
     );

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -88,8 +88,8 @@ class SiteBuilds extends React.Component {
             within a few minutes.
           </p>
           <RefreshBuildsButton site={this.props.site} />
+        </div>
       </div>
-    </div>
     );
   }
 

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -73,10 +73,11 @@ class SitePublishedBranchesTable extends React.Component {
       <div className="usa-alert usa-alert-info" role="alert">
         <div className="usa-alert-body">
           <h3 className="usa-alert-header">No branches have been published.</h3>
-          <p className="usa-alert-text">Please wait for build to complete or check logs for error message.</p>
+          <p className="usa-alert-text">Please wait for build to complete or check logs
+            for error message.</p>
         </div>
       </div>
-  );
+    );
   }
 
   render() {

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -69,10 +69,14 @@ class SitePublishedBranchesTable extends React.Component {
   }
 
   renderEmptyState() {
-    return (<p>
-      No branches have been published.
-      Please wait for build to complete or check logs for error message.
-    </p>);
+    return (
+      <div className="usa-alert usa-alert-info" role="alert">
+        <div className="usa-alert-body">
+          <h3 className="usa-alert-header">No branches have been published.</h3>
+          <p className="usa-alert-text">Please wait for build to complete or check logs for error message.</p>
+        </div>
+      </div>
+  );
   }
 
   render() {

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -6,6 +6,7 @@ import publishedBranchActions from '../../actions/publishedBranchActions';
 import LoadingIndicator from '../LoadingIndicator';
 import BranchViewLink from '../branchViewLink';
 import { SITE } from '../../propTypes';
+import AlertBanner from '../alertBanner';
 
 class SitePublishedBranchesTable extends React.Component {
   componentDidMount() {
@@ -70,13 +71,11 @@ class SitePublishedBranchesTable extends React.Component {
 
   renderEmptyState() {
     return (
-      <div className="usa-alert usa-alert-info" role="alert">
-        <div className="usa-alert-body">
-          <h3 className="usa-alert-header">No branches have been published.</h3>
-          <p className="usa-alert-text">Please wait for build to complete or check logs
-            for error message.</p>
-        </div>
-      </div>
+      <AlertBanner
+        status="info"
+        header="No branches have been published."
+        message="Please wait for build to complete or check logs for error message."
+      />
     );
   }
 

--- a/test/frontend/components/site/SiteGitHubBranches.test.jsx
+++ b/test/frontend/components/site/SiteGitHubBranches.test.jsx
@@ -109,12 +109,10 @@ describe('<SiteGitHubBranches />', () => {
 
     const wrapper = shallow(<SiteGitHubBranches {...props} />);
     expect(wrapper.find('table')).to.have.length(0);
-    expect(wrapper.find('h3')).to.have.length(1);
-    expect(wrapper.find('h3').text()).to.have.string(
+    expect(wrapper.find('AlertBanner').prop('header')).to.equal(
       'No branches were found for this repository.'
     );
-    expect(wrapper.find('p')).to.have.length(1);
-    expect(wrapper.find('p').text()).to.have.string(
+    expect(wrapper.find('AlertBanner').prop('message')).to.equal(
       'Often this is because the repository is private or has been deleted.'
     );
   });

--- a/test/frontend/components/site/SiteGitHubBranches.test.jsx
+++ b/test/frontend/components/site/SiteGitHubBranches.test.jsx
@@ -109,9 +109,13 @@ describe('<SiteGitHubBranches />', () => {
 
     const wrapper = shallow(<SiteGitHubBranches {...props} />);
     expect(wrapper.find('table')).to.have.length(0);
+    expect(wrapper.find('h3')).to.have.length(1);
+    expect(wrapper.find('h3').text()).to.have.string(
+      'No branches were found for this repository.'
+    );
     expect(wrapper.find('p')).to.have.length(1);
     expect(wrapper.find('p').text()).to.have.string(
-      'No branches were found for this repository. Often this is because the repository is private or has been deleted.'
+      'Often this is because the repository is private or has been deleted.'
     );
   });
 

--- a/test/frontend/components/site/SitePublishedFilesTable.test.jsx
+++ b/test/frontend/components/site/SitePublishedFilesTable.test.jsx
@@ -63,6 +63,6 @@ describe('<SitePublishedFilesTable/>', () => {
     };
 
     const wrapper = shallow(<SitePublishedFilesTable {...props} />);
-    expect(wrapper.find('p').contains('No published branch files available.')).to.be.true;
+    expect(wrapper.find('AlertBanner').prop('message')).to.equal('No published branch files available.');
   });
 });

--- a/test/frontend/components/site/siteBuilds.test.js
+++ b/test/frontend/components/site/siteBuilds.test.js
@@ -99,9 +99,10 @@ describe('<SiteBuilds/>', () => {
     const wrapper = shallow(<SiteBuilds {...props} />);
 
     expect(wrapper.find('table')).to.have.length(0);
-    expect(wrapper.find('p')).to.have.length(2);
-    expect(wrapper.find('p').first().contains('This site does not yet have any builds.')).to.be.true;
-    expect(wrapper.find('p').at(1).text().indexOf('just added')).to.be.greaterThan(-1);
+    expect(wrapper.find('AlertBanner').prop('header')).to.equal('This site does not yet have any builds.');
+    expect(wrapper.find('AlertBanner').prop('message')).to.equal(
+      'If this site was just added, the first build should be available within a few minutes.'
+    );
     expect(wrapper.find('RefreshBuildsButton')).to.have.length(1);
   });
 

--- a/test/frontend/components/site/sitePublishedBranchesTable.test.js
+++ b/test/frontend/components/site/sitePublishedBranchesTable.test.js
@@ -42,9 +42,11 @@ describe('<SitePublishedBranchesTable/>', () => {
 
     const wrapper = shallow(<SitePublishedBranchesTable {...props} />);
     expect(wrapper.find('table')).to.have.length(0);
-    expect(wrapper.find('p')).to.have.length(1);
-    expect(wrapper.find('p').contains(
-      'No branches have been published. Please wait for build to complete or check logs for error message.'
-    )).to.be.true;
+    expect(wrapper.find('AlertBanner').prop('header')).to.equal(
+      'No branches have been published.'
+    );
+    expect(wrapper.find('AlertBanner').prop('message')).to.equal(
+      'Please wait for build to complete or check logs for error message.'
+    );
   });
 });

--- a/views/base.njk
+++ b/views/base.njk
@@ -8,7 +8,7 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-PRPJKWN');</script>
     <!-- End Google Tag Manager -->
-    
+
     <link rel="apple-touch-icon" sizes="57x57" href="/images/favicons/apple-touch-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="/images/favicons/apple-touch-icon-60x60.png">
     <link rel="apple-touch-icon" sizes="72x72" href="/images/favicons/apple-touch-icon-72x72.png">
@@ -116,12 +116,14 @@
     {% block flash_messages %}
       {% if messages.errors %}
         {% for error in messages.errors %}
+        <div class="usa-grid">
           <div class="usa-alert usa-alert-error usa-alert-home" role="alert">
             <div class="usa-alert-body">
               <h3 class="usa-alert-header">{{ error.title }}</h3>
               <p class="usa-alert-text">{{ error.message }}</p>
             </div>
           </div>
+        </div>
         {% endfor %}
       {% endif %}
     {% endblock %}


### PR DESCRIPTION
Some alerts did not have any styling. 
This adds some consistent styling to mostly informational alerts. 

### Before
<img width="614" alt="screen shot 2017-12-18 at 1 23 32 pm" src="https://user-images.githubusercontent.com/1449852/34121689-e63ef00c-e3f7-11e7-9232-834866e2e3bd.png">

### After
<img width="614" alt="screen shot 2017-12-18 at 1 33 10 pm" src="https://user-images.githubusercontent.com/1449852/34121733-06f87f98-e3f8-11e7-885c-6753c27d1bee.png">
