### PR TITLE
Update css to fix spacing issues and text overflow

### DIFF
--- a/frontend/sass/_flexbox.scss
+++ b/frontend/sass/_flexbox.scss
@@ -3,10 +3,16 @@
   display: block;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
 
   .usa-width-one-third {
-    margin-right: 0px !important;
+    &:nth-child(3n) {
+      margin-right: 0px;
+    }
+
+    @media screen and (max-width: 976px) {
+      // needed because performance.gov overflows its container
+      margin-right: 10% !important;
+    }
   }
   // TODO move this out of here
   // these are specific to the image grid

--- a/views/content/case-studies.njk
+++ b/views/content/case-studies.njk
@@ -41,12 +41,10 @@
             Eight agencies use Federalist to host over 100 sites with over 140,000 page views per day. This page shows a sample of our partners.
           </p>
         </div>
-        <div class="usa-width-one-half">
-          <div class="flexbox-grid example-sites-list">
-            {% for example in exampleSites %}
-            {{ exampleSite.template(example) }}
-            {% endfor %}
-          </div>
+        <div class="usa-width-one-half flexbox-grid example-sites-list">
+          {% for example in exampleSites %}
+          {{ exampleSite.template(example) }}
+          {% endfor %}
         </div>
       </div>
     </section>


### PR DESCRIPTION
Screenshots:

<img width="528" alt="screen shot 2018-04-17 at 6 29 29 pm" src="https://user-images.githubusercontent.com/1421848/38902166-61509574-426d-11e8-8beb-6dc5b1cee996.png">


<img width="817" alt="screen shot 2018-04-17 at 6 29 35 pm" src="https://user-images.githubusercontent.com/1421848/38902168-63f2b44c-426d-11e8-931f-6fb6bdc67e58.png">


This change also necessitates a move to two columns on certain browser sizes. We have to do this since `performance.gov` text overflows its container and bumps into the next link, rendering it hard to read.

Also, it looks like one of the images is not the correct size, it would need to be re-exported to be the same size as the others. I don't think it needs to block release.
