### PR TITLE
Use next alert state instead of current one

### DIFF
--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -15,9 +15,7 @@ import {
 } from './dispatchActions';
 
 
-const alertError = (error) => {
-  alertActions.httpError(error.message);
-};
+const alertError = error => alertActions.httpError(error.message);
 
 const onUserRemoveFromSite = (site) => {
   if (site) {

--- a/frontend/components/app.js
+++ b/frontend/components/app.js
@@ -9,12 +9,16 @@ import LoadingIndicator from './LoadingIndicator';
 export class App extends React.Component {
   componentWillReceiveProps(nextProps) {
     const { alert } = this.props;
-    this.shouldClearAlert(alert, nextProps);
+
+    if (alert.message) {
+      this.shouldClearAlert(nextProps);
+    }
   }
 
-  shouldClearAlert(alert, nextProps) {
+  shouldClearAlert(nextProps) {
     const { location: { key: lastKey } } = this.props;
     const { key: nextKey } = nextProps.location;
+    const { alert } = nextProps;
 
     if (alert.stale) {
       alertActions.clear();


### PR DESCRIPTION
* The current alert state doesn't always reflect when an alert message
is stale, and can produce flashes of content on views that shouldn't
display them

Now with a helpful GIF!

![site-add-error-message-cleared](https://user-images.githubusercontent.com/1421848/34415413-962a86c2-ebbc-11e7-893b-a5a3fc09646f.gif)
