### PR TITLE
Begins adding tables for user-actions

### DIFF
--- a/api/models/action-target.js
+++ b/api/models/action-target.js
@@ -1,3 +1,0 @@
-module.exports = (sequelize, DataTypes) => {
-
-};

--- a/api/models/action-target.js
+++ b/api/models/action-target.js
@@ -1,0 +1,3 @@
+module.exports = (sequelize, DataTypes) => {
+
+};

--- a/api/models/action-type.js
+++ b/api/models/action-type.js
@@ -1,3 +1,22 @@
+const associate = ({ ActionType, UserAction }) => {
+  ActionType.belongsTo(UserAction, {
+    foreignKey: 'actionTypeId',
+  });
+};
+
 module.exports = (sequelize, DataTypes) => {
-  
+  const ActionType = sequelize.define('ActionType', {
+    action: {
+      type: DataTypes.STRING,
+      length: 20,
+      allowNull: false,
+    },
+  }, {
+    tableName: 'action_type',
+    classMethods: {
+      associate,
+    },
+  });
+
+  return ActionType;
 };

--- a/api/models/action-type.js
+++ b/api/models/action-type.js
@@ -1,0 +1,3 @@
+module.exports = (sequelize, DataTypes) => {
+  
+};

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -1,6 +1,7 @@
 const Sequelize = require('sequelize');
-const logger = require("winston");
-const config = require("../../config");
+const logger = require('winston');
+const config = require('../../config');
+const path = require('path');
 
 const postgresConfig = config.postgres;
 const database = postgresConfig.database;
@@ -8,17 +9,17 @@ const username = postgresConfig.user;
 const password = postgresConfig.password;
 
 const sequelize = new Sequelize(database, username, password, {
-  dialect: "postgres",
+  dialect: 'postgres',
   host: postgresConfig.host,
   port: postgresConfig.port,
   logging: logger.info,
 });
 
