### PR TITLE
Remove markdown in nunjucks template

### DIFF
--- a/views/home.njk
+++ b/views/home.njk
@@ -125,7 +125,7 @@
         <div class="usa-width-two-thirds description">
           <h2>Launch your site in minutes.</h2>
           <p class="copy">
-            Federalist uses a [public code hosting service](https://github.com/) to load and store code for your site. If your code is already on GitHub, Federalist can securely deploy a static website from your repository in minutes. 
+            Federalist uses a <a href="https://github.com/">public code hosting service</a> to load and store code for your site. If your code is already on GitHub, Federalist can securely deploy a static website from your repository in minutes.
           </p>
           <div class="figure-group">
             <h4>Agencies using Federalist</h4>


### PR DESCRIPTION
Nunjucks doesn't support markdown, convert it to an `<a>` tag. This is from the staging homepage:

![screenshot from 2018-08-02 17-02-42](https://user-images.githubusercontent.com/509703/43617268-ed9bf9a4-9675-11e8-9ade-bc10234da156.png)
