### PR TITLE
Various datetime formatting; switch from moment to date-fns in front end bundle

### DIFF
--- a/frontend/components/site/UserActionsTable.jsx
+++ b/frontend/components/site/UserActionsTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { USER_ACTION } from '../../propTypes';
-import { dayAndDate } from '../../util/datetime';
+import { timestampUTC } from '../../util/datetime';
 
 const propTypes = {
   userActions: PropTypes.arrayOf(USER_ACTION),
@@ -22,16 +22,16 @@ const UserActionsTable = ({ userActions }) =>
           Target
         </th>
         <th>
-          Performed on
+          Timestamp (UTC)
         </th>
       </tr>
     </thead>
     <tbody>
       {userActions.map(action =>
         <tr key={`${action.id}-${action.targetType}`}>
-          <th>{action.actionType.action}</th>
-          <th>{action.actionTarget.username}</th>
-          <th>{dayAndDate(action.createdAt)}</th>
+          <td>{action.actionType.action}</td>
+          <td>{action.actionTarget.username}</td>
+          <td>{timestampUTC(action.createdAt)}</td>
         </tr>
       )}
     </tbody>

--- a/frontend/components/site/siteBuildLogTable.jsx
+++ b/frontend/components/site/siteBuildLogTable.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { BUILD_LOG } from '../../propTypes';
+import { timestampUTC } from '../../util/datetime';
 
 function SiteBuildLogTable({ buildLogs }) {
   return (
@@ -10,7 +11,7 @@ function SiteBuildLogTable({ buildLogs }) {
         <tr>
           <th>Source</th>
           <th>Output</th>
-          <th>Timestamp</th>
+          <th>Timestamp (UTC)</th>
         </tr>
       </thead>
       <tbody>
@@ -22,7 +23,7 @@ function SiteBuildLogTable({ buildLogs }) {
                 {log.output}
               </pre>
             </td>
-            <td>{log.createdAt}</td>
+            <td>{timestampUTC(log.createdAt)}</td>
           </tr>
         )))}
       </tbody>

--- a/frontend/components/siteList/publishedState.js
+++ b/frontend/components/siteList/publishedState.js
@@ -1,26 +1,31 @@
 import React from 'react';
-import moment from "moment";
+
+import { dateAndTime } from '../../util/datetime';
 
 const propTypes = {
   site: React.PropTypes.shape({
     publishedAt: React.PropTypes.string,
-  })
+  }),
+};
+
+const defaultProps = {
+  site: {},
 };
 
 const getPublishedState = (site) => {
   if (site.publishedAt) {
-    let formattedBuildTime = moment(site.publishedAt).format('MMMM Do YYYY, h:mm:ss a')
-    return `This site was last published at ${formattedBuildTime}.`;
-  } else {
-    return 'Please wait for build to complete or check logs for error message.';
+    const formattedBuildTime = dateAndTime(site.publishedAt);
+    return `Last published on ${formattedBuildTime}.`;
   }
+  return 'Please wait for build to complete or check logs for error message.';
 };
 
 const PublishedState = ({ site = {} }) =>
   <p>
     {getPublishedState(site)}
-  </p>
+  </p>;
 
 PublishedState.propTypes = propTypes;
+PublishedState.defaultProps = defaultProps;
 
 export default PublishedState;

--- a/frontend/util/datetime.js
+++ b/frontend/util/datetime.js
@@ -52,19 +52,6 @@ export const timeFrom = (date) => {
 };
 
 /**
- * Return a human-readable day, months and year (i.e. Monday, Dec. 25th 2020)
- * @param  {String | Date} date format "YYYY-DD-DDT00:00:00.000Z"
- * @return {String}
- */
-export const dayAndDate = (date) => {
-  if (!date) {
-    return NO_TIME;
-  }
-
-  return format(date, 'dddd, MMM Do YYYY');
-};
-
-/**
  * Return a human-readable day, months and year (i.e. December 25th 2020 5:22 PM)
  * @param  {String | Date} date format "YYYY-DD-DDT00:00:00.000Z"
  * @return {String}

--- a/frontend/util/datetime.js
+++ b/frontend/util/datetime.js
@@ -1,6 +1,25 @@
-import moment from 'moment';
+import { format, distanceInWords, distanceInWordsStrict } from 'date-fns';
+
 
 const NO_TIME = '-';
+
+/**
+ * Helper to get the given date or `now` in UTC.
+ * @param {String | Date} dateString  date to convert to UTC. Defaults to now.
+ * @return {Date}                     date in UTC
+ */
+function getUTCDate(dateString = Date.now()) {
+  const date = new Date(dateString);
+
+  return new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds()
+  );
+}
 
 
 /**
@@ -15,12 +34,12 @@ export const duration = (startTime, endTime) => {
   }
 
   const baseTime = endTime || new Date();
-  return moment.duration(moment(baseTime).diff(startTime)).humanize();
+  return distanceInWords(baseTime, startTime);
 };
 
 
 /**
- * Return a human-readable time since the supplied date
+ * Return a human-readable time since the supplied date, like '5 hours ago'
  * @param  {String | Date} date format "YYYY-DD-DDT00:00:00.000Z"
  * @return {String}
  */
