### PR TITLE
add npm scripts for easily testing single files

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The following environment variables are set on the Cloud Foundry environment in 
 - `NPM_CONFIG_PRODUCTION`: This should be set to true in Cloud Foundry to prevent Yarn/NPM from installing dev dependencies
 - `NODE_MODULES_CACHE`: This should be set to true in Cloud Foundry to prevent caching node modules since those are vendored by Federalist
 - `APP_NAME`: The name of the Cloud Foundry application
-- `APP_COMAIN`: The hostname where the application runs in Cloud Foundry
+- `APP_DOMAIN`: The hostname where the application runs in Cloud Foundry
 
 Secrets cannot be kept in the application manifest so they are provided by Cloud Foundry services.
 The app expects the following user provided services to be provided:
@@ -144,9 +144,11 @@ docker-compose run app yarn test
 You can also just run back or front end tests via:
 
 ```sh
-docker-compose run app yarn test:server  # for back end tests
-docker-compose run app yarn test:client  # for front end tests
+docker-compose run app yarn test:server  # for all back end tests
+docker-compose run app yarn test:server:file ./test/api/<path/to/test.js> # to run a single back end test file
+docker-compose run app yarn test:client  # for all front end tests
 docker-compose run app yarn test:client:watch  # to watch and re-run front end tests
+docker-compose run app yarn test:client:file ./test/frontend/<path/to/test.js> # to run a single front end test file
 ```
 
 To view coverage reports as HTML after running the full test suite:

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "test:prepare": "NODE_ENV=test yarn migrate:up && yarn build",
     "test:server": "NODE_ENV=test nyc --report-dir ./coverage/server mocha --timeout 2500 test/api/bootstrap.test.js test/api/unit/**/*.test.js test/api/requests/**/*.test.js",
     "test:client": "nyc --report-dir ./coverage/client mocha --compilers js:babel-register,jsx:babel-register --recursive ./test/frontend",
+    "test:client:file": "mocha --compilers js:babel-register,jsx:babel-register",
+    "test:server:file": "NODE_ENV=test nyc --report-dir ./coverage/server mocha --timeout 2500 test/api/bootstrap.test.js",
     "test:server:watch": "watch 'yarn test:server' ./api ./test/api",
     "test:client:watch": "watch 'yarn test:client' ./frontend ./test/frontend",
     "lint": "eslint ./api/**/*.js ./config/**/*.js ./frontend/**/*.js ./migration/**/*.js ./script/**/*.js ./services/**/*.js",


### PR DESCRIPTION
This had been annoying me for a while, and @line47 brought it up today as well, so figured I'd go ahead and some package.json tasks for running a single front or back end test.