### PR TITLE
route content/examples to cases studies

### DIFF
--- a/api/routers/main.js
+++ b/api/routers/main.js
@@ -5,7 +5,7 @@ const csrfProtection = require('../policies/csrfProtection');
 
 router.get('/', MainController.home);
 router.get('/case-studies/', MainController.examples);
-router.get('/content/examples', MainController.examples);
+router.get('/content/examples', (req, res) => res.redirect('/case-studies'));
 
 // add csrf middleware to app route so that we can use request.csrfToken()
 router.get('/sites(/*)?', csrfProtection, MainController.app);

--- a/api/routers/main.js
+++ b/api/routers/main.js
@@ -5,6 +5,7 @@ const csrfProtection = require('../policies/csrfProtection');
 
 router.get('/', MainController.home);
 router.get('/case-studies/', MainController.examples);
+router.get('/content/examples', MainController.examples);
 
 // add csrf middleware to app route so that we can use request.csrfToken()
 router.get('/sites(/*)?', csrfProtection, MainController.app);


### PR DESCRIPTION
fix the content/examples route which was broken by adding case-studies route