### PR TITLE
Adds error msg if org hasn't authorized federalist

### DIFF
--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -105,7 +105,6 @@ const handleCreateRepoError = (err) => {
 
 const handleWebhookError = (err) => {
   const error = err;
-
   const HOOK_EXISTS_MESSAGE = 'Hook already exists on this repository';
   const NO_ACCESS_MESSAGE = 'Not Found';
   const NO_ADMIN_ACCESS_ERROR_MESSAGE = 'You do not have admin access to this repository';
@@ -128,6 +127,11 @@ module.exports = {
     githubClient(user.githubAccessToken)
       .then(github => getRepository(github, { user: owner, repo: repository }))
       .then(fetchedRepository => fetchedRepository.permissions),
+
+  checkOrganizations: (user, orgName) =>
+    githubClient(user.githubAccessToken)
+    .then(github => getOrganizations(github))
+    .then(orgs => orgs.some(org => org.login === orgName)),
 
   createRepo: (user, owner, repository) =>
     githubClient(user.githubAccessToken)

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -48,7 +48,11 @@ function ownerIsFederalistUser(owner) {
 function checkGithubOrg({ user, owner }) {
   return ownerIsFederalistUser(owner)
   .then((model) => {
-    if (model) return Promise.resolve();
+    if (model) {
+      // Owner of the repo is a user, not an org.
+      // They exist in our DB, drop down to the next promise and bypass
+      return Promise.resolve(true);
+    }
 
     return GitHub.checkOrganizations(user, owner);
   })

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -56,10 +56,11 @@ function checkGithubOrg({ user, owner }) {
 
     return GitHub.checkOrganizations(user, owner);
   })
-  .then((existingOrg) => {
-    if (!existingOrg) {
+  .then((federalistAuthorizedOrg) => {
+    // Has this org authorized federalist as an oauth app?
+    if (!federalistAuthorizedOrg) {
       throw {
-        message: `Organization '${owner}'' hasn't approved access for federalist. Ask an owner to authorize it`,
+        message: `Organization '${owner}' hasn't approved access for Federalist. Ask an owner to authorize it.`,
         status: 403,
       };
     }

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -180,7 +180,7 @@ describe('SiteCreator', () => {
           return SiteCreator.createSite({ user, siteParams });
         })
         .catch((err) => {
-          const expectedError = `Organization '${siteParams.owner}'' hasn't approved access for federalist. Ask an owner to authorize it`;
+          const expectedError = `Organization '${siteParams.owner}' hasn't approved access for Federalist. Ask an owner to authorize it.`;
 
           expect(err.message).to.equal(expectedError);
           expect(err.status).to.equal(403);


### PR DESCRIPTION
* When a user attempts to add a site from an exisiting repo,
differentiate between the user not having admin access to that repo
and federalist access not approved for that repo's organization