### PR TITLE
Removing report config (test was successful!)

### DIFF
--- a/config/templates.js
+++ b/config/templates.js
@@ -8,15 +8,6 @@ module.exports = {
     description: 'A basic template to host a set of pages about a recent report or order.',
     thumb: '/images/federalist-report-template.jpg',
   },
-  reportconfig: {
-    owner: '18f',
-    repo: 'federalist-uswds-template',
-    branch: 'report-config',
-    example: 'https://federalist-proxy.app.cloud.gov/preview/18f/federalist-uswds-template/report-config/',
-    title: 'Report config',
-    description: 'A basic template to host a set of pages about a recent report or order.',
-    thumb: '/images/federalist-report-template.jpg',
-  },
   team: {
     owner: '18f',
     repo: 'federalist-modern-team-template',


### PR DESCRIPTION
Removed the template option for selecting the report config sub branch.

## Screenshot before
![screen shot 2017-12-22 at 3 15 15 pm](https://user-images.githubusercontent.com/1449852/34311322-f829ebd8-e72a-11e7-9665-e94536245646.png)

## Screenshot after
![screen shot 2017-12-22 at 3 14 58 pm](https://user-images.githubusercontent.com/1449852/34311319-f2d19564-e72a-11e7-8eb2-35844d2c57d1.png)

CC @wslack 