### PR TITLE
Removes unused error prop

### DIFF
--- a/frontend/components/AddSite/TemplateSiteList/index.js
+++ b/frontend/components/AddSite/TemplateSiteList/index.js
@@ -10,30 +10,7 @@ const propTypes = {
   defaultOwner: PropTypes.string.isRequired,
 };
 
-const MAX_CELLS_PER_ROW = 4;
-
-/**
- * Create a two-dimensional array of values that represent one or more rows
- * of values, with `perRow` values per row.
- *
- * @param {array<*>} values
- * @param {integer} perRow
- * @return {array<array<*>>}
- */
-const createRowsOf = (values, perRow) => {
-  let row = [];
-  const rows = [row];
-  values.forEach((val, index) => {
-    if (index === perRow) {
-      rows.push(row = []);
-    }
-    row.push(val);
-  });
-  return rows;
-};
-
 export class TemplateList extends React.Component {
-
   constructor(props) {
     super(props);
 
@@ -53,35 +30,24 @@ export class TemplateList extends React.Component {
   render() {
     const { templates } = this.props;
 
-    const templateKeys = Object.keys(templates);
-    // if there are fewer templates than cells per row,
-    // fill the space with them
-    const cellsPerRow = Math.min(templateKeys.length, MAX_CELLS_PER_ROW);
-    // generate a two-dimensional array of template keys
-    const templateRows = createRowsOf(templateKeys, cellsPerRow);
+    const templateGrid = Object.keys(templates).map((templateName, index) => {
+      const template = templates[templateName];
 
-    let index = 0;
-
-    const templateGrid = templateRows.map(row => (
-      <div className="federalist-template-list">
-        {row.map((templateName) => {
-          const template = templates[templateName];
-          return (
-            <TemplateSite
-              key={templateName}
-              name={templateName}
-              index={index++} // eslint-disable-line no-plusplus
-              thumb={template.thumb}
-              active={this.state.activeChildId}
-              handleChooseActive={this.handleChooseActive}
-              handleSubmit={this.props.handleSubmitTemplate}
-              defaultOwner={this.props.defaultOwner}
-              {...template}
-            />
-          );
-        })}
-      </div>
-    ));
+      return (
+        <div className="federalist-template-list" key={templateName}>
+          <TemplateSite
+            name={template.title}
+            index={index}
+            thumb={template.thumb}
+            active={this.state.activeChildId}
+            handleChooseActive={this.handleChooseActive}
+            handleSubmit={this.props.handleSubmitTemplate}
+            defaultOwner={this.props.defaultOwner}
+            {...template}
+          />
+        </div>
+      );
+    });
 
     return (
       <div>

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -6,25 +6,21 @@ import { connect } from 'react-redux';
 import { USER } from '../../propTypes';
 import TemplateSiteList from './TemplateSiteList';
 import AddRepoSiteForm from './AddRepoSiteForm';
-import AlertBanner from '../alertBanner';
 import { availableEngines } from '../SelectSiteEngine';
 import siteActions from '../../actions/siteActions';
 import addNewSiteFieldsActions from '../../actions/addNewSiteFieldsActions';
 
 const propTypes = {
-  error: PropTypes.string, // TODO: confirm that this is actually necessary
   showAddNewSiteFields: PropTypes.bool,
   user: PropTypes.shape(USER),
 };
 
 const defaultProps = {
-  error: null,
   showAddNewSiteFields: false,
   user: null,
 };
 
-const mapStateToProps = ({ showAddNewSiteFields, user, error }) => ({
-  error,
+const mapStateToProps = ({ showAddNewSiteFields, user }) => ({
   showAddNewSiteFields,
   user,
 });
@@ -82,7 +78,6 @@ export class AddSite extends React.Component {
 
     return (
       <div>
-        <AlertBanner message={this.props.error} />
         <div className="usa-grid">
           <div className="page-header usa-grid-full">
             <div className="header-title">

--- a/test/frontend/components/addSite/addSite.test.js
+++ b/test/frontend/components/addSite/addSite.test.js
@@ -25,7 +25,6 @@ const user = {
 
 const propsWithoutError = {
   user,
-  error: '',
   showAddNewSiteFields: false,
 };
 
@@ -51,7 +50,6 @@ describe('<AddSite/>', () => {
 
   it('renders its children', () => {
     expect(wrapper.find(TemplateSiteList)).to.have.length(1);
-    expect(wrapper.find(AlertBanner)).to.have.length(1);
     expect(wrapper.find('ReduxForm')).to.have.length(1);
   });
 
@@ -66,11 +64,9 @@ describe('<AddSite/>', () => {
   });
 
   it('delivers the correct props to its children', () => {
-    const bannerProps = wrapper.find(AlertBanner).props();
     const templateListProps = wrapper.find(TemplateSiteList).props();
     const formProps = wrapper.find('ReduxForm').props();
 
-    expect(bannerProps).to.deep.equal({ message: propsWithoutError.error });
     expect(templateListProps).to.deep.equal({
       handleSubmitTemplate: wrapper.instance().onSubmitTemplate,
       defaultOwner: propsWithoutError.user.data.username,


### PR DESCRIPTION
* Error not being provided by a reducer, so it shouldn't be ncessary.
Additionally, we don't surface errors on the AddSite page

* Also fixes key prop warning in TemplateList component, and removes
uneeded grid code