### PR TITLE
add YAML validation for site configs

### DIFF
--- a/api/models/site.js
+++ b/api/models/site.js
@@ -1,7 +1,7 @@
 const validator = require('validator');
 const config = require('../../config');
 
-const { branchRegex } = require('../utils/validators');
+const { branchRegex, isValidYaml } = require('../utils/validators');
 
 const afterValidate = (site) => {
   if (site.defaultBranch === site.demoBranch) {
@@ -129,6 +129,9 @@ module.exports = (sequelize, DataTypes) => {
     },
     config: {
       type: DataTypes.STRING,
+      validate: {
+        isValidYaml,
+      },
     },
     defaultBranch: {
       type: DataTypes.STRING,
@@ -154,9 +157,15 @@ module.exports = (sequelize, DataTypes) => {
     },
     previewConfig: {
       type: DataTypes.STRING,
+      validate: {
+        isValidYaml,
+      },
     },
     demoConfig: {
       type: DataTypes.STRING,
+      validate: {
+        isValidYaml,
+      },
     },
     publishedAt: {
       type: DataTypes.DATE,

--- a/api/utils/validators.js
+++ b/api/utils/validators.js
@@ -1,9 +1,25 @@
+const yaml = require('js-yaml');
+
 const branchRegex = /^[^-][a-zA-Z0-9._-]+$/;
 const githubUsernameRegex = /^[^-][a-zA-Z-]+$/;
 const shaRegex = /^[a-f0-9]{40}$/;
+
+
+function isValidYaml(yamlString) {
+  try {
+    yaml.safeLoad(yamlString);
+  } catch (e) {
+    // for Sequelize validators, we need to throw an error
+    // on invalid values
+    throw new Error('input is not valid YAML');
+  }
+  // if no error, then the string was valid
+  return true;
+}
 
 module.exports = {
   branchRegex,
   shaRegex,
   githubUsernameRegex,
+  isValidYaml,
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express-session": "^1.5.0",
     "express-winston": "^2.3.0",
     "github": "^0.2.4",
+    "js-yaml": "^3.10.0",
     "json-to-csv": "^1.0.0",
     "method-override": "^2.3.10",
     "moment": "^2.19.3",

--- a/test/api/unit/utils/validators.test.js
+++ b/test/api/unit/utils/validators.test.js
@@ -1,0 +1,56 @@
+const expect = require('chai').expect;
+
+const validators = require('../../../../api/utils/validators');
+
+function multiExpect(testFn, testCases, expectedVerb = 'equal') {
+  // helper to run the same expectation on multiple cases of
+  // inputs and expected results
+  testCases.forEach((tc) => {
+    const failureMsg = `Args "${tc.args}" did not result in "${tc.result}"`;
+
+    if (expectedVerb === 'throw') {
+      // need to wrap in an anonymous function for trapping thrown errors
+      expect(() => testFn(...tc.args), failureMsg).to.throw(tc.result);
+    } else {
+      // otherwise, call directly
+      expect(testFn(...tc.args), failureMsg).to[expectedVerb](tc.result);
+    }
+  });
+}
+
+
+describe('validators', () => {
+  describe('.isValidYaml', () => {
+    it('properly validates', () => {
+      const goodYaml = [
+        '---',
+        'hi: james',
+        'you_are:',
+        '  - cool',
+        '  - awesome',
+      ].join('\n');
+
+      const badYaml = [
+        '---',
+        'this_is_not_valid:',
+        '-:boop',
+      ].join('\n');
+
+      const goodTestCases = [
+        { args: [null], result: true },
+        { args: [''], result: true },
+        { args: ['one-line'], result: true },
+        { args: [goodYaml], result: true },
+      ];
+
+      multiExpect(validators.isValidYaml, goodTestCases);
+
+      const badTestCases = [
+        { args: [': funky-line: boop'], result: 'input is not valid YAML' },
+        { args: [badYaml], result: 'input is not valid YAML' },
+      ];
+
+      multiExpect(validators.isValidYaml, badTestCases, 'throw');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4167,6 +4167,13 @@ js-yaml@3.7.x, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
+js-yaml@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.8.4:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"


### PR DESCRIPTION
Adds server-side validation to make sure submitted `config`, `demoConfig`, and `previewConfig` values are valid YAML.

Client-side would be nice, too, but I figured including `js-yaml` in the client-side bundle was a little too much just for this one thing.

ref #1330 