### PR TITLE
Pass build id to build `create` action

### DIFF
--- a/api/controllers/build.js
+++ b/api/controllers/build.js
@@ -41,13 +41,21 @@ module.exports = {
     .catch(res.error);
   },
 
-  create: (req, res) => {
+  /**
+   * Create a new build using data from an existing build
+   * Currently, the only way for a user to directly create a new build is
+   * the `restart build` interface in the site builds view.
+   *
+   * This method is named `restart` as it's
+   * not otherwise possible to create a build via the API.
+   */
+  restart: (req, res) => {
     let params;
 
     Build.findById(req.body.buildId, { include: [Site] })
     .then((build) => {
       if (!build) {
-        throw 400;
+        throw 404;
       }
 
       params = {

--- a/api/routers/build.js
+++ b/api/routers/build.js
@@ -5,7 +5,7 @@ const sessionAuth = require('../policies/sessionAuth');
 const csrfProtection = require('../policies/csrfProtection');
 
 router.get('/site/:site_id/build', sessionAuth, BuildController.find);
-router.post('/build', sessionAuth, csrfProtection, BuildController.create);
+router.post('/build', sessionAuth, csrfProtection, BuildController.restart);
 router.get('/build/:id', sessionAuth, BuildController.findOne);
 router.post('/build/:id/status/:token', buildCallback, BuildController.status);
 

--- a/frontend/actions/buildActions.js
+++ b/frontend/actions/buildActions.js
@@ -5,29 +5,29 @@ import {
   buildsFetchStarted as createBuildsFetchStartedAction,
   buildsReceived as createBuildsReceivedAction,
   buildRestarted as createBuildRestartedAction,
-} from "./actionCreators/buildActions";
+} from './actionCreators/buildActions';
 
 const dispatchBuildsFetchStartedAction = () => {
-  dispatch(createBuildsFetchStartedAction())
-}
+  dispatch(createBuildsFetchStartedAction());
+};
 
-const dispatchBuildsReceivedAction = builds => {
-  dispatch(createBuildsReceivedAction(builds))
-}
+const dispatchBuildsReceivedAction = (builds) => {
+  dispatch(createBuildsReceivedAction(builds));
+};
 
-const dispatchBuildRestartedAction = build => {
-  dispatch(createBuildRestartedAction(build))
+const dispatchBuildRestartedAction = (build) => {
+  dispatch(createBuildRestartedAction(build));
 };
 
 export default {
   fetchBuilds(site) {
-    dispatchBuildsFetchStartedAction()
+    dispatchBuildsFetchStartedAction();
     return api.fetchBuilds(site)
-      .then(dispatchBuildsReceivedAction)
+      .then(dispatchBuildsReceivedAction);
   },
 
-  restartBuild(build) {
-    return api.restartBuild(build)
+  restartBuild(buildId) {
+    return api.restartBuild(buildId)
       .then(dispatchBuildRestartedAction);
   },
 };

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -20,7 +20,7 @@ class SiteBuilds extends React.Component {
 
   static restartClicked(event, build) {
     event.preventDefault();
-    buildActions.restartBuild(build);
+    buildActions.restartBuild(build.id);
   }
 
   static buildLogsLink(build) {

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -91,13 +91,11 @@ export default {
     });
   },
 
-  restartBuild(build) {
+  restartBuild(buildId) {
     return this.fetch('build/', {
       method: 'POST',
       data: {
-        site: build.site.id || build.site,
-        branch: build.branch,
-        commitSha: build.commitSha,
+        buildId,
       },
     });
   },

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -40,6 +40,10 @@ paths:
           description: Not authorized
           schema:
             $ref: "Error.json"
+        404:
+          descriptions: Not found
+          schema:
+            $ref: "Error.json"
   /site/{site_id}/build:
     get:
       summary: Fetch all of the user's builds for a given site

--- a/test/frontend/util/federalistApi.test.js
+++ b/test/frontend/util/federalistApi.test.js
@@ -141,27 +141,11 @@ describe('federalistApi', () => {
 
   describe('restartBuild', () => {
     it('is defined', () => {
-      federalistApi.restartBuild(testBuild);
+      federalistApi.restartBuild(testBuild.id);
       testRouteCalled('postBuild', {
         method: 'POST',
         body: {
-          site: testSite.id,
-          branch: testBranch,
-          commitSha: testBuild.commitSha,
-        },
-      });
-    });
-
-    it('works when build site is not an object', () => {
-      const boopBuild = Object.assign({}, testBuild);
-      boopBuild.site = 123;
-      federalistApi.restartBuild(boopBuild);
-      testRouteCalled('postBuild', {
-        method: 'POST',
-        body: {
-          site: 123,
-          branch: testBranch,
-          commitSha: testBuild.commitSha,
+          buildId: testBuild.id,
         },
       });
     });


### PR DESCRIPTION
* The `create` route handler is a little weird, as we only use to create builds that are being restarted, i.e. we only use it when there is an existing build to get an id from.
