### PR TITLE
Fix adding a site from a template

### DIFF
--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -176,6 +176,7 @@ function createSiteFromSource({ siteParams, user }) {
 
 function createSite({ user, siteParams }) {
   const templateName = siteParams.template;
+
   const template = templateName && TemplateResolver.getTemplate(templateName);
   const newSiteParams = paramsForNewSite(siteParams);
 

--- a/frontend/components/AddSite/TemplateSiteList/index.js
+++ b/frontend/components/AddSite/TemplateSiteList/index.js
@@ -30,13 +30,13 @@ export class TemplateList extends React.Component {
   render() {
     const { templates } = this.props;
 
-    const templateGrid = Object.keys(templates).map((templateName, index) => {
-      const template = templates[templateName];
+    const templateGrid = Object.keys(templates).map((templateKey, index) => {
+      const template = templates[templateKey];
 
       return (
-        <div className="federalist-template-list" key={templateName}>
+        <div className="federalist-template-list" key={templateKey}>
           <TemplateSite
-            name={template.title}
+            templateKey={templateKey}
             index={index}
             thumb={template.thumb}
             active={this.state.activeChildId}

--- a/frontend/components/AddSite/TemplateSiteList/templateSite.js
+++ b/frontend/components/AddSite/TemplateSiteList/templateSite.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { getSafeRepoName } from '../../../util';
 
 const propTypes = {
-  name: PropTypes.string.isRequired,
+  templateKey: PropTypes.string.isRequired,
   defaultOwner: PropTypes.string.isRequired,
   example: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
@@ -23,7 +23,7 @@ class TemplateSite extends React.Component {
     this.state = {
       owner: props.defaultOwner,
       repository: '',
-      template: props.name,
+      template: props.templateKey,
     };
 
     this.handleChooseActive = this.handleChooseActive.bind(this);

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -12,7 +12,7 @@ import addNewSiteFieldsActions from '../../actions/addNewSiteFieldsActions';
 
 const propTypes = {
   showAddNewSiteFields: PropTypes.bool,
-  user: PropTypes.shape(USER),
+  user: USER,
 };
 
 const defaultProps = {


### PR DESCRIPTION
Ref #1654.

In the clean-up from #1633, an incorrect value (the `title` of a template) was passed into the template `name` field.
This was at least partially because `name` was not really an appropriate name for the prop. To help prevent a similar issue in the future, the `name` prop has also been renamed to `templateKey`. The correct value is now passed into the renamed prop.