### PR TITLE
migrate user_action createdAt/updatedAt to be timestamps

### DIFF
--- a/migrations/20180110203014-user-action-timestamps.js
+++ b/migrations/20180110203014-user-action-timestamps.js
@@ -1,0 +1,23 @@
+exports.up = (db, callback) => {
+  const newColConfig = { type: 'timestamp', notNull: true };
+
+  db.changeColumn('user_action', 'createdAt', newColConfig, (err) => {
+    if (err) {
+      callback(err);
+    } else {
+      db.changeColumn('user_action', 'updatedAt', newColConfig, callback);
+    }
+  });
+};
+
+exports.down = (db, callback) => {
+  const oldColConfig = { type: 'date', notNull: true };
+
+  db.changeColumn('user_action', 'createdAt', oldColConfig, (err) => {
+    if (err) {
+      callback(err);
+    } else {
+      db.changeColumn('user_action', 'updatedAt', oldColConfig, callback);
+    }
+  });
+};


### PR DESCRIPTION
Now we'll store user actions with the time and not just the date:

<img width="839" alt="screen shot 2018-01-10 at 2 39 42 pm" src="https://user-images.githubusercontent.com/697848/34794456-51cdf362-f614-11e7-9723-dbd41b06820a.png">

ref #1479 