### PR TITLE
Add command to create dev db data

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This will be the file that holds your S3 and SQS configurations.
 1. Type `npm run update-local-config` to read necessary service keys from the staging environment and load them into a local file called `config/local-from-staging.js`. Note that this command will need to be re-run with some frequency, as service keys are changed every time Federalist's staging instance is deployed.
 1. Run `docker-compose build`.
 1. Run `docker-compose run app yarn && docker-compose run app yarn build` to install dependencies and build the app initially.
+1. Run `docker-compose run app yarn create-dev-data` and answer its prompts to create some fake development data for your local database.
 1. Run `docker-compose up` to start the development environment.  You should now be able to see Federalist running at http://localhost:1337/. Local file changes will cause the server to restart and/or the front end bundles to be rebuilt.
 
 **Pro tips:**

--- a/api/models/action-type.js
+++ b/api/models/action-type.js
@@ -1,3 +1,5 @@
+const defaultTypes = ['add', 'remove', 'update'];
+
 const associate = ({ ActionType, UserAction }) => {
   ActionType.hasMany(UserAction, {
     foreignKey: 'actionId',
@@ -5,6 +7,12 @@ const associate = ({ ActionType, UserAction }) => {
 };
 
 module.exports = (sequelize, DataTypes) => {
+  const createDefaultActionTypes = () => {
+    Promise.all(defaultTypes.map(type =>
+      sequelize.models.ActionType.create({ action: type })
+    ));
+  };
+
   const ActionType = sequelize.define('ActionType', {
     action: {
       type: DataTypes.STRING,
@@ -15,6 +23,7 @@ module.exports = (sequelize, DataTypes) => {
     tableName: 'action_type',
     classMethods: {
       associate,
+      createDefaultActionTypes,
     },
     timestamps: false,
   });

--- a/api/utils/cleanDatabase.js
+++ b/api/utils/cleanDatabase.js
@@ -1,0 +1,16 @@
+
+const { models } = require('../../api/models').sequelize;
+
+function cleanDatabase() {
+  const promises = Object.keys(models).map((name) => {
+    const model = models[name];
+    // Using `force: true` removes soft deleted models and prevents uniqueness validation errors
+    const promise = model.destroy({ where: {}, force: true });
+
+    return promise;
+  });
+
+  return Promise.all(promises);
+}
+
+module.exports = cleanDatabase;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:server": "NODE_ENV=test nyc --report-dir ./coverage/server mocha --timeout 2500 test/api/bootstrap.test.js test/api/unit/**/*.test.js test/api/requests/**/*.test.js",
     "test:client": "nyc --report-dir ./coverage/client mocha --compilers js:babel-register,jsx:babel-register --recursive ./test/frontend",
     "test:client:file": "mocha --compilers js:babel-register,jsx:babel-register",
-    "test:server:file": "NODE_ENV=test nyc --report-dir ./coverage/server mocha --timeout 2500 test/api/bootstrap.test.js",
+    "test:server:file": "NODE_ENV=test mocha --timeout 2500 test/api/bootstrap.test.js",
     "test:server:watch": "watch 'yarn test:server' ./api ./test/api",
     "test:client:watch": "watch 'yarn test:client' ./frontend ./test/frontend",
     "lint": "eslint ./api/**/*.js ./config/**/*.js ./frontend/**/*.js ./migration/**/*.js ./script/**/*.js ./services/**/*.js",
@@ -62,7 +62,8 @@
     "export:sites": "node ./scripts/exportSitesAsCsv.js",
     "analyze-webpack": "webpack-bundle-analyzer -h 0.0.0.0 public/stats.json",
     "serve-coverage": "http-server ./coverage",
-    "update-local-config": "node ./scripts/update-local-config.js"
+    "update-local-config": "node ./scripts/update-local-config.js",
+    "create-dev-data": "node ./scripts/create-dev-data.js"
   },
   "main": "index.js",
   "repository": {
@@ -100,6 +101,7 @@
     "file-loader": "^0.11.1",
     "history": "^4.6.3",
     "http-server": "^0.10.0",
+    "inquirer": "^5.0.1",
     "json-schema-deref-sync": "^0.3.3",
     "jsonschema": "^1.1.1",
     "mocha": "2.3.4",

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -1,0 +1,111 @@
+const inquirer = require('inquirer');
+
+const cleanDatabase = require('../api/utils/cleanDatabase');
+const { ActionType, Build, BuildLog, Site, User, UserAction } = require('../api/models');
+
+const confirm = {
+  type: 'confirm',
+  default: false,
+  name: 'userAgrees',
+  message: 'This will DELETE all data in your development database. Are you sure you want to continue?',
+};
+
+function createSite(user, params) {
+  return Site.create(params)
+    .then(site => site.addUser(user.id).then(() => site));
+}
+
+inquirer.prompt(confirm).then(({ userAgrees }) => {
+  // exit if the user did not agree to the confirmation
+  if (!userAgrees) {
+    // eslint-disable-next-line no-console
+    console.log('Exiting without making any changes.');
+    process.exit();
+  }
+
+  // questions to collect necessary info to bootstrap the db
+  const questions = [{
+    type: 'input',
+    name: 'githubUsername',
+    message: 'What is your GitHub username?',
+  }];
+
+  inquirer.prompt(questions).then(({ githubUsername }) => {
+    const thisUserId = 1;
+    const thisSiteId = 1;
+
+    cleanDatabase()
+      .then(() => ActionType.createDefaultActionTypes())
+      // create a user for the given github username
+      .then(() => User.create({
+        id: thisUserId,
+        username: githubUsername,
+        email: `${githubUsername}@example.com`,
+      }))
+      // create a site for the user
+      .then(thisUser => createSite(thisUser, {
+        id: thisSiteId,
+        demoBranch: 'demo-branch',
+        demoDomain: 'https://demo.example.gov',
+        defaultBranch: 'master',
+        domain: 'https://example.gov',
+        engine: 'jekyll',
+        owner: thisUser.username,
+        repository: 'example-site',
+      }))
+      // create a build for the site
+      .then(site => Build.create({
+        branch: site.defaultBranch,
+        completedAt: new Date(),
+        source: 'fake-build',
+        state: 'success',
+        site: site.id,
+        user: thisUserId,
+        token: 'fake-token',
+      }))
+      // create a build log for the build
+      .then(build => BuildLog.create({
+        output: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                 Nullam fringilla, arcu ut ultricies auctor, elit quam
+                 consequat neque, eu blandit metus lorem non turpis.
+                 Ut luctus nec turpis pellentesque dignissim. Vivamus
+                 porttitor tellus turpis, a tempor velit tincidunt at.
+                 Aenean laoreet nulla ut porta semper.`.replace(/\s\s+/g, ' '),
+        source: 'fake-build-step',
+        build: build.id,
+      }))
+      // create another user
+      .then(() => User.create({
+        id: 2,
+        username: 'fake-user',
+        email: 'fake-user@example.com',
+        githubAccessToken: 'fake-access-token',
+        githubUserId: 123456,
+      }))
+      // add the other user to example site
+      .then(fakeUser =>
+        fakeUser.addSite(thisSiteId).then(() => fakeUser)
+      )
+      // create a useraction of removing the other user
+      .then(fakeUser =>
+        ActionType
+          .findOne({ where: { action: 'remove' } })
+          .then(removeAction =>
+            UserAction.create({
+              userId: thisUserId,
+              targetId: fakeUser.id,
+              targetType: 'user',
+              actionId: removeAction.id,
+              siteId: thisSiteId,
+            })
+        )
+    )
+    .then(() => {
+      /* eslint-disable no-console */
+      console.log('Done!');
+      console.log('You may have to log out and then back in to your local development instance of Federalist.');
+      /* eslint-enable no-console */
+      process.exit();
+    });
+  });
+});

--- a/test/api/bootstrap.test.js
+++ b/test/api/bootstrap.test.js
@@ -1,27 +1,12 @@
 Promise.props = require('promise-props');
 
 require('./support/aws-mocks');
-const sequelize = require('../../api/models').sequelize;
-
-const models = sequelize.models;
-const ActionType = models.ActionType;
-const types = ['add', 'remove', 'update'];
-const cleanDatabase = () => {
-  const promises = Object.keys(models).map((name) => {
-    const model = models[name];
-    // Using `force: true` removes soft deleted models and prevents uniqueness validation errors
-    const promise = model.destroy({ where: {}, force: true });
-
-    return promise;
-  });
-
-  return Promise.all(promises);
-};
-const addActionTypes = () => Promise.all(types.map(type => ActionType.create({ action: type })));
+const cleanDatabase = require('../../api/utils/cleanDatabase');
+const { ActionType } = require('../../api/models');
 
 before((done) => {
   cleanDatabase()
-  .then(() => addActionTypes())
-  .then(() => done())
-  .catch(err => done(err));
+    .then(() => ActionType.createDefaultActionTypes())
+    .then(() => done())
+    .catch(err => done(err));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,6 +121,10 @@ ansi-escapes@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
@@ -1513,6 +1517,10 @@ chalk@~0.4.0:
     ansi-styles "~1.0.0"
     has-color "~0.1.0"
     strip-ansi "~0.1.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 charenc@~0.0.1:
   version "0.0.2"
@@ -2957,6 +2965,14 @@ external-editor@^2.0.4:
     jschardet "^1.4.2"
     tmp "^0.0.31"
 
+external-editor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -3764,6 +3780,24 @@ inquirer@^3.0.6:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.0.1.tgz#5c0396c974fd98df4cab9afd26ed85874b563550"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -5294,7 +5328,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -6598,6 +6632,12 @@ rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
 
+rxjs@^5.5.2:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
+
 safe-buffer@5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -7169,6 +7209,10 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
 symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
@@ -7284,6 +7328,12 @@ tmp@^0.0.31:
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
   dependencies:
     os-tmpdir "~1.0.1"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Adds a command that can be invoked by `yarn create-dev-data` to setup some fake development data in a fresh database.

This is useful for folks just getting setup with federalist development so that they don't have a completely empty website upon first run.

ref #1350 