-const Build = sequelize.import(__dirname + "/build");
-const BuildLog = sequelize.import(__dirname + "/build-log");
-const Site = sequelize.import(__dirname + "/site");
-const User = sequelize.import(__dirname + "/user");
-const UserAction = sequelize.import(__dirname + "/user-action");
+const Build = sequelize.import(path.join(__dirname, '/build')); // eslint-disable-line no-unused-vars
+const BuildLog = sequelize.import(path.join(__dirname, '/build-log')); // eslint-disable-line no-unused-vars
+const Site = sequelize.import(path.join(__dirname, '/site')); // eslint-disable-line no-unused-vars
+const User = sequelize.import(path.join(__dirname, '/user')); // eslint-disable-line no-unused-vars
+const UserAction = sequelize.import(path.join(__dirname, '/user-action')); // eslint-disable-line no-unused-vars
 
 Object.keys(sequelize.models).forEach(key =>
   sequelize.models[key].associate(sequelize.models)

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -19,7 +19,6 @@ const BuildLog = sequelize.import(__dirname + "/build-log");
 const Site = sequelize.import(__dirname + "/site");
 const User = sequelize.import(__dirname + "/user");
 const UserAction = sequelize.import(__dirname + "/user-action");
-const ActionType = sequelize.import(__dirname + "/action-type");
 
 Object.keys(sequelize.models).forEach(key =>
   sequelize.models[key].associate(sequelize.models)

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -14,13 +14,6 @@ const sequelize = new Sequelize(database, username, password, {
   logging: logger.info,
 });
 
-const Build = sequelize.import(__dirname + "/build");
-const BuildLog = sequelize.import(__dirname + "/build-log");
-const Site = sequelize.import(__dirname + "/site");
-const User = sequelize.import(__dirname + "/user");
-const UserAction = sequelize.import(__dirname + "/user-action");
-const ActionType = sequelize.import(__dirname + "/action-type");
-
 Object.keys(sequelize.models).forEach(key =>
   sequelize.models[key].associate(sequelize.models)
 );

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -14,12 +14,13 @@ const sequelize = new Sequelize(database, username, password, {
   port: postgresConfig.port,
   logging: logger.info,
 });
-
-const Build = sequelize.import(path.join(__dirname, '/build')); // eslint-disable-line no-unused-vars
-const BuildLog = sequelize.import(path.join(__dirname, '/build-log')); // eslint-disable-line no-unused-vars
-const Site = sequelize.import(path.join(__dirname, '/site')); // eslint-disable-line no-unused-vars
-const User = sequelize.import(path.join(__dirname, '/user')); // eslint-disable-line no-unused-vars
-const UserAction = sequelize.import(path.join(__dirname, '/user-action')); // eslint-disable-line no-unused-vars
+/* eslint-disable no-unused-vars */
+const Build = sequelize.import(path.join(__dirname, '/build'));
+const BuildLog = sequelize.import(path.join(__dirname, '/build-log'));
+const Site = sequelize.import(path.join(__dirname, '/site'));
+const User = sequelize.import(path.join(__dirname, '/user'));
+const UserAction = sequelize.import(path.join(__dirname, '/user-action'));
+/* eslint-enable no-unused-vars */
 
 Object.keys(sequelize.models).forEach(key =>
   sequelize.models[key].associate(sequelize.models)

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -1,26 +1,28 @@
 const Sequelize = require('sequelize');
-const logger = require("winston")
-const config = require("../../config")
+const logger = require("winston");
+const config = require("../../config");
 
-const postgresConfig = config.postgres
-const database = postgresConfig.database
-const username = postgresConfig.user
-const password = postgresConfig.password
+const postgresConfig = config.postgres;
+const database = postgresConfig.database;
+const username = postgresConfig.user;
+const password = postgresConfig.password;
 
 const sequelize = new Sequelize(database, username, password, {
   dialect: "postgres",
   host: postgresConfig.host,
   port: postgresConfig.port,
   logging: logger.info,
-})
+});
 
-const Build = sequelize.import(__dirname + "/build")
-const BuildLog = sequelize.import(__dirname + "/build-log")
-const Site = sequelize.import(__dirname + "/site")
-const User = sequelize.import(__dirname + "/user")
+const Build = sequelize.import(__dirname + "/build");
+const BuildLog = sequelize.import(__dirname + "/build-log");
+const Site = sequelize.import(__dirname + "/site");
+const User = sequelize.import(__dirname + "/user");
+const UserAction = sequelize.import(__dirname + "/user-action");
+const ActionType = sequelize.import(__dirname + "/action-type");
 
-Object.keys(sequelize.models).forEach(key => {
+Object.keys(sequelize.models).forEach(key =>
   sequelize.models[key].associate(sequelize.models)
-})
+);
 
-module.exports = Object.assign({ sequelize }, sequelize.models)
+module.exports = Object.assign({ sequelize }, sequelize.models);

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -14,6 +14,13 @@ const sequelize = new Sequelize(database, username, password, {
   logging: logger.info,
 });
 
+const Build = sequelize.import(__dirname + "/build");
+const BuildLog = sequelize.import(__dirname + "/build-log");
+const Site = sequelize.import(__dirname + "/site");
+const User = sequelize.import(__dirname + "/user");
+const UserAction = sequelize.import(__dirname + "/user-action");
+const ActionType = sequelize.import(__dirname + "/action-type");
+
 Object.keys(sequelize.models).forEach(key =>
   sequelize.models[key].associate(sequelize.models)
 );

--- a/api/models/user-action.js
+++ b/api/models/user-action.js
@@ -1,3 +1,4 @@
+const validTargetTypes = ['site', 'user'];
 const associate = ({ User, UserAction }) => {
   UserAction.belongsTo(User, {
     foreignKey: 'userId',
@@ -36,12 +37,23 @@ module.exports = (sequelize, DataTypes) => {
     },
     targetType: {
       type: DataTypes.ENUM,
-      values: ['site', 'user'],
+      values: validTargetTypes,
+      validate: {
+        isIn: validTargetTypes,
+      },
       allowNull: false,
     },
-    actionTypeID: {
+    actionId: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: sequelize.literal('NOW()'),
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: sequelize.literal('NOW()'),
     },
   }, tableOptions);
 

--- a/api/models/user-action.js
+++ b/api/models/user-action.js
@@ -1,0 +1,51 @@
+const associate = ({ User, UserAction }) => {
+  UserAction.belongsTo(UserAction, {
+    foreignKey: 'userId'
+  });
+};
+
+const toJSON = () => {
+  const record = this.get({
+    plain: true,
+  });
+
+  record.createdAt = record.createdAt.toISOString();
+
+  return record;
+};
+
+module.exports = (sequelize, DataTypes) => {
+  const UserAction = sequelize.define('UserAction', {
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    targetId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    targetTypeId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    actionTypeID: {
+      type: DataTypes.INTEGER
+      //values: ['zadd', 'remove', 'update'],
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.TIMESTAMP,
+      allowNull: false
+    }
+  }, {
+    tableName: 'user_action',
+    classMethods: {
+      associate,
+    },
+    instanceMethods: {
+      toJSON,
+    }
+  });
+
+  return UserAction;
+};

--- a/api/models/user-action.js
+++ b/api/models/user-action.js
@@ -14,6 +14,16 @@ const toJSON = () => {
   return record;
 };
 
+const tableOptions = {
+  tableName: 'user_action',
+  classMethods: {
+    associate,
+  },
+  instanceMethods: {
+    toJSON,
+  },
+};
+
 module.exports = (sequelize, DataTypes) => {
   const UserAction = sequelize.define('UserAction', {
     userId: {
@@ -24,23 +34,16 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    targetTypeId: {
-      type: DataTypes.INTEGER,
+    targetType: {
+      type: DataTypes.ENUM,
+      values: ['site', 'user'],
       allowNull: false,
     },
     actionTypeID: {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-  }, {
-    tableName: 'user_action',
-    classMethods: {
-      associate,
-    },
-    instanceMethods: {
-      toJSON,
-    },
-  });
+  }, tableOptions);
 
   return UserAction;
 };

--- a/api/models/user-action.js
+++ b/api/models/user-action.js
@@ -5,7 +5,7 @@ const associate = ({ User, UserAction }) => {
   });
 };
 
-const toJSON = () => {
+const toJSON = function json() {
   const record = this.get({
     plain: true,
   });
@@ -46,14 +46,6 @@ module.exports = (sequelize, DataTypes) => {
     actionId: {
       type: DataTypes.INTEGER,
       allowNull: false,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      defaultValue: sequelize.literal('NOW()'),
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      defaultValue: sequelize.literal('NOW()'),
     },
   }, tableOptions);
 

--- a/api/models/user-action.js
+++ b/api/models/user-action.js
@@ -1,6 +1,6 @@
 const associate = ({ User, UserAction }) => {
-  UserAction.belongsTo(UserAction, {
-    foreignKey: 'userId'
+  UserAction.belongsTo(User, {
+    foreignKey: 'userId',
   });
 };
 
@@ -29,14 +29,9 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
     },
     actionTypeID: {
-      type: DataTypes.INTEGER
-      //values: ['zadd', 'remove', 'update'],
+      type: DataTypes.INTEGER,
       allowNull: false,
     },
-    createdAt: {
-      type: DataTypes.TIMESTAMP,
-      allowNull: false
-    }
   }, {
     tableName: 'user_action',
     classMethods: {
@@ -44,7 +39,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     instanceMethods: {
       toJSON,
-    }
+    },
   });
 
   return UserAction;

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -8,7 +8,7 @@ const associate = ({ User, Build, Site, UserAction }) => {
     timestamps: false,
   });
   User.hasMany(UserAction, {
-    foreignKey: 'userId'
+    foreignKey: 'userId',
   });
 };
 

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -1,4 +1,4 @@
-const associate = ({ User, Build, Site }) => {
+const associate = ({ User, Build, Site, UserAction }) => {
   User.hasMany(Build, {
     foreignKey: 'user',
   });
@@ -6,6 +6,9 @@ const associate = ({ User, Build, Site }) => {
     through: 'site_users__user_sites',
     foreignKey: 'user_sites',
     timestamps: false,
+  });
+  User.hasMany(UserAction, {
+    foreignKey: 'userId'
   });
 };
 

