### PR TITLE
Adds scroll after http error on site settings page

### DIFF
--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -1,3 +1,5 @@
+/* global window:true */
+
 import federalist from '../util/federalistApi';
 import alertActions from './alertActions';
 
@@ -15,7 +17,10 @@ import {
 } from './dispatchActions';
 import userActions from './userActions';
 
-const alertError = error => alertActions.httpError(error.message);
+const alertError = (error) => {
+  window.scrollTo(0, 0);
+  alertActions.httpError(error.message);
+};
 
 export default {
   fetchSites() {

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -96,6 +96,8 @@ export default {
     return this.fetch(`site/${site.id}`, {
       method: 'PUT',
       data,
+    }, {
+      handleHttpError: false,
     });
   },
 

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -28,6 +28,7 @@ describe('siteActions', () => {
   let dispatchUserAddedToSiteAction;
   let dispatchUserRemovedFromSiteAction;
   let fetchUser;
+  const scrollTo = stub();
 
   const siteId = 'kuaw8fsru8hwugfw';
   const site = {
@@ -42,7 +43,7 @@ describe('siteActions', () => {
   const rejectedWithErrorPromise = Promise.reject(error);
 
   before(() => {
-    global.window = { scrollTo: stub() };
+    global.window = { scrollTo };
   });
 
   after(() => {
@@ -211,6 +212,8 @@ describe('siteActions', () => {
       const actual = fixture.updateSite(siteToUpdate, data);
 
       return actual.then(() => {
+        expect(scrollTo.called).to.be.true;
+        expect(scrollTo.getCall(0).args).to.deep.equal([0, 0]);
         expect(dispatchSiteUpdatedAction.called).to.be.false;
         validateResultDispatchesHttpAlertError(actual, errorMessage);
       });

--- a/test/frontend/actions/siteActionsTest.js
+++ b/test/frontend/actions/siteActionsTest.js
@@ -41,6 +41,14 @@ describe('siteActions', () => {
   };
   const rejectedWithErrorPromise = Promise.reject(error);
 
+  before(() => {
+    global.window = { scrollTo: stub() };
+  });
+
+  after(() => {
+    global.window = undefined;
+  });
+
   beforeEach(() => {
     httpErrorAlertAction = spy();
     fetchSites = stub();


### PR DESCRIPTION
Site settings page will scroll to the top on error, so the user is aware of it.

**GIF**:
![scroll-to-error](https://user-images.githubusercontent.com/1421848/36871570-aad9c944-1d70-11e8-815e-fddd06dc9e91.gif)



I've only added it to this page for now, adding it to all error events means ripping out the error handling logic from the `federalistAPI`, which probably shouldn't be issuing alerts.

Unless people think it should! Open to moving the scroll and handling all errors directly in the api file if that seems cleaner.