### PR TITLE
Preserve path in rewritten URLs

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,11 +72,10 @@ app.use(responses);
 
 app.use((req, res, next) => {
   const host = req.hostname;
-  const path = req.pathname || '';
+  const reqPath = req.path;
 
   if (redirectUrls.indexOf(host) !== -1) {
-    console.log('i should be redirecting')
-    return res.redirect(301, `https://${host.slice().replace('fr.cloud', '18f')}${path}`);
+    return res.redirect(301, `https://${host.slice().replace('fr.cloud', '18f')}${reqPath}`);
   }
 
   return next();

--- a/app.js
+++ b/app.js
@@ -72,9 +72,11 @@ app.use(responses);
 
 app.use((req, res, next) => {
   const host = req.hostname;
+  const path = req.pathname || '';
 
   if (redirectUrls.indexOf(host) !== -1) {
-    return res.redirect(301, `https://${host.slice().replace('fr.cloud', '18f')}`);
+    console.log('i should be redirecting')
+    return res.redirect(301, `https://${host.slice().replace('fr.cloud', '18f')}${path}`);
   }
 
   return next();

--- a/test/api/requests/app.test.js
+++ b/test/api/requests/app.test.js
@@ -2,12 +2,11 @@ const request = require('supertest');
 const app = require('../../../app');
 const { expect } = require('chai');
 
-const expectRedirect = (hostname, pathname = '', expectedUrl) =>
+const expectRedirect = (hostname, pathname = '/', expectedUrl) =>
   new Promise(resolve =>
     request(app)
-    .get('/')
+    .get(pathname)
     .set('host', hostname)
-    .set('path', pathname)
     .expect(301)
     .then((res) => {
       expect(res.headers.location).to.equal(expectedUrl);
@@ -15,19 +14,19 @@ const expectRedirect = (hostname, pathname = '', expectedUrl) =>
     })
   );
 
-describe.only('.fr.cloud redirects', () => {
+describe('.fr.cloud redirects', () => {
   it('redirects from old .fr.cloud domain to .18f', (done) => {
-    const path = '/preview/my-great/path';
-    const stagingUrl = `federalist-staging.fr.cloud.gov${path}`;
-    const expectedUrl =`https://federalist-staging.18f.gov${path}`;
+    const stagingPath = '/preview/my-great/path';
+    const stagingUrl = 'federalist-staging.fr.cloud.gov';
+    const expectedUrl =`https://federalist-staging.18f.gov${stagingPath}`;
 
     Promise.all([
-      expectRedirect(stagingUrl, path, expectedUrl),
-      expectRedirect('federalist.fr.cloud.gov', '', 'https://federalist.18f.gov'),
+      expectRedirect(stagingUrl, stagingPath, expectedUrl),
+      expectRedirect('federalist.fr.cloud.gov', '', 'https://federalist.18f.gov/'),
     ])
     .then(() => done())
     .catch((error) => {
-      console.log(error);
+      console.warn(error);
       done();
     });
   });

--- a/test/api/requests/app.test.js
+++ b/test/api/requests/app.test.js
@@ -2,25 +2,33 @@ const request = require('supertest');
 const app = require('../../../app');
 const { expect } = require('chai');
 
-const expectRedirect = (hostname, expectedUrl) =>
+const expectRedirect = (hostname, pathname = '', expectedUrl) =>
   new Promise(resolve =>
     request(app)
     .get('/')
     .set('host', hostname)
+    .set('path', pathname)
     .expect(301)
     .then((res) => {
       expect(res.headers.location).to.equal(expectedUrl);
-
       resolve();
     })
   );
 
-describe('.fr.cloud redirects', () => {
+describe.only('.fr.cloud redirects', () => {
   it('redirects from old .fr.cloud domain to .18f', (done) => {
+    const path = '/preview/my-great/path';
+    const stagingUrl = `federalist-staging.fr.cloud.gov${path}`;
+    const expectedUrl =`https://federalist-staging.18f.gov${path}`;
+
     Promise.all([
-      expectRedirect('federalist-staging.fr.cloud.gov', 'https://federalist-staging.18f.gov'),
-      expectRedirect('federalist.fr.cloud.gov', 'https://federalist.18f.gov'),
+      expectRedirect(stagingUrl, path, expectedUrl),
+      expectRedirect('federalist.fr.cloud.gov', '', 'https://federalist.18f.gov'),
     ])
-    .then(() => done());
+    .then(() => done())
+    .catch((error) => {
+      console.log(error);
+      done();
+    });
   });
 });


### PR DESCRIPTION
Redirect middleware was rewriting all URLs to point to the base federalist site, which may break legacy preview links.

This PR re-appends the path to those rewrites