### PR TITLE
Specs for redirect middleware

### DIFF
--- a/test/api/requests/app.test.js
+++ b/test/api/requests/app.test.js
@@ -1,0 +1,26 @@
+const request = require('supertest');
+const app = require('../../../app');
+const { expect } = require('chai');
+
+const expectRedirect = (hostname, expectedUrl) =>
+  new Promise(resolve =>
+    request(app)
+    .get('/')
+    .set('host', hostname)
+    .expect(301)
+    .then((res) => {
+      expect(res.headers.location).to.equal(expectedUrl);
+
+      resolve();
+    })
+  );
+
+describe('.fr.cloud redirects', () => {
+  it('redirects from old .fr.cloud domain to .18f', (done) => {
+    Promise.all([
+      expectRedirect('federalist-staging.fr.cloud.gov', 'https://federalist-staging.18f.gov'),
+      expectRedirect('federalist.fr.cloud.gov', 'https://federalist.18f.gov'),
+    ])
+    .then(() => done());
+  });
+});


### PR DESCRIPTION
Backfilling test for the `.fr.cloud` redirect functionality. 