### PR TITLE
Handle error in action instead of fetch wrapper

### DIFF
--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -38,7 +38,10 @@ export default {
           updateRouterToSitesUri();
         }
       })
-      .catch(alertError);
+      .catch((err) => {
+        updateRouterToSitesUri();
+        alertError(err);
+      });
   },
 
   addUserToSite({ owner, repository }) {

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -87,6 +87,8 @@ export default {
     return this.fetch('site', {
       method: 'POST',
       data: site,
+    }, {
+      handleHttpError: false,
     });
   },
 

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -101,9 +101,8 @@ describe('siteActions', () => {
     }).default;
   });
 
-  const expectDispatchOfHttpErrorAlert = (errMsg) => {
+  const expectDispatchOfHttpErrorAlert = errMsg =>
     expect(httpErrorAlertAction.calledWith(errMsg)).to.be.true;
-  };
 
   const validateResultDispatchesHttpAlertError = (promise, errMsg) => promise.then(() => {
     expectDispatchOfHttpErrorAlert(errMsg);
@@ -162,6 +161,17 @@ describe('siteActions', () => {
       return actual.then(() => {
         expect(dispatchSiteAddedAction.called).to.be.false;
         expect(updateRouterToSiteBuildsUri.called).to.be.false;
+        expect(updateRouterToSitesUri.calledOnce).to.be.true;
+        validateResultDispatchesHttpAlertError(actual, errorMessage);
+      });
+    });
+
+    it('triggers an error and redirects when a thrown error is caught', () => {
+      addSite.withArgs(siteToAdd).returns(rejectedWithErrorPromise);
+
+      const actual = fixture.addSite(siteToAdd);
+
+      return actual.catch(() => {
         expect(updateRouterToSitesUri.calledOnce).to.be.true;
         validateResultDispatchesHttpAlertError(actual, errorMessage);
       });


### PR DESCRIPTION
Screenshot following redirect after adding a site fails:

<img width="1044" alt="screen shot 2018-01-12 at 9 35 43 pm" src="https://user-images.githubusercontent.com/1421848/34901996-98e2c732-f7e0-11e7-853f-5e9e7a0b13ca.png">
