### PR TITLE
Use AlertBanner component over hand-coded alerts in component

### DIFF
--- a/frontend/components/AddSite/AddRepoSiteForm.jsx
+++ b/frontend/components/AddSite/AddRepoSiteForm.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 import BranchField from '../Fields/BranchField';
 import GitHubRepoUrlField from '../Fields/GitHubRepoUrlField';
 import SelectSiteEngine from '../SelectSiteEngine';
+import AlertBanner from '../alertBanner';
 
 const propTypes = {
   showAddNewSiteFields: PropTypes.bool,
@@ -20,6 +21,18 @@ const propTypes = {
 
 const defaultProps = {
   showAddNewSiteFields: false,
+};
+
+const showNewSiteAlert = () => {
+  const message = (
+    <span>
+      Looks like this site is completely new to Federalist!
+      <br />
+      Please fill out these additional fields to complete the process.
+    </span>
+  );
+
+  return <AlertBanner status="info" heading="New Site" message={message} />;
 };
 
 export const AddRepoSiteForm = ({
@@ -52,16 +65,7 @@ export const AddRepoSiteForm = ({
     {
       showAddNewSiteFields && (
       <div className="add-repo-site-additional-fields">
-        <div className="usa-alert usa-alert-info" role="alert">
-          <div className="usa-alert-body">
-            <h3 className="usa-alert-heading">New Site</h3>
-            <p className="usa-alert-text">
-              Looks like this site is completely new to Federalist!
-              <br />
-              Please fill out these additional fields to complete the process.
-            </p>
-          </div>
-        </div>
+        {showNewSiteAlert()}
         <div className="form-group">
           <label htmlFor="engine">Static site engine</label>
           <Field

--- a/frontend/components/AddSite/AddRepoSiteForm.jsx
+++ b/frontend/components/AddSite/AddRepoSiteForm.jsx
@@ -32,7 +32,7 @@ const showNewSiteAlert = () => {
     </span>
   );
 
-  return <AlertBanner status="info" heading="New Site" message={message} />;
+  return <AlertBanner status="info" header="New Site" message={message} />;
 };
 
 export const AddRepoSiteForm = ({

--- a/frontend/components/alertBanner.js
+++ b/frontend/components/alertBanner.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-  message: PropTypes.string,
+  message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   status: PropTypes.string,
   header: PropTypes.string,
   children: PropTypes.node,

--- a/frontend/components/alertBanner.js
+++ b/frontend/components/alertBanner.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-  message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  message: PropTypes.node,
   status: PropTypes.string,
   header: PropTypes.string,
   children: PropTypes.node,

--- a/frontend/components/alertBanner.js
+++ b/frontend/components/alertBanner.js
@@ -6,12 +6,26 @@ const propTypes = {
   status: PropTypes.string,
   header: PropTypes.string,
   children: PropTypes.node,
+  /**
+   * role="alert" is a flag which will tell a user's assistive device to notify the user
+   * that there is important information to be communicated. The majority of our alerts are
+   * used to inform the user of form errors or missing information.
+   *
+   * However, there are some places where the AlertBanner component is used to display information
+   * that is not critical to the user (such as the site delete action under AdvancedSettings).
+   * For these cases, this flag is added to opt out of adding `role="alert"` where desired.
+   *
+   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
+   */
+
+  alertRole: PropTypes.bool,
 };
 
 const defaultProps = {
   message: null,
   status: 'info',
   children: null,
+  alertRole: true,
 };
 
 const renderHeader = (text) => {
@@ -26,7 +40,15 @@ const renderHeader = (text) => {
   );
 };
 
-const AlertBanner = ({ children, header, message, status }) => {
+const addRole = (shouldAddRole) => {
+  if (shouldAddRole) {
+    return { role: 'alert' };
+  }
+
+  return {};
+};
+
+const AlertBanner = ({ children, header, message, status, alertRole }) => {
   if (!message) {
     return null;
   }
@@ -34,7 +56,7 @@ const AlertBanner = ({ children, header, message, status }) => {
   return (
     <div
       className={`usa-alert usa-alert-${status}`}
-      role="alert"
+      {...addRole(alertRole)}
     >
       <div className="usa-alert-body">
         { renderHeader(header) }

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 
 import SelectSiteEngine from '../../SelectSiteEngine';
+import AlertBanner from '../../alertBanner';
 
 const propTypes = {
   onDelete: PropTypes.func.isRequired,
@@ -116,19 +117,15 @@ export const AdvancedSiteSettings = ({
       Save advanced settings
     </button>
 
-
-    <div className="usa-alert usa-alert-warning">
-      <div className="usa-alert-body">
-        <h3 className="usa-alert-heading">Danger zone</h3>
-        <p className="usa-alert-text">Delete this site from Federalist?</p>
-        <button
-          className="usa-button usa-button-red"
-          onClick={onDelete}
-        >
-          Delete
-        </button>
-      </div>
-    </div>
+    <AlertBanner
+      status="warning"
+      heading="Danger zone"
+      message="Delete this site from Federalist?"
+    >
+      <button className="usa-button usa-button-red" onClick={onDelete}>
+        Delete
+      </button>
+    </AlertBanner>
   </form>
 );
 

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -121,6 +121,7 @@ export const AdvancedSiteSettings = ({
       status="warning"
       header="Danger zone"
       message="Delete this site from Federalist?"
+      alertRole={false}
     >
       <button className="usa-button usa-button-red" onClick={onDelete}>
         Delete

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -119,7 +119,7 @@ export const AdvancedSiteSettings = ({
 
     <AlertBanner
       status="warning"
-      heading="Danger zone"
+      header="Danger zone"
       message="Delete this site from Federalist?"
     >
       <button className="usa-button usa-button-red" onClick={onDelete}>

--- a/test/frontend/components/addSite/AddRepoSiteForm.test.jsx
+++ b/test/frontend/components/addSite/AddRepoSiteForm.test.jsx
@@ -45,8 +45,14 @@ describe('<AddRepoSiteForm />', () => {
 
     props.showAddNewSiteFields = true;
     wrapper = shallow(<AddRepoSiteForm {...props} />);
+
+    const alertBanner = wrapper.find('AlertBanner');
+
     expect(wrapper.find('Field[name="engine"]')).to.have.length(1);
     expect(wrapper.find('BranchField').props().required).to.be.true;
+    expect(alertBanner).to.have.length(1);
+    expect(alertBanner.prop('header')).to.be.defined;
+    expect(alertBanner.prop('message')).to.be.defined;
   });
 
   it('makes GitHubRepoUrlField readOnly when showAddNewSiteFields is true', () => {

--- a/test/frontend/components/alertBanner.test.js
+++ b/test/frontend/components/alertBanner.test.js
@@ -12,16 +12,26 @@ describe('<AlertBanner/>', () => {
     expect(component.html()).to.equal(null);
   });
 
-  statusTypes.forEach(status => {
+  statusTypes.forEach((status) => {
     it(`outputs an ${status} banner when the status is ${status}`, () => {
-      const component = shallow(<AlertBanner message='hello' status={status}/>);
+      const component = shallow(<AlertBanner message="hello" status={status} />);
 
       expect(component.find(`.usa-alert-${status}`).length).not.to.equal(0);
     });
   });
 
   it('falls back to an info banner when status is not provided', () => {
-    const component = shallow(<AlertBanner message='hello'/>);
-    expect(component.find(`.usa-alert-info`).length).not.to.equal(0);
+    const component = shallow(<AlertBanner message="hello" />);
+    expect(component.find('.usa-alert-info').length).not.to.equal(0);
+  });
+
+  it('can render a component as a message', () => {
+    const componentText = 'Hey there';
+    const child = <h1>{componentText}</h1>;
+    const wrapper = shallow(<AlertBanner message={child} />);
+    const childInstance = wrapper.find('h1');
+
+    expect(childInstance).to.have.length(1);
+    expect(childInstance.text()).to.equal(componentText);
   });
 });

--- a/test/frontend/components/alertBanner.test.js
+++ b/test/frontend/components/alertBanner.test.js
@@ -34,4 +34,12 @@ describe('<AlertBanner/>', () => {
     expect(childInstance).to.have.length(1);
     expect(childInstance.text()).to.equal(componentText);
   });
+
+  it('can opt out of displaying `role="alert"`', () => {
+    const wrapperWithRole = shallow(<AlertBanner message="wow" />);
+    const wrapperWithoutRole = shallow(<AlertBanner message="hi" alertRole={false} />);
+
+    expect(wrapperWithRole.find('div').at(0).prop('role')).to.equal('alert');
+    expect(wrapperWithoutRole.find('div').at(0).prop('role')).to.equal(undefined);
+  });
 });

--- a/test/frontend/components/site/SiteSettings/AdvancedSiteSettings.test.jsx
+++ b/test/frontend/components/site/SiteSettings/AdvancedSiteSettings.test.jsx
@@ -26,13 +26,17 @@ describe('<AdvancedSiteSettings/>', () => {
   it('should render', () => {
     const props = makeProps();
     const wrapper = shallow(<AdvancedSiteSettings {...props} />);
-    expect(wrapper.exists()).to.be.true;
+    const alertBanner = wrapper.find('AlertBanner');
 
+    expect(wrapper.exists()).to.be.true;
     expect(wrapper.find('Field')).to.have.length(4);
     expect(wrapper.find('Field[name="engine"]').exists()).to.be.true;
     expect(wrapper.find('Field[name="config"]').exists()).to.be.true;
     expect(wrapper.find('Field[name="demoConfig"]').exists()).to.be.true;
     expect(wrapper.find('Field[name="previewConfig"]').exists()).to.be.true;
+    expect(alertBanner).to.have.length(1);
+    expect(alertBanner.prop('header')).to.be.defined;
+    expect(alertBanner.prop('message')).to.be.defined;
   });
 
   it('should have its buttons disabled when pristine', () => {

--- a/test/frontend/components/site/SiteSettings/AdvancedSiteSettings.test.jsx
+++ b/test/frontend/components/site/SiteSettings/AdvancedSiteSettings.test.jsx
@@ -37,6 +37,7 @@ describe('<AdvancedSiteSettings/>', () => {
     expect(alertBanner).to.have.length(1);
     expect(alertBanner.prop('header')).to.be.defined;
     expect(alertBanner.prop('message')).to.be.defined;
+    expect(alertBanner.prop('alertRole')).to.be.false;
   });
 
   it('should have its buttons disabled when pristine', () => {


### PR DESCRIPTION
There were a few remaining components that manually built alert banners out of divs. This PR replaces those with `AlertBanner` components and updates the appropriate specs.