### PR TITLE
Fix duplicate PropTypes.shape wrapping in USER_ACTION propType definition

### DIFF
--- a/frontend/components/site/UserActionsTable.jsx
+++ b/frontend/components/site/UserActionsTable.jsx
@@ -5,10 +5,6 @@ import { USER_ACTION } from '../../propTypes';
 import { timestampUTC } from '../../util/datetime';
 import userActions from '../../actions/userActions';
 
-const propTypes = {
-  site: PropTypes.number.isRequired,
-  userActions: PropTypes.arrayOf(USER_ACTION),
-};
 
 class UserActionsTable extends React.Component {
   componentDidMount() {
@@ -66,7 +62,11 @@ class UserActionsTable extends React.Component {
   }
 }
 
-UserActionsTable.propTypes = propTypes;
+UserActionsTable.propTypes = {
+  site: PropTypes.number.isRequired,
+  userActions: PropTypes.arrayOf(USER_ACTION),
+};
+
 UserActionsTable.defaultProps = {
   userActions: [],
 };

--- a/frontend/propTypes.js
+++ b/frontend/propTypes.js
@@ -49,7 +49,7 @@ export const BUILD_LOG = PropTypes.shape({
 export const USER_ACTION = PropTypes.shape({
   targetType: PropTypes.string,
   createdAt: PropTypes.string,
-  actionTarget: PropTypes.shape(USER),
+  actionTarget: USER,
   actionType: PropTypes.shape({ action: PropTypes.string }),
-  initiator: PropTypes.shape(USER),
+  initiator: USER,
 });


### PR DESCRIPTION
ref #1482

The bizarre warning was actually caused by the `actionTarget` and `initiator` props
being essentially doubled-wrapped in `PropTypes.shape`, since the underlying `USER`
propType was already a `PropType.shape`.