### PR TITLE
Add a highlight to the active link in the side nav

### DIFF
--- a/frontend/components/site/SideNav.jsx
+++ b/frontend/components/site/SideNav.jsx
@@ -13,7 +13,10 @@ const SideNav = ({ siteId }) => (
           const IconComponent = icons[conf.icon];
           return (
             <li key={conf.route}>
-              <Link to={`/sites/${siteId}/${conf.route}`}>
+              <Link
+                to={`/sites/${siteId}/${conf.route}`}
+                activeClassName="side-nav-active-item"
+              >
                 <IconComponent /> {conf.display}
               </Link>
             </li>

--- a/frontend/sass/_side-nav.scss
+++ b/frontend/sass/_side-nav.scss
@@ -13,7 +13,20 @@
     &:hover svg g {
       fill: $link-color-active;
     }
+
+    &.side-nav-active-item {
+      background-color: #2d476a;
+      color: white !important;
+      padding: 5px !important;
+
+      svg {
+        g {
+          fill: white;
+        }
+      }
+    }
   }
+
 }
 
 .usa-width-one-sixth {


### PR DESCRIPTION
* The sidenav width is super tiny and breaking the line on the GitHub
Branches link.

**HANDY GIF**:
![highlight-link-gif](https://user-images.githubusercontent.com/1421848/37426256-3e24e00a-279c-11e8-9889-1ea49b110430.gif)


Let me know your thoughts, this was like 5 minutes of work so its not a big deal if its not what we want to go with