### PR TITLE
Use site authorizer in build log controller

### DIFF
--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -1,4 +1,4 @@
-const buildAuthorizer = require('../authorizers/build');
+const siteAuthorizer = require('../authorizers/site');
 const buildLogSerializer = require('../serializers/build-log');
 const { Build, BuildLog } = require('../models');
 
@@ -54,7 +54,7 @@ module.exports = {
         if (!build) {
           throw 404;
         }
-        return buildAuthorizer.findOne(req.user, { buildId: build.id, siteId: build.site });
+        return siteAuthorizer.findOne(req.user, { id: build.site });
       })
       .then(() => BuildLog.findAll({ where: { build: build.id } }))
       .then(buildLogs => buildLogSerializer.serialize(buildLogs, { isPlaintext }))


### PR DESCRIPTION
* Previously, we used the build authorizer, which was bsaically the same
as the site authorizer code. The site authorizer is acceptable here
since we only need to check if the user is associated with the site before
displaying logs

I added a test checking explicitly that the user was not associated with the build logs being retrieved.