### PR TITLE
Updating dashboard header

### DIFF
--- a/frontend/components/siteList/siteList.js
+++ b/frontend/components/siteList/siteList.js
@@ -62,7 +62,10 @@ export const SiteList = ({ storeState }) =>
     <div className="usa-grid dashboard header">
       <div className="usa-width-two-thirds">
         <div className="header-title">
-          <h1><img className="header-icon" src="/images/websites.svg" alt="Websites icon" /> Your websites</h1>
+          <h1>
+            <img className="header-icon" src="/images/websites.svg" alt="Websites icon" />
+            Your websites
+          </h1>
           <h2>Dashboard</h2>
         </div>
       </div>

--- a/frontend/components/siteList/siteList.js
+++ b/frontend/components/siteList/siteList.js
@@ -34,7 +34,6 @@ const getSites = (sitesState) => {
 
   return (
     <div className="usa-grid">
-      <h2>Websites</h2>
       <ul className="sites-list usa-unstyled-list">
         {
           sitesState.data
@@ -62,10 +61,9 @@ export const SiteList = ({ storeState }) =>
   (<div>
     <div className="usa-grid dashboard header">
       <div className="usa-width-two-thirds">
-        <img className="header-icon" src="/images/websites.svg" alt="Websites icon" />
         <div className="header-title">
-          <h1>Your Websites</h1>
-          <p>Dashboard</p>
+          <h1><img className="header-icon" src="/images/websites.svg" alt="Websites icon" /> Your websites</h1>
+          <h2>Dashboard</h2>
         </div>
       </div>
       <div className="usa-width-one-third">


### PR DESCRIPTION
Moved the image inside of the heading tag to make consistent with the pages header.

**In addition**
Removed the redundant `Websites` header and made `Dashboard` an `H2` which follows the format of the sub pages.

I think we could even go one step further and remove the `Dashboard` heading as I feel that `Your websites` is enough to convey what is being shown on the page and the word Dashboard isn't necessary. 

# Before screenshot
![screen shot 2018-01-02 at 2 55 07 pm](https://user-images.githubusercontent.com/1449852/34497783-f4079550-efcc-11e7-91df-290508144392.png)


# After screenshot
![screen shot 2018-01-02 at 2 53 07 pm](https://user-images.githubusercontent.com/1449852/34497791-fb18ad20-efcc-11e7-961a-680110eb9b1d.png)


CC @wslack 