### PR TITLE
Added brightness overlay on .figure images & removed whitespace

### DIFF
--- a/frontend/sass/_figure_group.scss
+++ b/frontend/sass/_figure_group.scss
@@ -10,18 +10,22 @@
 
 .figure-group {
   @media screen and (max-width: $mobile-size) {
-    margin: 0 auto;    
+    margin: 0 auto;
   }
 }
 
 .figure {
   margin: 0;
 
+  img {
+    filter: brightness(95%);
+  }
+
   figcaption {
     margin-bottom: 6px;
     margin-top: 20px;
     text-align: left;
-    
+
     @media screen and (max-width: $mobile-size) {
       text-align: center;
     }


### PR DESCRIPTION
This addresses issue #1810 in a very simple PR.

The issue is that when scrolling thru the main landing page, the images do not particularly stand out against the white background of the page. So, a simple solution suggested by @ericronne was to add a darker background and then change the transparency of all the images. I took a slightly different approach by adding `filter: brightness(95%)` to the `img` tags inside of `.figure` div's.

Here are some screenshots of what my proposed solution looks like - 
<img width="718" alt="screen shot 2018-06-29 at 3 10 22 pm" src="https://user-images.githubusercontent.com/1751160/42117084-91d24a46-7baf-11e8-81d7-c685f3f006ec.png">
<img width="825" alt="screen shot 2018-06-29 at 3 10 19 pm" src="https://user-images.githubusercontent.com/1751160/42117092-9873c820-7baf-11e8-916f-ed43025a8292.png">
<img width="1061" alt="screen shot 2018-06-29 at 3 10 15 pm" src="https://user-images.githubusercontent.com/1751160/42117093-9af1ff54-7baf-11e8-899e-98256320d20b.png">

You can see that there isn't really a background on the Agency Logos screenshot - this is because they all happen to be circular `.png` images. Whereas the screenshots of sample sites are rectangular.

If you would like to have the agency logos with a similar gray background, we can simply apply `background-color: $color-gray-lightest;` to the `img` tag styling.
