### PR TITLE
Adds trailing slash to site prefixes on s3 delete

### DIFF
--- a/api/services/S3SiteRemover.js
+++ b/api/services/S3SiteRemover.js
@@ -56,12 +56,15 @@ const removeSite = (site) => {
   return Promise.all(
     prefixes.map(prefix => getKeys(`${prefix}/`))
   ).then((keys) => {
-    // S3 puts redirect objects in the root of each user's folder which correspond to the
-    // names of each site prefix. We have to manually add them to the array of keys to delete
-    // because `listObjects` will no longer find them now that each prefix is suffixed
-    // with a trailing slash
-    const redirectObjects = prefixes.slice(0);
-    const mergedKeys = redirectObjects.concat(...keys);
+    let mergedKeys = [].concat(...keys);
+
+    if (mergedKeys.length) {
+      // S3 puts redirect objects in the root of each user's folder which correspond to the
+      // names of each site prefix. We have to manually add them to the array of keys to delete
+      // because `listObjects` will no longer find them now that each prefix is suffixed
+      // with a trailing slash
+      mergedKeys = mergedKeys.concat(prefixes.slice(0));
+    }
 
     return deleteObjects(mergedKeys);
   });

--- a/api/services/S3SiteRemover.js
+++ b/api/services/S3SiteRemover.js
@@ -59,10 +59,12 @@ const removeSite = (site) => {
     let mergedKeys = [].concat(...keys);
 
     if (mergedKeys.length) {
-      // S3 puts redirect objects in the root of each user's folder which correspond to the
-      // names of each site prefix. We have to manually add them to the array of keys to delete
-      // because `listObjects` will no longer find them now that each prefix is suffixed
-      // with a trailing slash
+      /**
+       * The federalist build container puts redirect objects in the root of each user's folder
+       * which correspond to the name of each site prefix. Because each site prefix is suffixed
+       * with a trailing `/`, `listObjects will no longer see them.
+       * Therefore, they are manually added to the array of keys marked for deletion.
+       */
       mergedKeys = mergedKeys.concat(prefixes.slice(0));
     }
 


### PR DESCRIPTION
* hopefully prevents a site whose name is a substring of another site
owned by the same user from being deleted