@@ -29,7 +48,7 @@ export const timeFrom = (date) => {
     return NO_TIME;
   }
 
-  return moment(date).fromNow();
+  return distanceInWordsStrict(new Date(), date, { addSuffix: true });
 };
 
 /**
@@ -42,5 +61,32 @@ export const dayAndDate = (date) => {
     return NO_TIME;
   }
 
-  return moment(date).format('dddd, MMM Do YYYY');
+  return format(date, 'dddd, MMM Do YYYY');
+};
+
+/**
+ * Return a human-readable day, months and year (i.e. December 25th 2020 5:22 PM)
+ * @param  {String | Date} date format "YYYY-DD-DDT00:00:00.000Z"
+ * @return {String}
+ */
+export const dateAndTime = (date) => {
+  if (!date) {
+    return NO_TIME;
+  }
+
+  return format(date, 'MMMM Do YYYY, h:mm:ss a');
+};
+
+/**
+ * Return a formatted timestamp in UTC (i.e. '2018-02-11 04:22:33 ')
+ * @param  {String | Date} date format "YYYY-DD-DDT00:00:00.000Z"
+ * @return {String}
+ */
+export const timestampUTC = (date) => {
+  if (!date) {
+    return NO_TIME;
+  }
+
+  const utcTimestamp = format(getUTCDate(date), 'YYYY-MM-DD HH:mm:ss');
+  return `${utcTimestamp}`;
 };

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "concurrently": "^3.4.0",
     "cookie": "^0.3.1",
     "css-loader": "^0.28.4",
+    "date-fns": "^1.29.0",
     "enzyme": "^2.4.1",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",

--- a/test/frontend/components/site/SiteBuildLogTable.test.js
+++ b/test/frontend/components/site/SiteBuildLogTable.test.js
@@ -7,18 +7,19 @@ describe('<SiteBuildLogTable/>', () => {
   it('should render a table of build logs', () => {
     const props = {
       buildLogs: [
-        { id: 1, output: 'output 1', source: 'source 1', createdAt: '2017-06-19T14:45:00.126Z' },
-        { id: 1, output: 'output 2', source: 'source 2', createdAt: '2017-06-19T14:50:00.126Z' },
+        { id: 1, output: 'output 1', source: 'source 1', createdAt: '2017-06-19T14:45:12.126Z' },
+        { id: 1, output: 'output 2', source: 'source 2', createdAt: '2017-06-19T14:50:44.336Z' },
       ],
     };
 
     const wrapper = shallow(<SiteBuildLogTable {...props} />);
     expect(wrapper.find('table')).to.have.length(1);
+    expect(wrapper.find('table thead').contains('Timestamp (UTC)')).to.be.true;
     expect(wrapper.find('table').contains('output 1')).to.be.true;
     expect(wrapper.find('table').contains('source 1')).to.be.true;
-    expect(wrapper.find('table').contains('2017-06-19T14:45:00.126Z')).to.be.true;
+    expect(wrapper.find('table').contains('2017-06-19 14:45:12')).to.be.true;
     expect(wrapper.find('table').contains('output 2')).to.be.true;
     expect(wrapper.find('table').contains('source 2')).to.be.true;
-    expect(wrapper.find('table').contains('2017-06-19T14:50:00.126Z')).to.be.true;
+    expect(wrapper.find('table').contains('2017-06-19 14:50:44')).to.be.true;
   });
 });

