### PR TITLE
Use :delegated app volume in docker-compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
     command: ["scripts/wait-for-it.sh", "db:5432", "--", "yarn", "watch"]
     volumes:
-      - .:/app
+      - .:/app:delegated
       - node-modules:/app/node_modules/
       - yarn-cache:/app/.yarn-cache/
     ports:


### PR DESCRIPTION
This should make doing things that touch the file system (like `docker-compose run app yarn test` and `docker-compose up`) faster!

Thanks to @toolness for this handy tidbit

More reading at https://docs.docker.com/docker-for-mac/osxfs-caching/#examples