### PR TITLE
Update settings page to fix left alignment make more accessible

### DIFF
--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -50,12 +50,13 @@ export const AdvancedSiteSettings = ({
 
       {/* CUSTOM CONFIG */}
       <fieldset>
-        <legend>Site configuration</legend>
+        <legend>Live site</legend>
         <p className="well-text">
           Add additional configuration in yaml to be added to your
           {' '}
           <code>_config.yml</code> file when we build your site&apos;s primary branch.
         </p>
+        <label htmlFor="config">Site configuration</label>
         <Field
           component="textarea"
           name="config"
@@ -65,12 +66,13 @@ export const AdvancedSiteSettings = ({
 
       {/* DEMO CONFIG */}
       <fieldset>
-        <legend>Demo configuration</legend>
+        <legend>Demo site</legend>
         <p className="well-text">
           Add additional configuration in yaml to be added to your
           {' '}
           <code>_config.yml</code> file when we build your site&apos;s demo branch.
         </p>
+        <label htmlFor="demoConfig">Demo configuration</label>
         <Field
           component="textarea"
           name="demoConfig"
@@ -80,12 +82,13 @@ export const AdvancedSiteSettings = ({
 
       {/* PREVIEW CONFIG */}
       <fieldset>
-        <legend>Preview configuration</legend>
+        <legend>Preview site</legend>
         <p className="well-text">
           Add additional configuration in yaml to be added to your
           {' '}
           <code>_config.yml</code> file when we build a preview branch for your site.
         </p>
+        <label htmlFor="previewConfig">Preview configuration</label>
         <Field
           component="textarea"
           name="previewConfig"

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -47,7 +47,8 @@ export const AdvancedSiteSettings = ({
           />
         }
       />
-
+    </div>
+    <div className="well">
       {/* CUSTOM CONFIG */}
       <fieldset>
         <legend>Live site</legend>
@@ -63,7 +64,8 @@ export const AdvancedSiteSettings = ({
           className="form-control-mono"
         />
       </fieldset>
-
+    </div>
+    <div className="well">
       {/* DEMO CONFIG */}
       <fieldset>
         <legend>Demo site</legend>
@@ -79,7 +81,8 @@ export const AdvancedSiteSettings = ({
           className="form-control-mono"
         />
       </fieldset>
-
+    </div>
+    <div className="well">
       {/* PREVIEW CONFIG */}
       <fieldset>
         <legend>Preview site</legend>
@@ -95,27 +98,27 @@ export const AdvancedSiteSettings = ({
           className="form-control-mono"
         />
       </fieldset>
-      <button
-        type="button"
-        className="usa-button usa-button-gray button-reset"
-        disabled={pristine}
-        onClick={reset}
-      >
-        Reset
-      </button>
-
-      <button
-        type="submit"
-        className="usa-button usa-button-primary"
-        disabled={pristine}
-      >
-        Save advanced settings
-      </button>
     </div>
+    <button
+      type="button"
+      className="usa-button usa-button-gray button-reset"
+      disabled={pristine}
+      onClick={reset}
+    >
+      Reset
+    </button>
+
+    <button
+      type="submit"
+      className="usa-button usa-button-primary"
+      disabled={pristine}
+    >
+      Save advanced settings
+    </button>
 
 
-    <div className="usa-alert usa-alert-error usa-alert-delete" role="alert">
-       <div className="usa-alert-body">
+    <div className="usa-alert usa-alert-warning usa-alert-danger">
+      <div className="usa-alert-body">
         <h3 className="usa-alert-heading">Danger zone</h3>
         <p className="usa-alert-text">Delete this site from Federalist?</p>
         <button

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -34,105 +34,87 @@ export const AdvancedSiteSettings = ({
   handleSubmit,
 }) => (
   <form className="settings-form settings-form-advanced" onSubmit={handleSubmit}>
-    <div className="usa-grid">
-      <div className="usa-width-one-whole">
-        <label htmlFor="engine">Static site engine</label>
+    <div className="well">
+      <label htmlFor="engine">Static site engine</label>
+      <Field
+        name="engine"
+        id="engine"
+        component={p =>
+          <SelectSiteEngine
+            value={p.input.value}
+            onChange={p.input.onChange}
+            className="form-control"
+          />
+        }
+      />
+
+      {/* CUSTOM CONFIG */}
+      <fieldset>
+        <legend>Site configuration</legend>
+        <p className="well-text">
+          Add additional configuration in yaml to be added to your
+          {' '}
+          <code>_config.yml</code> file when we build your site&apos;s primary branch.
+        </p>
         <Field
-          name="engine"
-          id="engine"
-          component={p =>
-            <SelectSiteEngine
-              value={p.input.value}
-              onChange={p.input.onChange}
-              className="form-control"
-            />
-          }
+          component="textarea"
+          name="config"
+          className="form-control-mono"
         />
-      </div>
+      </fieldset>
+
+      {/* DEMO CONFIG */}
+      <fieldset>
+        <legend>Demo configuration</legend>
+        <p className="well-text">
+          Add additional configuration in yaml to be added to your
+          {' '}
+          <code>_config.yml</code> file when we build your site&apos;s demo branch.
+        </p>
+        <Field
+          component="textarea"
+          name="demoConfig"
+          className="form-control-mono"
+        />
+      </fieldset>
+
+      {/* PREVIEW CONFIG */}
+      <fieldset>
+        <legend>Preview configuration</legend>
+        <p className="well-text">
+          Add additional configuration in yaml to be added to your
+          {' '}
+          <code>_config.yml</code> file when we build a preview branch for your site.
+        </p>
+        <Field
+          component="textarea"
+          name="previewConfig"
+          className="form-control-mono"
+        />
+      </fieldset>
+      <button
+        type="button"
+        className="usa-button usa-button-gray button-reset"
+        disabled={pristine}
+        onClick={reset}
+      >
+        Reset
+      </button>
+
+      <button
+        type="submit"
+        className="usa-button usa-button-primary"
+        disabled={pristine}
+      >
+        Save advanced settings
+      </button>
     </div>
 
-    {/* CUSTOM CONFIG */}
-    <div className="usa-grid">
-      <div className="usa-width-one-whole">
-        <div className="well">
-          <h3 className="well-heading">Site configuration</h3>
-          <p className="well-text">
-            Add additional configuration in yaml to be added to your
-            {' '}
-            <code>_config.yml</code> file when we build your site&apos;s primary branch.
-          </p>
-          <Field
-            component="textarea"
-            name="config"
-            className="form-control"
-          />
-        </div>
-      </div>
-    </div>
 
-    {/* DEMO CONFIG */}
-    <div className="usa-grid">
-      <div className="usa-width-one-whole">
-        <div className="well">
-          <h3 className="well-heading">Demo configuration</h3>
-          <p className="well-text">
-            Add additional configuration in yaml to be added to your
-            {' '}
-            <code>_config.yml</code> file when we build your site&apos;s demo branch.
-          </p>
-          <Field
-            component="textarea"
-            name="demoConfig"
-            className="form-control"
-          />
-        </div>
-      </div>
-    </div>
-
-    {/* PREVIEW CONFIG */}
-    <div className="usa-grid">
-      <div className="usa-width-one-whole">
-        <div className="well">
-          <h3 className="well-heading">Preview configuration</h3>
-          <p className="well-text">
-            Add additional configuration in yaml to be added to your
-            {' '}
-            <code>_config.yml</code> file when we build a preview branch for your site.
-          </p>
-          <Field
-            component="textarea"
-            name="previewConfig"
-            className="form-control"
-          />
-        </div>
-      </div>
-    </div>
-
-    <div className="usa-grid">
-      <div className="usa-width-one-whole">
-        <button
-          type="button"
-          className="usa-button usa-button-gray button-reset"
-          disabled={pristine}
-          onClick={reset}
-        >
-          Reset
-        </button>
-
-        <button
-          type="submit"
-          className="usa-button usa-button-primary"
-          disabled={pristine}
-        >
-          Save Advanced Settings
-        </button>
-      </div>
-    </div>
-
-    <div className="usa-grid">
-      <h3>Danger Zone</h3>
-      <div className="usa-alert usa-alert-delete" role="alert">
-        Delete this site from Federalist?
+    <div className="usa-alert usa-alert-error usa-alert-delete" role="alert">
+       <div className="usa-alert-body">
+        <h3 className="usa-alert-heading">Danger zone</h3>
+        <p className="usa-alert-text">Delete this site from Federalist?</p>
         <button
           className="usa-button usa-button-secondary button-delete"
           onClick={onDelete}

--- a/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
@@ -29,6 +29,7 @@ export const BasicSiteSettings = ({
   handleSubmit,
 }) => (
   <form className="settings-form" onSubmit={handleSubmit}>
+    <h3>Basic settings</h3>
     <div className="well">
       <fieldset>
         <legend>Live site</legend>
@@ -62,7 +63,8 @@ export const BasicSiteSettings = ({
           className="form-control"
         />
       </fieldset>
-
+    </div>
+    <div className="well">
       <fieldset>
         <legend>Demo site</legend>
         <p className="well-text">
@@ -87,24 +89,23 @@ export const BasicSiteSettings = ({
           className="form-control"
         />
       </fieldset>
-
-      <button
-        type="button"
-        className="usa-button usa-button-gray button-reset"
-        disabled={pristine}
-        onClick={reset}
-      >
-        Reset
-      </button>
-
-      <button
-        type="submit"
-        className="usa-button usa-button-primary"
-        disabled={pristine}
-      >
-        Save basic settings
-      </button>
     </div>
+    <button
+      type="button"
+      className="usa-button usa-button-gray button-reset"
+      disabled={pristine}
+      onClick={reset}
+    >
+      Reset
+    </button>
+
+    <button
+      type="submit"
+      className="usa-button usa-button-primary"
+      disabled={pristine}
+    >
+      Save basic settings
+    </button>
   </form>
 );
 

--- a/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
@@ -29,95 +29,81 @@ export const BasicSiteSettings = ({
   handleSubmit,
 }) => (
   <form className="settings-form" onSubmit={handleSubmit}>
-    <div className="usa-grid">
-      <div className="usa-width-one-whole">
-        <div className="form-group">
-          <div className="well">
-            <h3 className="well-heading">Live Site</h3>
-            <p className="well-text">
-              Set the primary branch Federalist uses to build your site.
-              After your DNS is pointed to Federalist, you&apos;ll set
-              the <a
-                href="https://federalist-docs.18f.gov/pages/how-federalist-works/custom-urls/"
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Custom URL documentation"
-              >
-                live URL
-              </a> to ensure the site builds correctly.
-            </p>
-            <label htmlFor="defaultBranchInput">
-              Branch name:
-            </label>
-            <Field
-              component="input"
-              type="text"
-              id="defaultBranchInput"
-              name="defaultBranch"
-              className="form-control"
-            />
-            <HttpsUrlField
-              label="Live URL:"
-              name="domain"
-              id="domainInput"
-              placeholder="https://example.gov"
-              className="form-control"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
+    <div className="well">
+      <fieldset>
+        <legend>Live site</legend>
+        <p className="well-text">
+          Set the primary branch Federalist uses to build your site.
+          After your DNS is pointed to Federalist, you&apos;ll set
+          the <a
+            href="https://federalist-docs.18f.gov/pages/how-federalist-works/custom-urls/"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Custom URL documentation"
+          >
+            live URL
+          </a> to ensure the site builds correctly.
+        </p>
+        <label htmlFor="defaultBranchInput">
+          Branch name:
+        </label>
+        <Field
+          component="input"
+          type="text"
+          id="defaultBranchInput"
+          name="defaultBranch"
+          className="form-control"
+        />
+        <HttpsUrlField
+          label="Live URL:"
+          name="domain"
+          id="domainInput"
+          placeholder="https://example.gov"
+          className="form-control"
+        />
+      </fieldset>
 
-    <div className="usa-grid">
-      <div className="usa-width-one-whole">
-        <div className="form-group">
-          <div className="well">
-            <h3 className="well-heading">Demo Site</h3>
-            <p className="well-text">
-              Optional: After setting up DNS with the Federalist team, set a demo branch
-              to be deployed to a custom URL like <code>demo.example.gov</code> instead
-              of a standard Federalist preview URL.
-            </p>
-            <label htmlFor="demoBranchInput">Branch name:</label>
-            <Field
-              component="input"
-              name="demoBranch"
-              id="demoBranchInput"
-              className="form-control"
-              type="text"
-              placeholder="Branch name"
-            />
-            <HttpsUrlField
-              label="Demo URL:"
-              name="demoDomain"
-              id="demoDomainInput"
-              placeholder="https://demo.example.gov"
-              className="form-control"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
+      <fieldset>
+        <legend>Demo site</legend>
+        <p className="well-text">
+          Optional: After setting up DNS with the Federalist team, set a demo branch
+          to be deployed to a custom URL like <code>demo.example.gov</code> instead
+          of a standard Federalist preview URL.
+        </p>
+        <label htmlFor="demoBranchInput">Branch name:</label>
+        <Field
+          component="input"
+          name="demoBranch"
+          id="demoBranchInput"
+          className="form-control"
+          type="text"
+          placeholder="Branch name"
+        />
+        <HttpsUrlField
+          label="Demo URL:"
+          name="demoDomain"
+          id="demoDomainInput"
+          placeholder="https://demo.example.gov"
+          className="form-control"
+        />
+      </fieldset>
 
-    <div className="usa-grid">
-      <div className="usa-width-one-whole">
-        <button
-          type="button"
-          className="usa-button usa-button-gray button-reset"
-          disabled={pristine}
-          onClick={reset}
-        >
-          Reset
-        </button>
+      <button
+        type="button"
+        className="usa-button usa-button-gray button-reset"
+        disabled={pristine}
+        onClick={reset}
+      >
+        Reset
+      </button>
 
-        <button
-          type="submit"
-          className="usa-button usa-button-primary"
-          disabled={pristine}
-        >
-          Save Basic Settings
-        </button>
-      </div>
+      <button
+        type="submit"
+        className="usa-button usa-button-primary"
+        disabled={pristine}
+      >
+        Save basic settings
+      </button>
     </div>
   </form>
 );

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -82,7 +82,6 @@ class SiteSettings extends React.Component {
             viewing site previews
           </a>.
         </p>
-        <h3>Basic settings</h3>
         <BasicSiteSettings
           initialValues={basicInitialValues}
           onSubmit={this.onSubmit}

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -82,7 +82,7 @@ class SiteSettings extends React.Component {
             viewing site previews
           </a>.
         </p>
-        <h3>Basic Settings</h3>
+        <h3>Basic settings</h3>
         <BasicSiteSettings
           initialValues={basicInitialValues}
           onSubmit={this.onSubmit}

--- a/frontend/sass/_alerts.scss
+++ b/frontend/sass/_alerts.scss
@@ -13,7 +13,7 @@
   }
 }
 
-.usa-alert-delete {
+.usa-alert-danger {
   background-color: $alert-delete-bg-color;
 }
 

--- a/frontend/sass/_alerts.scss
+++ b/frontend/sass/_alerts.scss
@@ -15,10 +15,6 @@
 
 .usa-alert-delete {
   background-color: $alert-delete-bg-color;
-
-  button {
-    margin-left: .5em;
-  }
 }
 
 .usa-alert.no-icon {

--- a/frontend/sass/_expandableArea.scss
+++ b/frontend/sass/_expandableArea.scss
@@ -37,3 +37,6 @@
 .expandable-area-content[aria-hidden="true"] {
   display: none;
 }
+.expandable-area-content {
+  padding-top: 2rem;
+}

--- a/frontend/sass/_forms.scss
+++ b/frontend/sass/_forms.scss
@@ -1,6 +1,7 @@
 label,
 legend {
   font-size: inherit;
+  font-weight: 800;
 }
 
 fieldset {
@@ -55,6 +56,9 @@ select {
 .settings-form {
   button[type="submit"] {
     display: inline;
+  }
+  .well {
+    margin-left: 2rem;
   }
 }
 

--- a/frontend/sass/_forms.scss
+++ b/frontend/sass/_forms.scss
@@ -1,12 +1,18 @@
 label,
 legend {
   font-size: inherit;
-  font-weight: 800;
-  text-transform: capitalize;
 }
 
-label,
 fieldset {
+  margin-bottom: 2rem;
+}
+
+legend {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+label {
   margin-top: 2rem;
 }
 
@@ -49,5 +55,14 @@ select {
 .settings-form {
   button[type="submit"] {
     display: inline;
+  }
+}
+
+.form-control-mono {
+  font-family: monospace,monospace;
+}
+.settings-form-advanced {
+  select {
+    margin-bottom: 2rem;
   }
 }

--- a/frontend/sass/_forms.scss
+++ b/frontend/sass/_forms.scss
@@ -59,7 +59,7 @@ select {
 }
 
 .form-control-mono {
-  font-family: monospace,monospace;
+  font-family: monospace;
 }
 .settings-form-advanced {
   select {

--- a/frontend/sass/_wells.scss
+++ b/frontend/sass/_wells.scss
@@ -5,6 +5,12 @@
   padding: 1.5rem;
   position: relative;
   margin-bottom: 1.5rem;
+  :first-child {
+    margin-top: 0;
+  }
+  :last-child {
+    margin-bottom: 0;
+  }
 }
 
 .well-heading {


### PR DESCRIPTION
# Updates
- Fixes the left alignment of the settings page content Currently there is a gap that is caused by the `usa-grid` classes that have been removed.
- Adds labels to the text areas for configurations. Currently there is not label for any of the advance settings text boxes and that is an accessibility issue. 
- Groups the basic and advanced settings into a single well instead of multiple .This helps with giving the save buttons some context on what you are saving and clean up the UI a bit
- Sentence cased the headings, labels, buttons, and links as necessary. Did not address page title casing (that's for a diff PR)
- Added `fieldsets` and `legends` for greater accessibility.
- Removed the `usa-grid` and `usa-width-one-whole` divs as the content of the page is already inside a `usa-grid` div. This clean up the code a bit.
- Updated the danger zone to use the proper alert markup for headings and content.
- Updated the config textboxes in the advanced settings to use monospace font, per issue https://github.com/18F/federalist/issues/1328

## Screenshot
![localhost_1337_sites_1_settings](https://user-images.githubusercontent.com/1449852/34501529-5245ebb6-efdd-11e7-824c-da73ec454830.png)

CC @wslack 
