### PR TITLE
add iconClass for side nav links

### DIFF
--- a/frontend/components/site/SideNav.jsx
+++ b/frontend/components/site/SideNav.jsx
@@ -10,7 +10,7 @@ const SideNav = ({ siteId }) => (
       {
         SITE_NAVIGATION_CONFIG.map(conf => (
           <li key={conf.route}>
-            <Link to={`/sites/${siteId}/${conf.route}`} className="icon icon-logs">
+            <Link to={`/sites/${siteId}/${conf.route}`} className={`icon ${conf.iconClass}`}>
               {conf.display}
             </Link>
           </li>

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -43,22 +43,27 @@ export const SITE_NAVIGATION_CONFIG = [
   {
     display: 'Build history',
     route: 'builds',
+    iconClass: 'icon-logs',
   },
   {
     display: 'GitHub branches',
     route: 'branches',
+    iconClass: 'icon-pages',
   },
   {
     display: 'Published files',
     route: 'published',
+    iconClass: 'icon-upload',
   },
   {
     display: 'Collaborators',
     route: 'users',
+    iconClass: 'icon-gear',
   },
   {
     display: 'Site settings',
     route: 'settings',
+    iconClass: 'icon-settings',
   },
 ];
 


### PR DESCRIPTION
Adds back the icons for the Side Nav links.

<img width="606" alt="screen shot 2018-01-05 at 4 09 37 pm" src="https://user-images.githubusercontent.com/697848/34630748-0b14dcea-f233-11e7-9b31-b1a6ddd46de2.png">

ref #1458.