### PR TITLE
Allow empty string to be supplied to branch fields

### DIFF
--- a/api/models/site.js
+++ b/api/models/site.js
@@ -96,6 +96,12 @@ function viewLinkForBranch(branch) {
   return this.branchPreviewUrl(branch);
 }
 
+function isEmptyOrBranch(value) {
+  if (value && value.length && !branchRegex.test(value)) {
+    throw new Error('Invalid branch name — branches can only contain alphanumeric characters, underscores, and hyphens.');
+  }
+}
+
 function isEmptyOrUrl(value) {
   const validUrlOptions = {
     require_protocol: true,
@@ -112,7 +118,7 @@ module.exports = (sequelize, DataTypes) => {
     demoBranch: {
       type: DataTypes.STRING,
       validate: {
-        is: branchRegex,
+        isEmptyOrBranch,
       },
     },
     demoDomain: {
@@ -128,7 +134,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       defaultValue: 'master',
       validate: {
-        is: branchRegex,
+        isEmptyOrBranch,
       },
     },
     domain: {

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -131,7 +131,7 @@ describe('Site model', () => {
       defaultBranch: 'very/bad',
     }).catch((err) => {
       expect(err.status).to.equal(403);
-      expect(err.message).to.equal('defaultBranch: Validation is failed');
+      expect(err.message).to.equal('defaultBranch: Invalid branch name — branches can only contain alphanumeric characters, underscores, and hyphens.');
       done();
     });
   });
@@ -142,7 +142,7 @@ describe('Site model', () => {
     })
     .catch((err) => {
       expect(err.status).to.equal(403);
-      expect(err.message).to.equal('demoBranch: Validation is failed');
+      expect(err.message).to.equal('demoBranch: Invalid branch name — branches can only contain alphanumeric characters, underscores, and hyphens.');
       done();
     });
   });


### PR DESCRIPTION
Now you can correctly save your site settings!

**GIF:**:
![site-settings-fix](https://user-images.githubusercontent.com/1421848/35939670-d73e2960-0c1a-11e8-829e-b55caac629e6.gif)