--- a/test/frontend/components/site/UserActionsTable.test.jsx
+++ b/test/frontend/components/site/UserActionsTable.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import UserActionsTable from '../../../../frontend/components/site/UserActionsTable';
+
+describe('<UserActionsTable/>', () => {
+  it('should render a table of user actions', () => {
+    const props = {
+      userActions: [
+        {
+          targetType: 'user',
+          actionType: { action: 'remove' },
+          actionTarget: { username: 'test_user_1' },
+          createdAt: '2017-06-19T14:50:44.336Z',
+        },
+        {
+          targetType: 'user',
+          actionType: { action: 'remove' },
+          actionTarget: { username: 'test_user_2' },
+          createdAt: '2018-01-02T21:45:00.000+05:00', // with +5 offset
+        },
+      ],
+    };
+    const wrapper = shallow(<UserActionsTable {...props} />);
+    expect(wrapper.find('table')).to.have.length(1);
+    expect(wrapper.find('th').at(0).contains('Action')).to.be.true;
+    expect(wrapper.find('th').at(1).contains('Target')).to.be.true;
+    expect(wrapper.find('th').at(2).contains('Timestamp (UTC)')).to.be.true;
+
+    const rows = wrapper.find('tbody tr');
+    expect(rows).to.have.length(2);
+
+    const row1 = rows.at(0);
+    expect(row1.find('td').at(0).contains('remove')).to.be.true;
+    expect(row1.find('td').at(1).contains('test_user_1')).to.be.true;
+    expect(row1.find('td').at(2).contains('2017-06-19 14:50:44')).to.be.true;
+
+    const row2 = rows.at(1);
+    expect(row2.find('td').at(0).contains('remove')).to.be.true;
+    expect(row2.find('td').at(1).contains('test_user_2')).to.be.true;
+
+    // this time is 5 hours "earlier" than the specified createdAt due to the UTC offset of +5
+    expect(row2.find('td').at(2).contains('2018-01-02 16:45:00')).to.be.true;
+  });
+});

--- a/test/frontend/components/siteList/publishedState.test.js
+++ b/test/frontend/components/siteList/publishedState.test.js
@@ -1,18 +1,16 @@
 import React from 'react';
-import moment from 'moment'
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import PublishedState from '../../../../frontend/components/siteList/publishedState';
 
 const PUBLISHED_BASE = 'Please wait for build to complete or check logs for error message.';
