### PR TITLE
Fix proptypes issues or add justificaiton for ignoring

### DIFF
--- a/frontend/components/AddSite/TemplateSiteList/index.js
+++ b/frontend/components/AddSite/TemplateSiteList/index.js
@@ -53,6 +53,9 @@ export class TemplateList extends React.Component {
 }
 
 TemplateList.propTypes = {
+  // Templates data structure is described in config/templates.js and is
+  // chellenging to describe with proptypes. Ignoring the rule here.
+  // eslint-disable-next-line react/forbid-prop-types
   templates: PropTypes.object.isRequired,
   handleSubmitTemplate: PropTypes.func.isRequired,
   defaultOwner: PropTypes.string.isRequired,

--- a/frontend/components/CreateBuildLink.jsx
+++ b/frontend/components/CreateBuildLink.jsx
@@ -34,6 +34,9 @@ class CreateBuildLink extends React.Component {
 }
 
 CreateBuildLink.propTypes = {
+  // Handler params object is intentionally ambiguous to allow the parent
+  // component to specify params for the handleClick function
+  // eslint-disable-next-line react/forbid-prop-types
   handlerParams: PropTypes.object,
   handleClick: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -129,7 +129,11 @@ SiteContainer.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
-  sites: PropTypes.object,
+  sites: PropTypes.shape({
+    isLoading: PropTypes.bool.isRequired,
+    currentSite: PropTypes.object.isRequired,
+    sites: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }),
   alert: ALERT,
 };
 


### PR DESCRIPTION
This commit fixes a place where the propType was set to `object` which
made the linter upset. I also added a comment to ignore the rule in 2
places along with a comment providing justification for ignoring it.