### PR TITLE
Remove GA script

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -43,16 +43,7 @@
 
     {% block head_extra %}
     {% endblock %}
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-48605964-31', 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('set', 'forceSSL', true);
-      ga('send', 'pageview');
-    </script>
+    
     <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=18F"></script>
   </head>


### PR DESCRIPTION
This has been migrated to the Google Tag Manager config and should be pulled to prod at the same time as #1382 to avoid data loss in Google Analytics