### PR TITLE
Lowercase org name before organization check

### DIFF
--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -131,7 +131,7 @@ module.exports = {
   checkOrganizations: (user, orgName) =>
     githubClient(user.githubAccessToken)
     .then(github => getOrganizations(github))
-    .then(orgs => orgs.some(org => org.login === orgName)),
+    .then(orgs => orgs.some(org => org.login.toLowerCase() === orgName)),
 
   createRepo: (user, owner, repository) =>
     githubClient(user.githubAccessToken)


### PR DESCRIPTION
The org name that we get from the GitHub API can be uppercase or
lowercase, but we lowercase the "owner" param when we consume it in the
SiteCreator. In order to properly compare the org name with the repo
owner name, we need to down case the org name we receive from GitHub.