### PR TITLE
Check that site user has valid token in GitHubBuildStatusReporter

### DIFF
--- a/api/services/GithubBuildStatusReporter.js
+++ b/api/services/GithubBuildStatusReporter.js
@@ -10,7 +10,7 @@ const { Build, Site, User } = require('../models');
 // finds a user with a valid access token
 const checkAccessTokenPermissions = (users, site) => {
   let count = 0;
-  
+
   const getNextToken = (user) => {
     if (!user) {
       return Promise.resolve(null);
@@ -21,15 +21,15 @@ const checkAccessTokenPermissions = (users, site) => {
       if (permissions.admin) {
         return Promise.resolve(user.githubAccessToken);
       }
-      
+
       count += 1;
 
       return getNextToken(users[count]);
     });
-  }
+  };
 
   return getNextToken(users[count]);
-}
+};
 
 const loadSiteUserAccessToken = site =>
   site.getUsers({

--- a/test/api/requests/webhook.test.js
+++ b/test/api/requests/webhook.test.js
@@ -30,13 +30,18 @@ describe('Webhook API', () => {
     },
   });
 
-  describe.only('POST /webhook/github', () => {
+  describe('POST /webhook/github', () => {
     beforeEach(() => {
       nock.cleanAll();
       githubAPINocks.status();
+      githubAPINocks.repo({
+        response: [201, {
+          permissions: { admin: false },
+        }],
+      });
     });
 
-    it.only('should create a new site build for the sender', (done) => {
+    it('should create a new site build for the sender', (done) => {
       let site;
       let user;
       let payload;

--- a/test/api/requests/webhook.test.js
+++ b/test/api/requests/webhook.test.js
@@ -30,13 +30,13 @@ describe('Webhook API', () => {
     },
   });
 
-  describe('POST /webhook/github', () => {
+  describe.only('POST /webhook/github', () => {
     beforeEach(() => {
       nock.cleanAll();
       githubAPINocks.status();
     });
 
-    it('should create a new site build for the sender', (done) => {
+    it.only('should create a new site build for the sender', (done) => {
       let site;
       let user;
       let payload;

--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -161,6 +161,7 @@ const repo = ({ accessToken, owner, repo, response } = {}) => {
     resp[1] = typicalResponse;
   }
 
+
   return webhookNock.reply(...resp);
 };
 

--- a/test/api/unit/services/GithubBuildStatusReporter.test.js
+++ b/test/api/unit/services/GithubBuildStatusReporter.test.js
@@ -1,5 +1,7 @@
 const crypto = require('crypto');
 const { expect } = require('chai');
+const { spy } = require('sinon');
+const logger = require('winston');
 const nock = require('nock');
 const config = require('../../../../config');
 const factory = require('../../support/factory');
@@ -213,39 +215,111 @@ describe('GithubBuildStatusReporter', () => {
     });
 
     context('with a build by a user outside Federalist', () => {
-      it("should use the access token of the site's most recently signed in user", (done) => {
-        let statusNock;
+      const githubUserName = () => `github-user-${crypto.randomBytes(8).toString('hex')}`;
+      const validUserParams = () => ({
+        username: githubUserName(),
+        githubAccessToken: 'fallback-access-token',
+        signedInAt: new Date(),
+      });
+      const invalidUserParams = () => ({
+        username: githubUserName(),
+        githubAccessToken: null,
+      });
 
-        const federalistUser = factory.user({
-          githubAccessToken: 'fallback-access-token',
+      let site;
+      let invalidPermissionsNock;
+
+      it('uses the access token of a signed in user with valid permissions' , (done) => {
+        let statusNock;
+        let validPermissionsNock;
+
+        const federalistUser = factory.user(validUserParams());
+        const expiredFederalistUser = factory.user({
           signedInAt: new Date(),
         });
-        const githubUserName = `github-user-${crypto.randomBytes(8).toString('hex')}`;
-        const githubUser = User.create({ username: githubUserName });
-        const site = factory.site({
+        const githubUser = factory.user(invalidUserParams());
+
+        factory.site({
           owner: 'test-owner',
           repository: 'test-repo',
-          users: Promise.all([federalistUser, githubUser]),
-        });
-
-        factory.build({
-          state: 'processing',
-          user: githubUser,
-          site,
-          commitSha,
-        }).then((build) => {
+          users: Promise.all([expiredFederalistUser, federalistUser, githubUser]),
+        })
+        .then((model) => {
+          site = model;
+        })
+        .then(() =>
+          factory.build({
+            state: 'processing',
+            user: githubUser,
+            site,
+            commitSha,
+          })
+        )
+        .then((build) => {
           statusNock = githubAPINocks.status({
-            owner: 'test-owner',
-            repo: 'test-repo',
+            owner: site.owner,
+            repo: site.repository,
             sha: commitSha,
-            accessToken: 'fallback-access-token',
+            accessToken: federalistUser.githubAccessToken,
+          });
+          invalidPermissionsNock = githubAPINocks.repo({
+            response: [201, {
+              permissions: { admin: false },
+            }],
+          });
+          validPermissionsNock = githubAPINocks.repo({
+            response: [201, {
+              permissions: { admin: true },
+            }],
           });
 
           return GithubBuildStatusReporter.reportBuildStatus(build);
         }).then(() => {
           expect(statusNock.isDone()).to.be.true;
+          expect(invalidPermissionsNock.isDone()).to.be.true;
+          expect(validPermissionsNock.isDone()).to.be.true;
           done();
         }).catch(done);
+      });
+
+      it('reports an error if no users with valid permissions are found', (done) => {
+        const githubUser = factory.user(invalidUserParams());
+        const loggerSpy = spy(logger, 'error');
+
+        factory.site({
+          owner: 'test-owner',
+          repository: 'test-repo',
+          users: Promise.all([githubUser]),
+        })
+        .then(site =>
+          factory.build({
+            state: 'processing',
+            user: githubUser,
+            site,
+            commitSha,
+          })
+        )
+        .then(build => {
+          invalidPermissionsNock = githubAPINocks.repo({
+            response: [201, {
+              permissions: { admin: false },
+            }],
+          });
+          statusNock = githubAPINocks.status({
+            owner: site.owner,
+            repo: site.repository,
+            sha: commitSha,
+            accessToken: githubUser.githubAccessToken,
+          });
+          
+          return GithubBuildStatusReporter.reportBuildStatus(build);
+        })
+        .then(() => {
+          expect(loggerSpy.called).to.be.true;
+          loggerSpy.restore();
+          done();
+        })
+        .catch(done);
       });
     });
   });

--- a/test/api/unit/services/GithubBuildStatusReporter.test.js
+++ b/test/api/unit/services/GithubBuildStatusReporter.test.js
@@ -6,7 +6,6 @@ const nock = require('nock');
 const config = require('../../../../config');
 const factory = require('../../support/factory');
 const githubAPINocks = require('../../support/githubAPINocks');
-const { User } = require('../../../../api/models');
 
 const GithubBuildStatusReporter = require('../../../../api/services/GithubBuildStatusReporter');
 
@@ -226,10 +225,10 @@ describe('GithubBuildStatusReporter', () => {
         githubAccessToken: null,
       });
 
-      let site;
       let invalidPermissionsNock;
 
-      it('uses the access token of a signed in user with valid permissions' , (done) => {
+      it('uses the access token of a signed in user with valid permissions', (done) => {
+        let site;
         let statusNock;
         let validPermissionsNock;
 
@@ -274,12 +273,14 @@ describe('GithubBuildStatusReporter', () => {
           });
 
           return GithubBuildStatusReporter.reportBuildStatus(build);
-        }).then(() => {
+        })
+        .then(() => {
           expect(statusNock.isDone()).to.be.true;
           expect(invalidPermissionsNock.isDone()).to.be.true;
           expect(validPermissionsNock.isDone()).to.be.true;
           done();
-        }).catch(done);
+        })
+        .catch(done);
       });
 
       it('reports an error if no users with valid permissions are found', (done) => {
@@ -299,19 +300,19 @@ describe('GithubBuildStatusReporter', () => {
             commitSha,
           })
         )
-        .then(build => {
-          invalidPermissionsNock = githubAPINocks.repo({
+        .then((build) => {
+          githubAPINocks.repo({
             response: [201, {
               permissions: { admin: false },
             }],
           });
-          statusNock = githubAPINocks.status({
-            owner: site.owner,
-            repo: site.repository,
+          githubAPINocks.status({
+            owner: build.site.owner,
+            repo: build.site.repository,
             sha: commitSha,
             accessToken: githubUser.githubAccessToken,
           });
-          
+
           return GithubBuildStatusReporter.reportBuildStatus(build);
         })
         .then(() => {


### PR DESCRIPTION
Previously, we just grabbed the access token of the most recently logged in user. This could cause issues as that user was not guaranteed to have an access token with the necessary permissions to post a status update back to GitHub.

Now, if a build is initiated by a non-federalist user, we get all users who have logged in, and try to find a valid access token among them.

Open questions:

* Should we get all users, not just the ones who have logged in?
* Does it make more sense to have the build status reporting logic live in an `afterCreate` hook on the build model? Since we are now querying GitHub for valid tokens during a `create` request, it doesn't necessarily make sense to block the server with that logic when the checks could happen in the background.