### PR TITLE
Removes /build/:id route, controller method, and tests

### DIFF
--- a/api/controllers/build.js
+++ b/api/controllers/build.js
@@ -75,31 +75,6 @@ module.exports = {
     .catch(res.error);
   },
 
-  findOne: (req, res) => {
-    let build;
-
-    Promise.resolve(Number(req.params.id))
-    .then((id) => {
-      if (isNaN(id)) {
-        const error = new Error();
-        error.status = 404;
-        throw error;
-      }
-      return Build.findById(id);
-    })
-    .then((model) => {
-      if (model) {
-        build = model;
-      } else {
-        res.notFound();
-      }
-      return siteAuthorizer.findOne(req.user, { id: build.site });
-    })
-    .then(() => buildSerializer.serialize(build))
-    .then(buildJSON => res.json(buildJSON))
-    .catch(res.error);
-  },
-
   status: (req, res) => {
     const message = decodeb64(req.body.message);
 

--- a/api/routers/build.js
+++ b/api/routers/build.js
@@ -6,7 +6,6 @@ const csrfProtection = require('../policies/csrfProtection');
 
 router.get('/site/:site_id/build', sessionAuth, BuildController.find);
 router.post('/build', sessionAuth, csrfProtection, BuildController.create);
-router.get('/build/:id', sessionAuth, BuildController.findOne);
 router.post('/build/:id/status/:token', buildCallback, BuildController.status);
 
 module.exports = router;

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -323,67 +323,6 @@ describe('Build API', () => {
     });
   });
 
-  describe('GET /v0/build/:id', () => {
-    it('should require authentication', (done) => {
-      factory.build().then(build =>
-        request(app)
-          .get(`/v0/build/${build.id}`)
-          .expect(403)
-      )
-      .then((response) => {
-        validateAgainstJSONSchema('GET', '/build/{id}', 403, response.body);
-        done();
-      })
-      .catch(done);
-    });
-
-    it('should return a JSON representation of the build', (done) => {
-      const user = factory.user();
-      const site = factory.site({ users: Promise.all([user]) });
-      const buildPromise = factory.build({ site });
-      let build;
-
-      Promise.props({
-        cookie: authenticatedSession(user),
-        site,
-        build: buildPromise,
-      })
-      .then((values) => {
-        build = values.build;
-        return request(app)
-          .get(`/v0/build/${build.id}`)
-          .set('Cookie', values.cookie)
-          .expect(200);
-      })
-      .then((response) => {
-        buildResponseExpectations(response.body, build);
-        validateAgainstJSONSchema('GET', '/build/{id}', 200, response.body);
-        done();
-      })
-      .catch(done);
-    });
-
-    it('should respond with a 403 if the current user is not associated with the build', (done) => {
-      let build;
-
-      factory.build().then((model) => {
-        build = model;
-        return authenticatedSession(factory.user());
-      })
-      .then(cookie =>
-        request(app)
-          .get(`/v0/build/${build.id}`)
-          .set('Cookie', cookie)
-          .expect(403)
-      )
-      .then((response) => {
-        validateAgainstJSONSchema('GET', '/build/{id}', 403, response.body);
-        done();
-      })
-      .catch(done);
-    });
-  });
-
   describe('GET /v0/site/:site_id/build', () => {
     it('should require authentication', (done) => {
       factory.site()


### PR DESCRIPTION
Removes functionality of getting a single build by id.

That route is not in use, and due to some authorizer simplifications, probably wouldn't work as expected if it ever did need to get used. Ref https://github.com/18F/federalist/issues/1467.

No need to keep it around if we don't need it.