--- a/migrations/20171218191907-add-user-actions.js
+++ b/migrations/20171218191907-add-user-actions.js
@@ -5,10 +5,11 @@ module.exports.up = (db, callback) => {
     targetId: { type: 'int', notNull: true },
     targetType: { type: 'text', notNull: true },
     actionId: { type: 'int', notNull: true },
-    createdAt: { type: 'timestamp', notNull: true },
+    created_at: { type: 'datetime', notNull: true },
+    updated_at: { type: 'datetime', notNull: true },
   }, callback);
 };
 
 module.exports.down = (db, callback) => {
-  db.dropTable('user_action ', callback);
+  db.dropTable('user_action', callback);
 };

--- a/migrations/20171218191907-add-user-actions.js
+++ b/migrations/20171218191907-add-user-actions.js
@@ -3,12 +3,12 @@ module.exports.up = (db, callback) => {
     id: { type: 'int', primaryKey: true, autoIncrement: true },
     userId: { type: 'int', notNull: true },
     targetId: { type: 'int', notNull: true },
-    targetTypeId: { type: 'int', notNull: true },
+    targetType: { type: 'text', notNull: true },
     actionId: { type: 'int', notNull: true },
     createdAt: { type: 'timestamp', notNull: true },
   }, callback);
 };
 
 module.exports.down = (db, callback) => {
-  db.dropTable('user_action', callback);
+  db.dropTable('user_action ', callback);
 };

