### PR TITLE
Don't render trigger build on unlinkable branches

### DIFF
--- a/frontend/components/branchViewLink.js
+++ b/frontend/components/branchViewLink.js
@@ -1,15 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import validBranchName from '../util/validators';
 import { SITE } from '../propTypes';
 
 const isDefaultBranch = (branchName, site) => branchName === site.defaultBranch;
-
 const isDemoBranch = (branchName, site) => branchName === site.demoBranch;
-
-// we only want to link branch names that are alphanumeric plus _, -, and .
-const isLinkable = s => validBranchName(s);
 
 const getUrlAndViewText = (branchName, site, previewHostname) => {
   if (isDefaultBranch(branchName, site)) {
@@ -24,10 +19,6 @@ const getUrlAndViewText = (branchName, site, previewHostname) => {
 };
 
 export const BranchViewLink = ({ branchName, site, previewHostname }) => {
-  if (!isLinkable(branchName)) {
-    return <span>Unlinkable branch name</span>;
-  }
-
   const { url, viewText } = getUrlAndViewText(branchName, site, previewHostname);
 
   return (<a href={url} target="_blank" rel="noopener noreferrer">{ viewText }</a>);

--- a/test/frontend/components/branchViewLink.test.js
+++ b/test/frontend/components/branchViewLink.test.js
@@ -24,13 +24,6 @@ describe('<BranchViewLink/>', () => {
     };
   });
 
-  it('does not link an unlinkable branch name', () => {
-    props.branchName = 'abc-#-def';
-    const wrapper = shallow(<BranchViewLink {...props} />);
-    expect(wrapper.find('span').length).to.equal(1);
-    expect(wrapper.find('span').text()).to.equal('Unlinkable branch name');
-  });
-
   it('renders a link to the default branch\'s site', () => {
     props.branchName = 'default-branch';
     const wrapper = shallow(<BranchViewLink {...props} />);

--- a/test/frontend/components/site/SiteGitHubBranches.test.jsx
+++ b/test/frontend/components/site/SiteGitHubBranches.test.jsx
@@ -83,6 +83,26 @@ describe('<SiteGitHubBranches />', () => {
     expect(firstTdHtml(rows.at(3))).to.have.string('branch-two');
   });
 
+  it('renders a fallback for unlinkable branch names', () => {
+    const props = {
+      site: {
+        owner: 'test-owner',
+        repository: 'test-repo',
+      },
+      githubBranches: {
+        isLoading: false,
+        data: [
+          { name: 'abc-#-def', commit: { sha: 'fd321' } },
+        ],
+      },
+    };
+
+    const wrapper = shallow(<SiteGitHubBranches {...props} />);
+    const data = wrapper.find('tbody tr td');
+
+    expect(data.at(1).find('span').text()).to.equal('Unlinkable branch name');
+  });
+
   it('should render a loading state if branches are loading', () => {
     const props = {
       githubBranches: {


### PR DESCRIPTION
* All actions are now replaced with 'unlinkable branch' if the branch
has an invalid name

💃 Screenshot 💃 
<img width="794" alt="screen shot 2018-01-25 at 5 03 46 pm" src="https://user-images.githubusercontent.com/1421848/35414858-c0ca53ee-01f1-11e8-8c2f-2a83bae86e19.png">
