### PR TITLE
redirect to Site List page when adding a site fails

### DIFF
--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -38,10 +38,17 @@ export default {
   addSite(siteToAdd) {
     return federalist.addSite(siteToAdd)
       .then((site) => {
-        dispatchSiteAddedAction(site);
-        return site;
+        // site is undefined here if addSite fails
+        if (site) {
+          dispatchSiteAddedAction(site);
+          // route to the builds page for the added site
+          updateRouterToSiteBuildsUri(site);
+        } else {
+          // route to the sites list page, which will display
+          // any errors that occurred during addSite
+          updateRouterToSitesUri();
+        }
       })
-      .then(updateRouterToSiteBuildsUri)
       .catch(alertError);
   },
 

--- a/frontend/components/Fields/RenderUrlField.jsx
+++ b/frontend/components/Fields/RenderUrlField.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const RenderField = ({
+const RenderUrlField = ({
   id,
   placeholder,
   label,
@@ -26,7 +26,7 @@ const RenderField = ({
   </div>
 );
 
-RenderField.propTypes = {
+RenderUrlField.propTypes = {
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
@@ -37,8 +37,8 @@ RenderField.propTypes = {
   }).isRequired,
 };
 
-RenderField.defaultProps = {
+RenderUrlField.defaultProps = {
   help: null,
 };
 
-export default RenderField;
+export default RenderUrlField;

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -149,15 +149,22 @@ describe('siteActions', () => {
       });
     });
 
-    it('triggers an error when adding a site fails', () => {
+    it('triggers an error and triggers a router update to the site list page when adding a site fails', () => {
       const siteToAdd = {
         hey: 'you',
       };
-      addSite.withArgs(siteToAdd).returns(rejectedWithErrorPromise);
+
+      // addSite returns nothing when the POST request fails, so resolve to undefined
+      addSite.withArgs(siteToAdd).returns(Promise.resolve(undefined));
 
       const actual = fixture.addSite(siteToAdd);
 
-      return validateResultDispatchesHttpAlertError(actual, errorMessage);
+      return actual.then(() => {
+        expect(dispatchSiteAddedAction.called).to.be.false;
+        expect(updateRouterToSiteBuildsUri.called).to.be.false;
+        expect(updateRouterToSitesUri.calledOnce).to.be.true;
+        validateResultDispatchesHttpAlertError(actual, errorMessage);
+      });
     });
   });
 

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -154,8 +154,9 @@ describe('siteActions', () => {
         hey: 'you',
       };
 
-      // addSite returns nothing when the POST request fails, so resolve to undefined
-      addSite.withArgs(siteToAdd).returns(Promise.resolve(undefined));
+      // addSite returns nothing when the POST request fails,
+      // so resolve to nothing
+      addSite.withArgs(siteToAdd).returns(Promise.resolve());
 
       const actual = fixture.addSite(siteToAdd);
 

--- a/test/frontend/components/Fields/RenderUrlField.test.jsx
+++ b/test/frontend/components/Fields/RenderUrlField.test.jsx
@@ -10,6 +10,7 @@ describe('<RenderUrlField />', () => {
       id: 'anId',
       input: {},
       name: 'aName',
+      label: 'the label',
       placeholder: 'placeholder',
       help: <span id="helpspan">help text</span>,
       meta: { touched: false, error: null },
@@ -26,6 +27,8 @@ describe('<RenderUrlField />', () => {
       id: 'anId',
       input: {},
       name: 'aName',
+      label: 'the label',
+      placeholder: 'put text here',
       meta: { touched: false, error: null },
     };
 

--- a/test/frontend/components/addSite/AddRepoSiteForm.test.jsx
+++ b/test/frontend/components/addSite/AddRepoSiteForm.test.jsx
@@ -21,6 +21,7 @@ describe('<AddRepoSiteForm />', () => {
   it('renders', () => {
     const props = {
       showAddNewSiteFields: false,
+      initialValues: { engine: 'jekyll' },
       handleSubmit: () => {},
       pristine: true,
     };
@@ -33,6 +34,7 @@ describe('<AddRepoSiteForm />', () => {
   it('renders additional fields when showAddNewSiteFields is true', () => {
     const props = {
       showAddNewSiteFields: false,
+      initialValues: { engine: 'jekyll' },
       handleSubmit: () => {},
       pristine: true,
     };
@@ -50,6 +52,7 @@ describe('<AddRepoSiteForm />', () => {
   it('makes GitHubRepoUrlField readOnly when showAddNewSiteFields is true', () => {
     const props = {
       showAddNewSiteFields: false,
+      initialValues: { engine: 'jekyll' },
       handleSubmit: () => {},
       pristine: true,
     };
@@ -65,6 +68,7 @@ describe('<AddRepoSiteForm />', () => {
   it('disables submit when pristine is true', () => {
     const props = {
       showAddNewSiteFields: false,
+      initialValues: { engine: 'jekyll' },
       handleSubmit: () => {},
       pristine: true,
     };
@@ -80,6 +84,7 @@ describe('<AddRepoSiteForm />', () => {
   it('calls handleSubmit when submitted', () => {
     const props = {
       showAddNewSiteFields: false,
+      initialValues: { engine: 'jekyll' },
       handleSubmit: spy(),
       pristine: false,
     };
@@ -92,6 +97,7 @@ describe('<AddRepoSiteForm />', () => {
   it('links back to /sites from the Cancel button', () => {
     const props = {
       showAddNewSiteFields: false,
+      initialValues: { engine: 'jekyll' },
       handleSubmit: () => {},
       pristine: true,
     };


### PR DESCRIPTION
in order to show the alert message with the error from the POST request.
ref #1392

Bonus: cleaned up some component tests that had props missing, and renamed `RenderField` var to `RenderUrlField` to match the filename