--- a/migrations/20171218191907-add-user-actions.js
+++ b/migrations/20171218191907-add-user-actions.js
@@ -1,0 +1,14 @@
+module.exports.up = (db, callback) => {
+  db.createTable("UserAction", {
+    id: { type: 'int', primaryKey: true, autoIncrement: true, },
+    userId: { type: 'int', notNull: true },
+    targetId: { type: 'int', notNull: true },
+    targetTypeId: { type: 'int', notNull: true },
+    actionId: { type: 'int', notNull: true },
+    createdAt: { type: 'timestamp', notNull: true }
+  }, callback)
+}
+
+module.exports.down = (db, callback) => {
+  db.dropTable("UserAction", callback)
+}

--- a/migrations/20171218191907-add-user-actions.js
+++ b/migrations/20171218191907-add-user-actions.js
@@ -1,14 +1,14 @@
 module.exports.up = (db, callback) => {
-  db.createTable("UserAction", {
-    id: { type: 'int', primaryKey: true, autoIncrement: true, },
+  db.createTable('user_action', {
+    id: { type: 'int', primaryKey: true, autoIncrement: true },
     userId: { type: 'int', notNull: true },
     targetId: { type: 'int', notNull: true },
     targetTypeId: { type: 'int', notNull: true },
     actionId: { type: 'int', notNull: true },
-    createdAt: { type: 'timestamp', notNull: true }
-  }, callback)
-}
+    createdAt: { type: 'timestamp', notNull: true },
+  }, callback);
+};
 
 module.exports.down = (db, callback) => {
-  db.dropTable("UserAction", callback)
-}
+  db.dropTable('user_action', callback);
+};

--- a/migrations/20171218191907-add-user-actions.js
+++ b/migrations/20171218191907-add-user-actions.js
@@ -5,8 +5,8 @@ module.exports.up = (db, callback) => {
     targetId: { type: 'int', notNull: true },
     targetType: { type: 'text', notNull: true },
     actionId: { type: 'int', notNull: true },
-    created_at: { type: 'datetime', notNull: true },
-    updated_at: { type: 'datetime', notNull: true },
+    createdAt: { type: 'date', notNull: true },
+    updatedAt: { type: 'date', notNull: true },
   }, callback);
 };
 

--- a/migrations/20171218193428-add-action-types.js
+++ b/migrations/20171218193428-add-action-types.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20171218193428-add-action-types.js
+++ b/migrations/20171218193428-add-action-types.js
@@ -1,27 +1,12 @@
-'use strict';
-
-var dbm;
-var type;
-var seed;
-
-/**
-  * We receive the dbmigrate dependency from dbmigrate initially.
-  * This enables us to not have to rely on NODE_PATH.
-  */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
+module.exports.up = (db, callback) => {
+  db.createTable('action_type', {
+    id: { type: 'int', primaryKey: true, autoIncrement: true },
+    action: { type: 'string', length: 20, notNull: true },
+    createdAt: { type: 'timestamp', notNull: true },
+    updatedAt: { type: 'timestamp', notNull: true },
+  }, callback);
 };
 
