### PR TITLE
Remove non federalist users from site users table

### DIFF
--- a/api/models/user.js
+++ b/api/models/user.js
@@ -44,6 +44,24 @@ function toJSON() {
   });
 }
 
+const tableOptions = {
+  tableName: 'user',
+  classMethods: {
+    associate,
+  },
+  instanceMethods: {
+    toJSON,
+  },
+  paranoid: true,
+  scopes: {
+    withGithub: {
+      where: {
+        githubAccessToken: { $ne: null },
+      },
+    },
+  },
+};
+
 module.exports = (sequelize, DataTypes) => {
   const User = sequelize.define('User', {
     email: {
@@ -66,16 +84,7 @@ module.exports = (sequelize, DataTypes) => {
       unique: true,
       allowNull: false,
     },
-  }, {
-    tableName: 'user',
-    classMethods: {
-      associate,
-    },
-    instanceMethods: {
-      toJSON,
-    },
-    paranoid: true,
-  });
+  }, tableOptions);
 
   return User;
 };

--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -12,7 +12,7 @@ const serializeObject = (site) => {
 };
 
 const serialize = (serializable) => {
-  const include = [User];
+  const include = [User.scope('withGithub')];
 
   if (serializable.length !== undefined) {
     const siteIds = serializable.map(site => site.id);

--- a/test/api/unit/serializers/site.test.js
+++ b/test/api/unit/serializers/site.test.js
@@ -35,5 +35,20 @@ describe('SiteSerializer', () => {
         })
         .catch(done);
     });
+
+    it('excludes users without a federalist account', (done) => {
+      const authUserCount = 3;
+      const nonGithubUser = factory.user({ githubAccessToken: null });
+      const otherUsers = Array(authUserCount).fill(0).map(() => factory.user());
+
+      Promise.all(otherUsers.concat(nonGithubUser))
+      .then(users => factory.site({ users }))
+      .then(SiteSerializer.serialize)
+      .then((object) => {
+        expect(object.users.length).to.equal(authUserCount);
+        done();
+      })
+      .catch(done);
+    });
   });
 });


### PR DESCRIPTION
* Adds scope to user model to filter out those who do not have a
federalist account, or are not members of the federalist-users org