-const MOST_RECENT_BUILD_TIME = "2015-09-04T15:11:23.000Z"
-const FORMATTED_MOST_RECENT_BUILD_TIME =  moment(MOST_RECENT_BUILD_TIME).format('MMMM Do YYYY, h:mm:ss a')
-const MOST_RECENT_BUILD = `This site was last published at ${FORMATTED_MOST_RECENT_BUILD_TIME}.`;
+const MOST_RECENT_BUILD_TIME = '2015-09-04T15:11:23.000Z';
+const FORMATTED_MOST_RECENT_BUILD_TIME = 'September 4th 2015, 3:11:23 pm';
+const MOST_RECENT_BUILD = `Last published on ${FORMATTED_MOST_RECENT_BUILD_TIME}.`;
 
 let wrapper;
 
 describe('<PublishedState />', () => {
-
   it('displays a fallback message if the site has no builds', () => {
     wrapper = shallow(<PublishedState />);
 

--- a/test/frontend/util/datetime.test.js
+++ b/test/frontend/util/datetime.test.js
@@ -1,30 +1,32 @@
 import { expect } from 'chai';
-import { duration, timeFrom, dayAndDate } from '../../../frontend/util/datetime';
+import { duration, timeFrom, dayAndDate, dateAndTime, timestampUTC } from '../../../frontend/util/datetime';
 
-const DURATION = 'a few seconds';
 const NO_DATE = '-';
 
 describe('datetime', () => {
-  const endTime = '2016-05-13T18:32:41.000Z';
-  const startTime = '2016-05-13T18:32:01.000Z';
+  const endTime = '2016-02-13T18:35:41.000Z';
+  const startTime = '2016-02-13T18:32:01.000Z';
 
   describe('duration()', () => {
     it('shows a human readable duration when provided two dates', () => {
-      expect(duration(startTime, endTime)).to.equal(DURATION);
+      expect(duration(startTime, endTime)).to.equal('4 minutes');
     });
 
     it('works if endTime isn\'t defined', () => {
-      expect(duration(+new Date())).to.equal(DURATION);
+      expect(duration(+new Date())).to.equal('less than a minute');
     });
 
-    it('provides a fallback if startTime isnt defined', () => {
+    it('provides a fallback if startTime isn\'t defined', () => {
       expect(duration()).to.equal(NO_DATE);
     });
   });
 
   describe('timeFrom()', () => {
     it('shows a human readable elapsed time from end date', () => {
-      expect(timeFrom(+new Date())).to.equal(`${DURATION} ago`);
+      const testDate = new Date();
+      testDate.setSeconds(testDate.getSeconds() - 32);
+
+      expect(timeFrom(testDate)).to.equal('32 seconds ago');
     });
 
     it('provides a fallback if no initial time is supplied', () => {
@@ -34,11 +36,37 @@ describe('datetime', () => {
 
   describe('.dayAndDate', () => {
     it('provides a day and date when a valid date is provided', () => {
-      expect(dayAndDate(startTime)).to.equal('Friday, May 13th 2016');
+      expect(dayAndDate(startTime)).to.equal('Saturday, Feb 13th 2016');
     });
 
     it('provides a fallback if no date is provided', () => {
       expect(dayAndDate()).to.equal(NO_DATE);
+    });
+  });
+
+  describe('.dateAndTime', () => {
+    it('provides a date and time when a valid date is provided', () => {
+      expect(dateAndTime(startTime)).to.equal('February 13th 2016, 6:32:01 pm');
+    });
+
+    it('provides a fallback if no date is provided', () => {
+      expect(dateAndTime()).to.equal(NO_DATE);
+    });
+  });
+
+  describe('.timestampUTC', () => {
+    it('provides a UTC timestamp when a valid date is provided', () => {
+      expect(timestampUTC(startTime)).to.equal('2016-02-13 18:32:01');
+
+      // make a date with a UTC offset of +5
+      const timeInZone = new Date('1984-02-11T16:01:01.000+05:00');
+
+      // UTC time should be 5 hours earlier
+      expect(timestampUTC(timeInZone)).to.equal('1984-02-11 11:01:01');
+    });
+
+    it('provides a fallback if no date is provided', () => {
+      expect(timestampUTC()).to.equal(NO_DATE);
     });
   });
 });

--- a/test/frontend/util/datetime.test.js
+++ b/test/frontend/util/datetime.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { duration, timeFrom, dayAndDate, dateAndTime, timestampUTC } from '../../../frontend/util/datetime';
+import { duration, timeFrom, dateAndTime, timestampUTC } from '../../../frontend/util/datetime';
 
 const NO_DATE = '-';
 
@@ -31,16 +31,6 @@ describe('datetime', () => {
 
     it('provides a fallback if no initial time is supplied', () => {
       expect(timeFrom()).to.equal(NO_DATE);
-    });
-  });
-
-  describe('.dayAndDate', () => {
-    it('provides a day and date when a valid date is provided', () => {
-      expect(dayAndDate(startTime)).to.equal('Saturday, Feb 13th 2016');
-    });
-
-    it('provides a fallback if no date is provided', () => {
-      expect(dayAndDate()).to.equal(NO_DATE);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,6 +1993,10 @@ date-fns@^1.23.0:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
+date-fns@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
To Do:
- [x] update the user actions table timestamps with the log-like timestamp formatting

Various datetime issues/features, including:

- #1301 - improve timestamp formatting in build log table
- #1448 - update site last published text
- #1160 - replace moment with date-fns in the front end (still used in back end though)

Summary of changes with screenshots:

### Sites List (#1448):

Changed to `Last published on January 9th 2018, 3:20:26 pm.`

<img width="610" alt="screen shot 2018-01-09 at 12 22 47 pm" src="https://user-images.githubusercontent.com/697848/34736224-d6825194-f537-11e7-9982-2e6e096a1bf0.png">

### Builds Logs Table (#1301)

Updated formatting to be a little more readable, ensure times are UTC. Added "(UTC)" to the column header.

This is the only place that has UTC times. I think they are nice to use here so that everyone looking at/debugging a build has the times in the same "zone," and they align with the timestamps shown in the actual logs from the build container (which are in UTC as well). 

<img width="559" alt="screen shot 2018-01-09 at 12 24 18 pm" src="https://user-images.githubusercontent.com/697848/34736307-19b591ba-f538-11e7-8a26-49d996efed71.png">

### User Actions Table

Updated to use UTC timestamps:

<img width="840" alt="screen shot 2018-01-09 at 5 21 29 pm" src="https://user-images.githubusercontent.com/697848/34748327-9a63c07e-f561-11e7-8781-7ecd919a868a.png">
 
  
  