-exports.up = function(db) {
-  return null;
-};
-
-exports.down = function(db) {
-  return null;
-};
-
-exports._meta = {
-  "version": 1
+module.exports.down = (db, callback) => {
+  db.dropTable('action_type', callback);
 };

--- a/migrations/20171218193428-add-action-types.js
+++ b/migrations/20171218193428-add-action-types.js
@@ -2,8 +2,6 @@ module.exports.up = (db, callback) => {
   db.createTable('action_type', {
     id: { type: 'int', primaryKey: true, autoIncrement: true },
     action: { type: 'string', length: 20, notNull: true },
-    createdAt: { type: 'timestamp', notNull: true },
-    updatedAt: { type: 'timestamp', notNull: true },
   }, callback);
 };
 

--- a/migrations/20171219144357-add-action-data.js
+++ b/migrations/20171219144357-add-action-data.js
@@ -1,0 +1,17 @@
+/* eslint-disable */
+const actionsExist = 'select count(*) from action_type;';
+
+module.exports.up = (db) =>
+  db.runSql(actionsExist)
+    .then((out) => {
+      if (out.rows.count !== 0) {
+        return db.runSql("insert into action_type (action) values ('add'), ('remove'), ('update')");
+      }
+    })
+    .catch((err) => {
+      console.log(err);
+    });
+
+module.exports.down = (db, callback) => {
+  callback();
+};

--- a/migrations/20171219144357-add-action-data.js
+++ b/migrations/20171219144357-add-action-data.js
@@ -1,17 +1,15 @@
-/* eslint-disable */
 const actionsExist = 'select count(*) from action_type;';
 
-module.exports.up = (db) =>
+module.exports.up = (db, callback) =>
   db.runSql(actionsExist)
     .then((out) => {
       if (out.rows.count !== 0) {
-        return db.runSql("insert into action_type (action) values ('add'), ('remove'), ('update')");
+        db.runSql('insert into action_type (action) values (\'add\'), (\'remove\'), (\'update\')');
       }
     })
     .catch((err) => {
-      console.log(err);
+      callback(err);
     });
 
-module.exports.down = (db, callback) => {
+module.exports.down = (db, callback) =>
   callback();
-};

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "migrate:up": "node migrate.js up || true",
     "migrate:down": "node migrate.js down",
     "migrate:test": "node migrate.js up --dry-run",
+    "migrate:reset": "node migrate.js reset",
     "export:sites": "node ./scripts/exportSitesAsCsv.js",
     "analyze-webpack": "webpack-bundle-analyzer -h 0.0.0.0 public/stats.json",
     "serve-coverage": "http-server ./coverage"

--- a/test/api/unit/models/user_action.test.js
+++ b/test/api/unit/models/user_action.test.js
@@ -11,10 +11,10 @@ describe('UserAction model', () => {
         targetType: 'site',
       });
 
-       model.validate().then(() => {
-         expect(model).to.exist;
-         done();
-       }).catch(done);
+      model.validate().then(() => {
+        expect(model).to.exist;
+        done();
+      }).catch(done);
     });
   });
 
