### PR TITLE
api call buildlogs in datbase once instead of twice

### DIFF
--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -29,8 +29,7 @@ module.exports = {
         source: req.body.source,
       });
     })
-    .then(buildLog => buildLogSerializer.serialize(buildLog))
-    .then((buildLogJSON) => { res.json(buildLogJSON); })
+    .then(buildLog => res.json(buildLogSerializer.serializeBuildLog(buildLog)))
     .catch((err) => {
       res.error(err);
     });
@@ -56,7 +55,7 @@ module.exports = {
         return siteAuthorizer.findOne(req.user, { id: build.site });
       })
       .then(() => BuildLog.findAll({ where: { build: build.id } }))
-      .then(buildLogs => buildLogSerializer.serialize(buildLogs, { isPlaintext }))
+      .then(buildLogs => buildLogSerializer.serializeBuildLogs(buildLogs, { isPlaintext }))
       .then((serializedBuildLogs) => {
         if (isPlaintext) {
           // .findAll always resolves to an array, so join is available

--- a/api/models/build-log.js
+++ b/api/models/build-log.js
@@ -31,8 +31,8 @@ function toJSON() {
   const object = this.get({
     plain: true,
   });
-  object.createdAt = object.createdAt.toISOString();
-  object.updatedAt = object.updatedAt.toISOString();
+  object.createdAt = new Date(object.createdAt).toISOString();
+  object.updatedAt = new Date(object.updatedAt).toISOString();
   return object;
 }
 

--- a/api/serializers/build-log.js
+++ b/api/serializers/build-log.js
@@ -1,33 +1,23 @@
-const { BuildLog, Build } = require('../models');
-
 function serializeObject(buildLog) {
-  const json = buildLog.toJSON();
-  json.build = buildLog.Build.toJSON();
-  delete json.Build;
-  return json;
+  return buildLog.toJSON();
 }
 
 function serializePlaintext(buildLog) {
   // Serializes a buildLog as a text-based representation
   return [
     `Source: ${buildLog.source}`,
-    `Timestamp: ${buildLog.createdAt.toISOString()}`,
+    `Timestamp: ${(new Date(buildLog.createdAt)).toISOString()}`,
     `Output:\n${buildLog.output}`,
   ].join('\n');
 }
 
-function serialize(serializable, { isPlaintext } = {}) {
+function serializeBuildLog(buildLog, { isPlaintext } = {}) {
   const serializationFn = isPlaintext ? serializePlaintext : serializeObject;
-
-  if (serializable.length !== undefined) {
-    const buildLogIds = serializable.map(buildLog => buildLog.id);
-    const query = BuildLog.findAll({ where: { id: buildLogIds }, include: [Build] });
-
-    return query.then(buildLogs => buildLogs.map(serializationFn));
-  }
-
-  const query = BuildLog.findById(serializable.id, { include: [Build] });
-  return query.then(serializationFn);
+  return serializationFn(buildLog);
 }
 
-module.exports = { serialize };
+function serializeBuildLogs(buildLogs, { isPlaintext } = {}) {
+  return buildLogs.map(buildLog => serializeBuildLog(buildLog, { isPlaintext }));
+}
+
+module.exports = { serializeBuildLogs, serializeBuildLog };

--- a/public/swagger/BuildLog.json
+++ b/public/swagger/BuildLog.json
@@ -2,7 +2,6 @@
   "type": "object",
   "required": [
     "id",
-    "build",
     "createdAt",
     "output",
     "source",
@@ -11,12 +10,6 @@
   "properties": {
     "id": {
       "type": "integer"
-    },
-    "build": {
-      "type": "object",
-      "not": {
-        "required": ["token"]
-      }
     },
     "createdAt": {
       "type": "string"

--- a/test/api/unit/serializers/build-log.test.js
+++ b/test/api/unit/serializers/build-log.test.js
@@ -17,7 +17,7 @@ describe('BuildLogSerializer', () => {
   describe('.serialize(serializable)', () => {
     it('should serialize an object correctly', (done) => {
       factory.buildLog()
-        .then(buildLog => BuildLogSerializer.serialize(buildLog))
+        .then(buildLog => BuildLogSerializer.serializeBuildLog(buildLog))
         .then((object) => {
           const result = validateJSONSchema(object, buildLogSchema);
           expect(result.errors).to.be.empty;
@@ -30,7 +30,7 @@ describe('BuildLogSerializer', () => {
       const buildLogs = Array(3).fill(0).map(() => factory.buildLog());
 
       Promise.all(buildLogs)
-        .then(logs => BuildLogSerializer.serialize(logs))
+        .then(logs => BuildLogSerializer.serializeBuildLogs(logs))
         .then((object) => {
           const arraySchema = {
             type: 'array',
@@ -45,7 +45,7 @@ describe('BuildLogSerializer', () => {
 
     it('should serialize an object to plaintext when specified', (done) => {
       factory.buildLog()
-        .then(buildLog => BuildLogSerializer.serialize(buildLog, { isPlaintext: true }))
+        .then(buildLog => BuildLogSerializer.serializeBuildLog(buildLog, { isPlaintext: true }))
         .then((text) => {
           plaintextLineIsOk(text);
           done();
@@ -57,7 +57,7 @@ describe('BuildLogSerializer', () => {
       const buildLogs = Array(3).fill(0).map(() => factory.buildLog());
 
       Promise.all(buildLogs)
-        .then(logs => BuildLogSerializer.serialize(logs, { isPlaintext: true }))
+        .then(logs => BuildLogSerializer.serializeBuildLogs(logs, { isPlaintext: true }))
         .then((arr) => {
           expect(arr).to.be.an('array');
           expect(arr.length).to.equal(3);


### PR DESCRIPTION
optimize api to call build logs in database only once  ... and not include build object in api as it is does not appear to be used