### PR TITLE
Tweaks to github and view-site icons

### DIFF
--- a/frontend/components/site/SiteUsers.jsx
+++ b/frontend/components/site/SiteUsers.jsx
@@ -56,9 +56,10 @@ const SiteUsers = ({ site, user }) => {
                   rel="noopener noreferrer"
                   title={`Visit GitHub profile for ${rowUser.username}`}
                 >
-                  {rowUser.username}<IconGitHub />
-                </a>
+                {rowUser.username}
                 {rowUser.username.toLowerCase() === user.username.toLowerCase() ? ' (you)' : ''}
+                <IconGitHub />
+                </a>
               </td>
               <td>
                 {

--- a/frontend/sass/_icons.scss
+++ b/frontend/sass/_icons.scss
@@ -1,31 +1,29 @@
 
 .repo-link {
   svg {
-    height: 18px;
-    width: 18px;
-    margin-left: 0.3rem;
-    vertical-align: middle;
-    
-    stroke-width: 0;
     fill: $link-color;
+    margin-left: 0.4rem;
+    stroke-width: 0;
+    vertical-align: middle;
+    width: 14px;
   }
 
   &:hover svg {
     fill: $link-color-active;
   }
+
 }
 
 .view-site-link {
   svg {
-    height: 1em;
-    width: 1em;
-    margin-left: 0.3rem;
-    vertical-align: middle;
-    padding-bottom: 3px;
     fill: $link-color;
+    margin-left: 0.5rem;
+    vertical-align: middle;
+    width: 13px;
   }
 
   &:hover svg {
     fill: $link-color-active;
   }
+
 }

--- a/frontend/sass/_icons.scss
+++ b/frontend/sass/_icons.scss
@@ -17,7 +17,7 @@
 .view-site-link {
   svg {
     fill: $link-color;
-    margin-left: 0.5rem;
+    margin-left: 0.4rem;
     vertical-align: middle;
     width: 13px;
   }


### PR DESCRIPTION
- Shrunk github and “view site” icons, since they overpowered when
shown multiple times on a page
- Slightly adjusted positioning
- Moved “(you)” into the collaborator link