@@ -26,10 +26,10 @@ describe('UserAction model', () => {
         done();
       }).catch((error) => {
         const { errors } = error;
-        const errorList = errors.reduce((memo, error) => [ ...memo, error.path], []);
+        const errorList = errors.reduce((memo, e) => [...memo, e.path], []);
 
-        errorList.forEach((error) => {
-          expect(requiredFields.indexOf(error)).to.not.equal(-1);
+        errorList.forEach((field) => {
+          expect(requiredFields.indexOf(field)).to.not.equal(-1);
         });
 
         done();
@@ -37,7 +37,6 @@ describe('UserAction model', () => {
     });
 
     it('fails validation if targetType is not `site` or `build`', (done) => {
-      const badTypes = ['penguin', 'llama'];
       const goodProps = {
         userId: 1,
         actionId: 1,

--- a/test/api/unit/models/user_action.test.js
+++ b/test/api/unit/models/user_action.test.js
@@ -23,7 +23,7 @@ describe('UserAction model', () => {
   });
 
   describe('validations', () => {
-    it('requires userId, targetId, targetType, actionId, and createdAt', (done) => {
+    it('requires userId, targetId, targetType, actionId', (done) => {
       const requiredFields = ['userId', 'targetId', 'targetType', 'actionId'];
 
       UserAction.create().then(() => {

--- a/test/api/unit/models/user_action.test.js
+++ b/test/api/unit/models/user_action.test.js
@@ -1,0 +1,60 @@
+const expect = require('chai').expect;
+const { UserAction } = require('../../../../api/models');
+
+describe('UserAction model', () => {
+  describe('instantiation', () => {
+    it('creates a new UserAction record', (done) => {
+      const model = UserAction.build({
+        userId: 1,
+        actionId: 1,
+        targetId: 1,
+        targetType: 'site',
+      });
+
+       model.validate().then(() => {
+         expect(model).to.exist;
+         done();
+       }).catch(done);
+    });
+  });
+
+  describe('validations', () => {
+    it('requires userId, targetId, targetType, actionId, and createdAt', (done) => {
+      const requiredFields = ['userId', 'targetId', 'targetType', 'actionId'];
+
+      UserAction.create().then(() => {
+        done();
+      }).catch((error) => {
+        const { errors } = error;
+        const errorList = errors.reduce((memo, error) => [ ...memo, error.path], []);
+
+        errorList.forEach((error) => {
+          expect(requiredFields.indexOf(error)).to.not.equal(-1);
+        });
+
+        done();
+      }).catch(done);
+    });
+
+    it('fails validation if targetType is not `site` or `build`', (done) => {
+      const badTypes = ['penguin', 'llama'];
+      const goodProps = {
+        userId: 1,
+        actionId: 1,
+        targetId: 1,
+      };
+
+      const promises = [
+        UserAction.build(Object.assign({}, goodProps, { actionType: 'penguin' })).validate(),
+        UserAction.build(Object.assign({}, goodProps, { actionType: 'alpaca' })).validate(),
+      ];
+
+      Promise.all(promises)
+        .then((errors) => {
+          expect(errors.length).to.equal(2);
+          errors.forEach(e => expect(e.errors[0].path).to.equal('targetType'));
+          done();
+        }).catch(done);
+    });
+  });
+});

--- a/test/api/unit/models/user_action.test.js
+++ b/test/api/unit/models/user_action.test.js
@@ -1,15 +1,19 @@
 const expect = require('chai').expect;
 const { UserAction } = require('../../../../api/models');
 
+const props = {
+  userId: 1,
+  actionId: 1,
+  targetId: 1,
+  targetType: 'site',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
 describe('UserAction model', () => {
   describe('instantiation', () => {
     it('creates a new UserAction record', (done) => {
-      const model = UserAction.build({
-        userId: 1,
-        actionId: 1,
-        targetId: 1,
-        targetType: 'site',
-      });
+      const model = UserAction.build(props);
 
       model.validate().then(() => {
         expect(model).to.exist;
@@ -54,6 +58,13 @@ describe('UserAction model', () => {
           errors.forEach(e => expect(e.errors[0].path).to.equal('targetType'));
           done();
         }).catch(done);
+    });
+  });
+
+  describe('.toJSON', () => {
+    it('returns an object with a formatted createdAt date', () => {
+      const model = UserAction.build(props);
+      expect(model.toJSON().createdAt).to.equal(props.createdAt.toISOString());
     });
   });
 });


### PR DESCRIPTION
* Add model for user-action
* add model for action-type
* Modifies user model
* begins writing migrations

Going down the road of using separate tables instead of enum fields, this gives us the flexibility to add additional metadata down the line, treats the enum values as data, normalizes the db, etc.

I don't think the foreign keys are specified properly in the models yet, I'll revisit once the migrations are written!