### PR TITLE
Consistent propTypes, defaultProps, and mapStateToProps Location

### DIFF
--- a/frontend/components/AddSite/AddRepoSiteForm.jsx
+++ b/frontend/components/AddSite/AddRepoSiteForm.jsx
@@ -7,21 +7,6 @@ import GitHubRepoUrlField from '../Fields/GitHubRepoUrlField';
 import SelectSiteEngine from '../SelectSiteEngine';
 import AlertBanner from '../alertBanner';
 
-const propTypes = {
-  showAddNewSiteFields: PropTypes.bool,
-
-  initialValues: PropTypes.shape({
-    engine: PropTypes.string.isRequired,
-  }).isRequired,
-  // the following props are from reduxForm:
-  handleSubmit: PropTypes.func.isRequired,
-  pristine: PropTypes.bool.isRequired,
-};
-
-const defaultProps = {
-  showAddNewSiteFields: false,
-};
-
 const showNewSiteAlert = () => {
   const message = (
     <span>
@@ -96,8 +81,20 @@ export const AddRepoSiteForm = ({
   </form>
 );
 
-AddRepoSiteForm.propTypes = propTypes;
-AddRepoSiteForm.defaultProps = defaultProps;
+AddRepoSiteForm.propTypes = {
+  showAddNewSiteFields: PropTypes.bool,
+
+  initialValues: PropTypes.shape({
+    engine: PropTypes.string.isRequired,
+  }).isRequired,
+  // the following props are from reduxForm:
+  handleSubmit: PropTypes.func.isRequired,
+  pristine: PropTypes.bool.isRequired,
+};
+
+AddRepoSiteForm.defaultProps = {
+  showAddNewSiteFields: false,
+};
 
 // create a higher-order component with reduxForm and export that
 export default reduxForm({ form: 'addRepoSite' })(AddRepoSiteForm);

--- a/frontend/components/AddSite/TemplateSiteList/index.js
+++ b/frontend/components/AddSite/TemplateSiteList/index.js
@@ -4,12 +4,6 @@ import PropTypes from 'prop-types';
 
 import TemplateSite from './templateSite';
 
-const propTypes = {
-  templates: PropTypes.object.isRequired,
-  handleSubmitTemplate: PropTypes.func.isRequired,
-  defaultOwner: PropTypes.string.isRequired,
-};
-
 export class TemplateList extends React.Component {
   constructor(props) {
     super(props);
@@ -58,7 +52,11 @@ export class TemplateList extends React.Component {
   }
 }
 
-TemplateList.propTypes = propTypes;
+TemplateList.propTypes = {
+  templates: PropTypes.object.isRequired,
+  handleSubmitTemplate: PropTypes.func.isRequired,
+  defaultOwner: PropTypes.string.isRequired,
+};
 
 const mapStateToProps = state => ({
   templates: state.FRONTEND_CONFIG.TEMPLATES,

--- a/frontend/components/AddSite/TemplateSiteList/templateSite.js
+++ b/frontend/components/AddSite/TemplateSiteList/templateSite.js
@@ -3,19 +3,6 @@ import PropTypes from 'prop-types';
 
 import { getSafeRepoName } from '../../../util';
 
-const propTypes = {
-  templateKey: PropTypes.string.isRequired,
-  defaultOwner: PropTypes.string.isRequired,
-  example: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-  thumb: PropTypes.string.isRequired,
-  active: PropTypes.number.isRequired,
-  handleChooseActive: PropTypes.func.isRequired,
-  handleSubmit: PropTypes.func.isRequired,
-  index: PropTypes.number.isRequired,
-};
-
 class TemplateSite extends React.Component {
   constructor(props) {
     super(props);
@@ -116,6 +103,17 @@ class TemplateSite extends React.Component {
   }
 }
 
-TemplateSite.propTypes = propTypes;
+TemplateSite.propTypes = {
+  templateKey: PropTypes.string.isRequired,
+  defaultOwner: PropTypes.string.isRequired,
+  example: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  thumb: PropTypes.string.isRequired,
+  active: PropTypes.number.isRequired,
+  handleChooseActive: PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  index: PropTypes.number.isRequired,
+};
 
 export default TemplateSite;

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -11,12 +11,6 @@ import { availableEngines } from '../SelectSiteEngine';
 import siteActions from '../../actions/siteActions';
 import addNewSiteFieldsActions from '../../actions/addNewSiteFieldsActions';
 
-const mapStateToProps = ({ alert, showAddNewSiteFields, user }) => ({
-  alert,
-  showAddNewSiteFields,
-  user,
-});
-
 function getOwnerAndRepo(repoUrl) {
   const owner = repoUrl.split('/')[3];
   const repository = repoUrl.split('/')[4];
@@ -114,5 +108,11 @@ AddSite.defaultProps = {
   showAddNewSiteFields: false,
   user: null,
 };
+
+const mapStateToProps = ({ alert, showAddNewSiteFields, user }) => ({
+  alert,
+  showAddNewSiteFields,
+  user,
+});
 
 export default connect(mapStateToProps)(AddSite);

--- a/frontend/components/AddSite/index.js
+++ b/frontend/components/AddSite/index.js
@@ -11,18 +11,6 @@ import { availableEngines } from '../SelectSiteEngine';
 import siteActions from '../../actions/siteActions';
 import addNewSiteFieldsActions from '../../actions/addNewSiteFieldsActions';
 
-const propTypes = {
-  alert: ALERT,
-  showAddNewSiteFields: PropTypes.bool,
-  user: USER,
-};
-
-const defaultProps = {
-  alert: null,
-  showAddNewSiteFields: false,
-  user: null,
-};
-
 const mapStateToProps = ({ alert, showAddNewSiteFields, user }) => ({
   alert,
   showAddNewSiteFields,
@@ -115,7 +103,16 @@ export class AddSite extends React.Component {
   }
 }
 
-AddSite.propTypes = propTypes;
-AddSite.defaultProps = defaultProps;
+AddSite.propTypes = {
+  alert: ALERT,
+  showAddNewSiteFields: PropTypes.bool,
+  user: USER,
+};
+
+AddSite.defaultProps = {
+  alert: null,
+  showAddNewSiteFields: false,
+  user: null,
+};
 
 export default connect(mapStateToProps)(AddSite);

--- a/frontend/components/ButtonLink.js
+++ b/frontend/components/ButtonLink.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const propTypes = {
-  clickHandler: PropTypes.func.isRequired,
-  children: PropTypes.node,
-};
-
 /* eslint-disable jsx-a11y/href-no-hash */
 const ButtonLink = ({ clickHandler, children }) =>
   <a
@@ -17,7 +12,11 @@ const ButtonLink = ({ clickHandler, children }) =>
   </a>;
 /* eslint-enable jsx-a11y/href-no-hash */
 
-ButtonLink.propTypes = propTypes;
+ButtonLink.propTypes = {
+  clickHandler: PropTypes.func.isRequired,
+  children: PropTypes.node,
+};
+
 ButtonLink.defaultProps = {
   children: null,
 };

--- a/frontend/components/CreateBuildLink.jsx
+++ b/frontend/components/CreateBuildLink.jsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const propTypes = {
-  handlerParams: PropTypes.object,
-  handleClick: PropTypes.func.isRequired,
-  children: PropTypes.node.isRequired,
-};
-
 class CreateBuildLink extends React.Component {
   constructor(props) {
     super(props);
@@ -39,7 +33,12 @@ class CreateBuildLink extends React.Component {
   }
 }
 
-CreateBuildLink.propTypes = propTypes;
+CreateBuildLink.propTypes = {
+  handlerParams: PropTypes.object,
+  handleClick: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
 CreateBuildLink.defaultProps = {
   handlerParams: {},
 };

--- a/frontend/components/ExpandableArea.jsx
+++ b/frontend/components/ExpandableArea.jsx
@@ -50,5 +50,4 @@ ExpandableArea.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-
 export default ExpandableArea;

--- a/frontend/components/SelectSiteEngine.jsx
+++ b/frontend/components/SelectSiteEngine.jsx
@@ -33,7 +33,6 @@ const SelectSiteEngine = ({ value, onChange, ...props }) => (
   </select>
 );
 
-
 SelectSiteEngine.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func,

--- a/frontend/components/alertBanner.js
+++ b/frontend/components/alertBanner.js
@@ -1,33 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const propTypes = {
-  message: PropTypes.node,
-  status: PropTypes.string,
-  header: PropTypes.string,
-  children: PropTypes.node,
-  /**
-   * role="alert" is a flag which will tell a user's assistive device to notify the user
-   * that there is important information to be communicated. The majority of our alerts are
-   * used to inform the user of form errors or missing information.
-   *
-   * However, there are some places where the AlertBanner component is used to display information
-   * that is not critical to the user (such as the site delete action under AdvancedSettings).
-   * For these cases, this flag is added to opt out of adding `role="alert"` where desired.
-   *
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
-   */
-
-  alertRole: PropTypes.bool,
-};
-
-const defaultProps = {
-  message: null,
-  status: 'info',
-  children: null,
-  alertRole: true,
-};
-
 const renderHeader = (text) => {
   if (!text) {
     return null;
@@ -69,7 +42,31 @@ const AlertBanner = ({ children, header, message, status, alertRole }) => {
   );
 };
 
-AlertBanner.propTypes = propTypes;
-AlertBanner.defaultProps = defaultProps;
+AlertBanner.propTypes = {
+  message: PropTypes.node,
+  status: PropTypes.string,
+  header: PropTypes.string,
+  children: PropTypes.node,
+  /**
+   * role="alert" is a flag which will tell a user's assistive device to notify the user
+   * that there is important information to be communicated. The majority of our alerts are
+   * used to inform the user of form errors or missing information.
+   *
+   * However, there are some places where the AlertBanner component is used to display information
+   * that is not critical to the user (such as the site delete action under AdvancedSettings).
+   * For these cases, this flag is added to opt out of adding `role="alert"` where desired.
+   *
+   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
+   */
+
+  alertRole: PropTypes.bool,
+};
+
+AlertBanner.defaultProps = {
+  message: null,
+  status: 'info',
+  children: null,
+  alertRole: true,
+};;
 
 export default AlertBanner;

--- a/frontend/components/alertBanner.js
+++ b/frontend/components/alertBanner.js
@@ -67,6 +67,6 @@ AlertBanner.defaultProps = {
   status: 'info',
   children: null,
   alertRole: true,
-};;
+};
 
 export default AlertBanner;

--- a/frontend/components/app.js
+++ b/frontend/components/app.js
@@ -7,12 +7,6 @@ import { USER, ALERT } from '../propTypes';
 import alertActions from '../actions/alertActions';
 import LoadingIndicator from './LoadingIndicator';
 
-const mapStateToProps = ({ alert, notifications, user }) => ({
-  alert,
-  notifications,
-  user,
-});
-
 export class App extends React.Component {
   componentWillReceiveProps(nextProps) {
     const { alert } = this.props;
@@ -94,5 +88,11 @@ App.defaultProps = {
   user: false,
   notifications: [],
 };
+
+const mapStateToProps = ({ alert, notifications, user }) => ({
+  alert,
+  notifications,
+  user,
+});
 
 export default connect(mapStateToProps)(App);

--- a/frontend/components/branchViewLink.js
+++ b/frontend/components/branchViewLink.js
@@ -30,7 +30,6 @@ BranchViewLink.propTypes = {
   previewHostname: PropTypes.string.isRequired,
 };
 
-
 const mapStateToProps = state => ({
   previewHostname: state.FRONTEND_CONFIG.PREVIEW_HOSTNAME,
 });

--- a/frontend/components/site/PagesHeader.jsx
+++ b/frontend/components/site/PagesHeader.jsx
@@ -5,13 +5,6 @@ import { Link } from 'react-router';
 import { IconView } from '../icons';
 import GitHubLink from '../GitHubLink';
 
-const propTypes = {
-  owner: PropTypes.string.isRequired, // Owner (org or user) of the repo
-  repository: PropTypes.string.isRequired, // Name of the repo
-  title: PropTypes.string.isRequired, // Title of the section we are on
-  viewLink: PropTypes.string.isRequired,
-};
-
 const PagesHeader = ({ owner, repository, title, viewLink }) => (
   <div className="page-header usa-grid-full">
     <div className="usa-width-two-thirds">
@@ -38,6 +31,11 @@ const PagesHeader = ({ owner, repository, title, viewLink }) => (
   </div>
 );
 
-PagesHeader.propTypes = propTypes;
+PagesHeader.propTypes = {
+  owner: PropTypes.string.isRequired, // Owner (org or user) of the repo
+  repository: PropTypes.string.isRequired, // Name of the repo
+  title: PropTypes.string.isRequired, // Title of the section we are on
+  viewLink: PropTypes.string.isRequired,
+};
 
 export default PagesHeader;

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -7,32 +7,6 @@ import publishedFileActions from '../../actions/publishedFileActions';
 import LoadingIndicator from '../LoadingIndicator';
 import AlertBanner from '../alertBanner';
 
-const propTypes = {
-  params: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-  }).isRequired,
-  publishedFiles: PropTypes.shape({
-    isLoading: PropTypes.bool.isRequired,
-    data: PropTypes.shape({
-      files: PropTypes.arrayOf(
-        PropTypes.shape({
-          name: PropTypes.string,
-          size: PropTypes.number,
-          key: PropTypes.string,
-          publishedBranch: PropTypes.shape({
-            name: PropTypes.string,
-          }),
-        })
-      ),
-      isTruncated: PropTypes.bool,
-    }),
-  }),
-};
-const defaultProps = {
-  publishedFiles: null,
-};
-
 const mapStateToProps = ({ publishedFiles, sites }) => ({
   publishedFiles,
   site: sites.currentSite,
@@ -209,8 +183,32 @@ class SitePublishedFilesTable extends React.Component {
   }
 }
 
-SitePublishedFilesTable.propTypes = propTypes;
-SitePublishedFilesTable.defaultProps = defaultProps;
+SitePublishedFilesTable.propTypes = {
+  params: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  publishedFiles: PropTypes.shape({
+    isLoading: PropTypes.bool.isRequired,
+    data: PropTypes.shape({
+      files: PropTypes.arrayOf(
+        PropTypes.shape({
+          name: PropTypes.string,
+          size: PropTypes.number,
+          key: PropTypes.string,
+          publishedBranch: PropTypes.shape({
+            name: PropTypes.string,
+          }),
+        })
+      ),
+      isTruncated: PropTypes.bool,
+    }),
+  }),
+};
+
+SitePublishedFilesTable.defaultProps = {
+  publishedFiles: null,
+};
 
 export { SitePublishedFilesTable };
 export default connect(mapStateToProps)(SitePublishedFilesTable);

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -7,11 +7,6 @@ import publishedFileActions from '../../actions/publishedFileActions';
 import LoadingIndicator from '../LoadingIndicator';
 import AlertBanner from '../alertBanner';
 
-const mapStateToProps = ({ publishedFiles, sites }) => ({
-  publishedFiles,
-  site: sites.currentSite,
-});
-
 class SitePublishedFilesTable extends React.Component {
   constructor(props) {
     super(props);
@@ -209,6 +204,11 @@ SitePublishedFilesTable.propTypes = {
 SitePublishedFilesTable.defaultProps = {
   publishedFiles: null,
 };
+
+const mapStateToProps = ({ publishedFiles, sites }) => ({
+  publishedFiles,
+  site: sites.currentSite,
+});
 
 export { SitePublishedFilesTable };
 export default connect(mapStateToProps)(SitePublishedFilesTable);

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -6,24 +6,6 @@ import { Field, reduxForm } from 'redux-form';
 import SelectSiteEngine from '../../SelectSiteEngine';
 import AlertBanner from '../../alertBanner';
 
-const propTypes = {
-  onDelete: PropTypes.func.isRequired,
-  siteId: PropTypes.number.isRequired,
-  // initialValues is what the initial form values are based on
-  initialValues: PropTypes.shape({
-    engine: PropTypes.string.isRequired,
-    config: PropTypes.string,
-    demoConfig: PropTypes.string,
-    previewConfig: PropTypes.string,
-  }).isRequired,
-
-  // the following props are from reduxForm:
-  handleSubmit: PropTypes.func.isRequired,
-  reset: PropTypes.func.isRequired,
-  pristine: PropTypes.bool.isRequired,
-};
-
-
 export const AdvancedSiteSettings = ({
   // even though initialValues is not directly used, it is used
   // by reduxForm, and we want PropType validation on it, so we'll
@@ -146,8 +128,22 @@ export const AdvancedSiteSettings = ({
   </form>
 );
 
+AdvancedSiteSettings.propTypes = {
+  onDelete: PropTypes.func.isRequired,
+  siteId: PropTypes.number.isRequired,
+  // initialValues is what the initial form values are based on
+  initialValues: PropTypes.shape({
+    engine: PropTypes.string.isRequired,
+    config: PropTypes.string,
+    demoConfig: PropTypes.string,
+    previewConfig: PropTypes.string,
+  }).isRequired,
 
-AdvancedSiteSettings.propTypes = propTypes;
+  // the following props are from reduxForm:
+  handleSubmit: PropTypes.func.isRequired,
+  reset: PropTypes.func.isRequired,
+  pristine: PropTypes.bool.isRequired,
+};
 
 // create a higher-order component with reduxForm and export that
 export default reduxForm({ form: 'advancedSiteSettings' })(AdvancedSiteSettings);

--- a/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
@@ -5,21 +5,6 @@ import { reduxForm } from 'redux-form';
 import HttpsUrlField from '../../Fields/HttpsUrlField';
 import BranchField from '../../Fields/BranchField';
 
-const propTypes = {
-  // initialValues is what the initial form values are based on
-  initialValues: PropTypes.shape({
-    defaultBranch: PropTypes.string,
-    domain: PropTypes.string,
-    demoBranch: PropTypes.string,
-    demoDomain: PropTypes.string,
-  }).isRequired,
-
-  // the following props are from reduxForm:
-  handleSubmit: PropTypes.func.isRequired,
-  reset: PropTypes.func.isRequired,
-  pristine: PropTypes.bool.isRequired,
-};
-
 export const BasicSiteSettings = ({
   // even though initialValues is not directly used, it is used
   // by reduxForm, and we want PropType validation on it, so we'll
@@ -107,7 +92,20 @@ export const BasicSiteSettings = ({
   </form>
 );
 
-BasicSiteSettings.propTypes = propTypes;
+BasicSiteSettings.propTypes = {
+  // initialValues is what the initial form values are based on
+  initialValues: PropTypes.shape({
+    defaultBranch: PropTypes.string,
+    domain: PropTypes.string,
+    demoBranch: PropTypes.string,
+    demoDomain: PropTypes.string,
+  }).isRequired,
+
+  // the following props are from reduxForm:
+  handleSubmit: PropTypes.func.isRequired,
+  reset: PropTypes.func.isRequired,
+  pristine: PropTypes.bool.isRequired,
+};
 
 // create a higher-order component with reduxForm and export that
 export default reduxForm({ form: 'basicSiteSettings' })(BasicSiteSettings);

--- a/frontend/components/site/SiteSettings/CopyRepoForm.jsx
+++ b/frontend/components/site/SiteSettings/CopyRepoForm.jsx
@@ -6,11 +6,6 @@ import BranchField from '../../Fields/BranchField';
 import InputWithErrorField from '../../Fields/InputWithErrorField';
 import { githubUsernameRegex } from '../../../../api/utils/validators';
 
-const propTypes = {
-  handleSubmit: PropTypes.func.isRequired,
-  pristine: PropTypes.bool.isRequired,
-};
-
 class CopyRepoForm extends React.Component {
   validateInput(value) {
     if (value && value.length && !(githubUsernameRegex.test(value))) {
@@ -129,7 +124,10 @@ class CopyRepoForm extends React.Component {
   }
 }
 
-CopyRepoForm.propTypes = propTypes;
+CopyRepoForm.propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+  pristine: PropTypes.bool.isRequired,
+};
 
 export { CopyRepoForm };
 

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -10,14 +10,6 @@ import AdvancedSiteSettings from './AdvancedSiteSettings';
 import CopyRepoForm from './CopyRepoForm';
 import siteActions from '../../../actions/siteActions';
 
-const propTypes = {
-  site: SITE,
-};
-
-const defaultProps = {
-  site: null,
-};
-
 const mapStateToProps = ({ sites }) => ({ site: sites.currentSite });
 
 class SiteSettings extends React.Component {
@@ -121,8 +113,13 @@ class SiteSettings extends React.Component {
   }
 }
 
-SiteSettings.propTypes = propTypes;
-SiteSettings.defaultProps = defaultProps;
+SiteSettings.propTypes = {
+  site: SITE,
+};
+
+SiteSettings.defaultProps = {
+  site: null,
+};
 
 export { SiteSettings };
 export default connect(mapStateToProps)(SiteSettings);

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -120,7 +120,7 @@ SiteSettings.defaultProps = {
 };
 
 const mapStateToProps = ({ sites }) => ({
-  site: sites.currentSite
+  site: sites.currentSite,
 });
 
 export { SiteSettings };

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -10,8 +10,6 @@ import AdvancedSiteSettings from './AdvancedSiteSettings';
 import CopyRepoForm from './CopyRepoForm';
 import siteActions from '../../../actions/siteActions';
 
-const mapStateToProps = ({ sites }) => ({ site: sites.currentSite });
-
 class SiteSettings extends React.Component {
   constructor(props) {
     super(props);
@@ -120,6 +118,10 @@ SiteSettings.propTypes = {
 SiteSettings.defaultProps = {
   site: null,
 };
+
+const mapStateToProps = ({ sites }) => ({
+  site: sites.currentSite
+});
 
 export { SiteSettings };
 export default connect(mapStateToProps)(SiteSettings);

--- a/frontend/components/site/UserActionsTable.jsx
+++ b/frontend/components/site/UserActionsTable.jsx
@@ -5,7 +5,6 @@ import { USER_ACTION } from '../../propTypes';
 import { timestampUTC } from '../../util/datetime';
 import userActions from '../../actions/userActions';
 
-
 class UserActionsTable extends React.Component {
   componentDidMount() {
     userActions.fetchUserActions(this.props.site);

--- a/frontend/components/site/refreshBuildLogsButton.jsx
+++ b/frontend/components/site/refreshBuildLogsButton.jsx
@@ -4,7 +4,6 @@ import autoBind from 'react-autobind';
 
 import buildLogActions from '../../actions/buildLogActions';
 
-
 class RefreshBuildLogsButton extends React.Component {
   constructor(props) {
     super(props);

--- a/frontend/components/site/refreshBuildsButton.jsx
+++ b/frontend/components/site/refreshBuildsButton.jsx
@@ -4,7 +4,6 @@ import autoBind from 'react-autobind';
 
 import buildActions from '../../actions/buildActions';
 
-
 class RefreshBuildsButton extends React.Component {
   constructor(props) {
     super(props);

--- a/frontend/components/site/siteBuildLogTable.jsx
+++ b/frontend/components/site/siteBuildLogTable.jsx
@@ -31,7 +31,6 @@ function SiteBuildLogTable({ buildLogs }) {
   );
 }
 
-
 SiteBuildLogTable.propTypes = {
   buildLogs: PropTypes.arrayOf(BUILD_LOG).isRequired,
 };

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -8,17 +8,6 @@ import SiteBuildLogTable from './siteBuildLogTable';
 import RefreshBuildLogsButton from './refreshBuildLogsButton';
 import DownloadBuildLogsButton from './downloadBuildLogsButton';
 
-const propTypes = {
-  params: PropTypes.shape({
-    buildId: PropTypes.string.isRequired,
-  }).isRequired,
-  buildLogs: PropTypes.shape({
-    isLoading: PropTypes.bool,
-    data: PropTypes.array,
-  }),
-};
-
-const defaultProps = { buildLogs: null };
 const mapStateToProps = ({ buildLogs }) => ({ buildLogs });
 
 class SiteBuildLogs extends React.Component {
@@ -57,8 +46,19 @@ class SiteBuildLogs extends React.Component {
   }
 }
 
-SiteBuildLogs.propTypes = propTypes;
-SiteBuildLogs.defaultProps = defaultProps;
+SiteBuildLogs.propTypes = {
+  params: PropTypes.shape({
+    buildId: PropTypes.string.isRequired,
+  }).isRequired,
+  buildLogs: PropTypes.shape({
+    isLoading: PropTypes.bool,
+    data: PropTypes.array,
+  }),
+};
+
+SiteBuildLogs.defaultProps = {
+  buildLogs: null,
+};
 
 export { SiteBuildLogs };
 export default connect(mapStateToProps)(SiteBuildLogs);

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -8,8 +8,6 @@ import SiteBuildLogTable from './siteBuildLogTable';
 import RefreshBuildLogsButton from './refreshBuildLogsButton';
 import DownloadBuildLogsButton from './downloadBuildLogsButton';
 
-const mapStateToProps = ({ buildLogs }) => ({ buildLogs });
-
 class SiteBuildLogs extends React.Component {
   componentDidMount() {
     buildLogActions.fetchBuildLogs({ id: this.props.params.buildId });
@@ -59,6 +57,10 @@ SiteBuildLogs.propTypes = {
 SiteBuildLogs.defaultProps = {
   buildLogs: null,
 };
+
+const mapStateToProps = ({ buildLogs }) => ({
+  buildLogs
+});
 
 export { SiteBuildLogs };
 export default connect(mapStateToProps)(SiteBuildLogs);

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -59,7 +59,7 @@ SiteBuildLogs.defaultProps = {
 };
 
 const mapStateToProps = ({ buildLogs }) => ({
-  buildLogs
+  buildLogs,
 });
 
 export { SiteBuildLogs };

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -8,18 +8,6 @@ import BranchViewLink from '../branchViewLink';
 import { SITE } from '../../propTypes';
 import AlertBanner from '../alertBanner';
 
-const propTypes = {
-  publishedBranches: PropTypes.shape({
-    isLoading: PropTypes.bool.isRequired,
-    data: PropTypes.array,
-  }),
-  site: SITE,
-};
-const defaultProps = {
-  publishedBranches: null,
-  site: null,
-};
-
 const mapStateToProps = ({ publishedBranches, sites }) => ({
   publishedBranches,
   site: sites.currentSite,
@@ -108,8 +96,18 @@ class SitePublishedBranchesTable extends React.Component {
   }
 }
 
-SitePublishedBranchesTable.propTypes = propTypes;
-SitePublishedBranchesTable.defaultProps = defaultProps;
+SitePublishedBranchesTable.propTypes = {
+  publishedBranches: PropTypes.shape({
+    isLoading: PropTypes.bool.isRequired,
+    data: PropTypes.array,
+  }),
+  site: SITE,
+};
+
+SitePublishedBranchesTable.defaultProps = {
+  publishedBranches: null,
+  site: null,
+};
 
 export { SitePublishedBranchesTable };
 export default connect(mapStateToProps)(SitePublishedBranchesTable);

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -8,11 +8,6 @@ import BranchViewLink from '../branchViewLink';
 import { SITE } from '../../propTypes';
 import AlertBanner from '../alertBanner';
 
-const mapStateToProps = ({ publishedBranches, sites }) => ({
-  publishedBranches,
-  site: sites.currentSite,
-});
-
 class SitePublishedBranchesTable extends React.Component {
   componentDidMount() {
     const { id } = this.props.site;
@@ -108,6 +103,11 @@ SitePublishedBranchesTable.defaultProps = {
   publishedBranches: null,
   site: null,
 };
+
+const mapStateToProps = ({ publishedBranches, sites }) => ({
+  publishedBranches,
+  site: sites.currentSite,
+});
 
 export { SitePublishedBranchesTable };
 export default connect(mapStateToProps)(SitePublishedBranchesTable);

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -9,29 +9,6 @@ import PagesHeader from './site/PagesHeader';
 import AlertBanner from './alertBanner';
 import LoadingIndicator from './LoadingIndicator';
 
-const propTypes = {
-  params: PropTypes.shape({
-    id: PropTypes.string,
-    branch: PropTypes.string,
-    fileName: PropTypes.string,
-  }).isRequired,
-  location: PropTypes.shape({
-    pathname: PropTypes.string,
-  }).isRequired,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]),
-  sites: PropTypes.object,
-  alert: ALERT,
-};
-
-const defaultProps = {
-  children: null,
-  sites: null,
-  alert: {},
-};
-
 export const SITE_NAVIGATION_CONFIG = [
   {
     display: 'Build history',
@@ -139,7 +116,27 @@ export class SiteContainer extends React.Component {
   }
 }
 
-SiteContainer.propTypes = propTypes;
-SiteContainer.defaultProps = defaultProps;
+SiteContainer.propTypes = {
+  params: PropTypes.shape({
+    id: PropTypes.string,
+    branch: PropTypes.string,
+    fileName: PropTypes.string,
+  }).isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }).isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  sites: PropTypes.object,
+  alert: ALERT,
+};
+
+SiteContainer.defaultProps = {
+  children: null,
+  sites: null,
+  alert: {},
+};
 
 export default connect(state => state)(SiteContainer);

--- a/frontend/components/siteList/publishedState.js
+++ b/frontend/components/siteList/publishedState.js
@@ -2,16 +2,6 @@ import React from 'react';
 
 import { dateAndTime } from '../../util/datetime';
 
-const propTypes = {
-  site: React.PropTypes.shape({
-    publishedAt: React.PropTypes.string,
-  }),
-};
-
-const defaultProps = {
-  site: {},
-};
-
 const getPublishedState = (site) => {
   if (site.publishedAt) {
     const formattedBuildTime = dateAndTime(site.publishedAt);
@@ -25,7 +15,14 @@ const PublishedState = ({ site = {} }) =>
     {getPublishedState(site)}
   </p>;
 
-PublishedState.propTypes = propTypes;
-PublishedState.defaultProps = defaultProps;
+PublishedState.propTypes = {
+  site: React.PropTypes.shape({
+    publishedAt: React.PropTypes.string,
+  }),
+};
+
+PublishedState.defaultProps = {
+  site: {},
+};
 
 export default PublishedState;

--- a/frontend/components/siteList/siteList.js
+++ b/frontend/components/siteList/siteList.js
@@ -9,19 +9,6 @@ import SiteListItem from './siteListItem';
 import LoadingIndicator from '../LoadingIndicator';
 import { IconPlus } from '../icons';
 
-const propTypes = {
-  alert: ALERT,
-  sites: PropTypes.shape({
-    data: PropTypes.arrayOf(SITE),
-    isLoading: PropTypes.bool,
-  }),
-};
-
-const defaultProps = {
-  alert: null,
-  sites: null,
-};
-
 const mapStateToProps = ({ alert, sites }) => ({
   alert,
   sites,
@@ -84,8 +71,18 @@ export const SiteList = ({ sites, alert }) =>
     <a href="#top">Return to top</a>
   </div>;
 
-SiteList.propTypes = propTypes;
-SiteList.defaultProps = defaultProps;
+SiteList.propTypes = {
+  alert: ALERT,
+  sites: PropTypes.shape({
+    data: PropTypes.arrayOf(SITE),
+    isLoading: PropTypes.bool,
+  }),
+};
+
+SiteList.defaultProps = {
+  alert: null,
+  sites: null,
+};
 
 export default connect(mapStateToProps)(SiteList);
 

--- a/frontend/components/siteList/siteList.js
+++ b/frontend/components/siteList/siteList.js
@@ -9,11 +9,6 @@ import SiteListItem from './siteListItem';
 import LoadingIndicator from '../LoadingIndicator';
 import { IconPlus } from '../icons';
 
-const mapStateToProps = ({ alert, sites }) => ({
-  alert,
-  sites,
-});
-
 const getSites = (sites) => {
   const { isLoading, data } = sites;
 
@@ -83,6 +78,11 @@ SiteList.defaultProps = {
   alert: null,
   sites: null,
 };
+
+const mapStateToProps = ({ alert, sites }) => ({
+  alert,
+  sites,
+});
 
 export default connect(mapStateToProps)(SiteList);
 

--- a/frontend/components/siteList/siteListItem.js
+++ b/frontend/components/siteList/siteListItem.js
@@ -6,16 +6,6 @@ import { IconView } from '../icons';
 import PublishedState from './publishedState';
 import GitHubLink from '../GitHubLink';
 
-const propTypes = {
-  site: PropTypes.shape({
-    repository: PropTypes.string,
-    owner: PropTypes.string,
-    id: PropTypes.number,
-    publishedAt: PropTypes.string,
-    viewLink: PropTypes.string,
-  }),
-};
-
 function getViewLink(viewLink, repo) {
   return (
     <a
@@ -46,6 +36,14 @@ const SiteListItem = ({ site }) =>
     </div>
   </li>);
 
-SiteListItem.propTypes = propTypes;
+SiteListItem.propTypes = {
+  site: PropTypes.shape({
+    repository: PropTypes.string,
+    owner: PropTypes.string,
+    id: PropTypes.number,
+    publishedAt: PropTypes.string,
+    viewLink: PropTypes.string,
+  }),
+};
 
 export default SiteListItem;


### PR DESCRIPTION
Per the comments on issue #1636, I simply rearranged and re-organized how `propTypes`, `defaultProps`, and `mapStateToProps` were located in all the component files. I also found a few files with some _small_ spacing issues, so I cleaned those up as well.

After running `docker-compose run app yarn test`, I received 348 passing tests & 0 failing tests.

After running `docker-compose run app yarn lint:diff`, I received three errors regarding `propTypes.object` being forbidden - in `AddSite/TemplateSiteList/index.js`, `CreateBuildLink.jsx`, and `siteContainer.js`. This has been there since I pulled the code and worthy of its own cleanup effort.