### PR TITLE
Fixing alert message width

### DIFF
--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -102,8 +102,8 @@ export class SiteContainer extends React.Component {
         <div className="usa-width-five-sixths site-main" id="pages-container">
           <div className="usa-grid">
             <AlertBanner
-            message={storeState.alert.message}
-            status={storeState.alert.status}
+              message={storeState.alert.message}
+              status={storeState.alert.status}
             />
           </div>
           <PagesHeader

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -100,10 +100,12 @@ export class SiteContainer extends React.Component {
       <div className="usa-grid site">
         <SideNav siteId={site.id} />
         <div className="usa-width-five-sixths site-main" id="pages-container">
-          <AlertBanner
+          <div className="usa-grid">
+            <AlertBanner
             message={storeState.alert.message}
             status={storeState.alert.status}
-          />
+            />
+          </div>
           <PagesHeader
             repository={site.repository}
             owner={site.owner}

--- a/frontend/components/siteList/siteList.js
+++ b/frontend/components/siteList/siteList.js
@@ -72,7 +72,9 @@ export const SiteList = ({ storeState }) =>
         {addWebsiteButton()}
       </div>
     </div>
-    <AlertBanner {...storeState.alert} />
+    <div className="usa-grid">
+      <AlertBanner {...storeState.alert} />
+    </div>
     {getSites(storeState.sites)}
     <div className="usa-grid">
       <div className="usa-width-one-whole">

--- a/frontend/sass/_alerts.scss
+++ b/frontend/sass/_alerts.scss
@@ -3,14 +3,21 @@
 }
 
 .usa-alert-home {
-  margin-top: 0;
+  background-color: $alert-delete-bg-color;
+  margin: 0 auto;
+  .usa-alert {
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 0;
+    max-width: 1040px;
+  }
 }
 
 .usa-alert-delete {
   background-color: $alert-delete-bg-color;
 
   button {
-    margin-left: 0.5em;
+    margin-left: .5em;
   }
 }
 
@@ -27,10 +34,10 @@
  * TODO: remove once USWDS dependency is upgraded
  */
 .usa-alert-body p:last-child {
-  margin-bottom: 0.8rem;
+  margin-bottom: .8rem;
 }
 
 .usa-alert-body p:first-child {
-  margin-top: 0.8rem;
+  margin-top: .8rem;
 }
 /* end borrowing */

--- a/views/base.njk
+++ b/views/base.njk
@@ -43,7 +43,7 @@
 
     {% block head_extra %}
     {% endblock %}
-    
+
     <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=18F"></script>
   </head>
@@ -119,8 +119,8 @@
     {% block flash_messages %}
       {% if messages.errors %}
         {% for error in messages.errors %}
-        <div class="usa-grid">
-          <div class="usa-alert usa-alert-error usa-alert-home" role="alert">
+        <div class="usa-alert-home">
+          <div class="usa-alert usa-alert-error" role="alert">
             <div class="usa-alert-body">
               <h3 class="usa-alert-header">{{ error.title }}</h3>
               <p class="usa-alert-text">{{ error.message }}</p>


### PR DESCRIPTION
Alert messages are shown in various ways and were previously always wrapped in a `usa-grid` div. 

When updating the alert component the container div which contained the `usa-grid` class was removed to separate layout classes from the alert component making it more pure and flexible in various situations.

The following alerts have been updated. 

## Screenshot of homepage alert
![screen shot 2017-12-22 at 3 36 32 pm](https://user-images.githubusercontent.com/1449852/34312528-db3484f4-e732-11e7-88ca-eba31032c7c7.png)

## Screenshot of published files alert
![screen shot 2017-12-22 at 3 53 12 pm](https://user-images.githubusercontent.com/1449852/34312533-df910626-e732-11e7-8904-761b3d4c5b0c.png)

In a separate issue, I'd like to address the usage of `usa-grid` as there are many places where the HTML can be simplified to better use the USWDS grid system. 

CC @wslack 