### PR TITLE
Show site delete button as disabled after click

### DIFF
--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import AdvancedSiteSettingsForm from './AdvancedSiteSettingsForm';
+
+
+export const AdvancedSiteSettings = ({
+  siteId,
+  initialValues,
+  onDelete,
+  onSubmit,
+}) => (
+  <div>
+    <AdvancedSiteSettingsForm
+      siteId={siteId}
+      initialValues={initialValues}
+      onDelete={onDelete}
+      onSubmit={onSubmit}
+    />
+  </div>
+);
+
+AdvancedSiteSettings.propTypes = {
+  onDelete: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  siteId: PropTypes.number.isRequired,
+  // initialValues is what the initial form values are based on
+  initialValues: PropTypes.shape({
+    engine: PropTypes.string.isRequired,
+    config: PropTypes.string,
+    demoConfig: PropTypes.string,
+    previewConfig: PropTypes.string,
+  }).isRequired,
+};
+
+export default AdvancedSiteSettings;

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettings.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import AdvancedSiteSettingsForm from './AdvancedSiteSettingsForm';
+import DeleteSiteForm from './DeleteSiteForm';
 
 
 export const AdvancedSiteSettings = ({
@@ -12,11 +13,10 @@ export const AdvancedSiteSettings = ({
 }) => (
   <div>
     <AdvancedSiteSettingsForm
-      siteId={siteId}
       initialValues={initialValues}
-      onDelete={onDelete}
       onSubmit={onSubmit}
     />
+    <DeleteSiteForm siteId={siteId} onSubmit={onDelete} />
   </div>
 );
 

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.jsx
@@ -1,18 +1,15 @@
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 
 import SelectSiteEngine from '../../SelectSiteEngine';
-import AlertBanner from '../../alertBanner';
+
 
 export const AdvancedSiteSettingsForm = ({
   // even though initialValues is not directly used, it is used
   // by reduxForm, and we want PropType validation on it, so we'll
   // keep it here but disable the eslint rule below
-  siteId,
   initialValues, // eslint-disable-line no-unused-vars
-  onDelete,
   reset,
   pristine,
   handleSubmit,
@@ -99,39 +96,10 @@ export const AdvancedSiteSettingsForm = ({
     >
       Save advanced settings
     </button>
-
-    <div className="well">
-      {/* DELETE SITE */}
-      <fieldset>
-        <legend>Delete Site</legend>
-        <p className="well-text">
-          Deleting a Federalist site removes the published site from our servers and
-          disconnects the Federalist admin interface for all users. This will bring the
-          entire site offline and make it inaccessible for users.<br /><br /> <i>Trying
-          to remove a site from your list of Federalist sites? Go to the
-          {' '}
-            <a href={`/sites/${siteId}/users`}>collaborators page</a> and remove yourself.</i>
-        </p>
-        <AlertBanner
-          status="warning"
-          header="Danger zone"
-          message="Are you sure you want to delete this site from Federalist for all users,
-                   remove all published sites, and delete all previews? Only Github repo
-                   administrators can use this feature."
-          alertRole={false}
-        >
-          <button className="usa-button usa-button-red" onClick={onDelete}>
-            Delete
-          </button>
-        </AlertBanner>
-      </fieldset>
-    </div>
   </form>
 );
 
 AdvancedSiteSettingsForm.propTypes = {
-  onDelete: PropTypes.func.isRequired,
-  siteId: PropTypes.number.isRequired,
   // initialValues is what the initial form values are based on
   initialValues: PropTypes.shape({
     engine: PropTypes.string.isRequired,

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.jsx
@@ -6,7 +6,7 @@ import { Field, reduxForm } from 'redux-form';
 import SelectSiteEngine from '../../SelectSiteEngine';
 import AlertBanner from '../../alertBanner';
 
-export const AdvancedSiteSettings = ({
+export const AdvancedSiteSettingsForm = ({
   // even though initialValues is not directly used, it is used
   // by reduxForm, and we want PropType validation on it, so we'll
   // keep it here but disable the eslint rule below
@@ -129,7 +129,7 @@ export const AdvancedSiteSettings = ({
   </form>
 );
 
-AdvancedSiteSettings.propTypes = {
+AdvancedSiteSettingsForm.propTypes = {
   onDelete: PropTypes.func.isRequired,
   siteId: PropTypes.number.isRequired,
   // initialValues is what the initial form values are based on
@@ -147,4 +147,4 @@ AdvancedSiteSettings.propTypes = {
 };
 
 // create a higher-order component with reduxForm and export that
-export default reduxForm({ form: 'advancedSiteSettings' })(AdvancedSiteSettings);
+export default reduxForm({ form: 'advancedSiteSettings' })(AdvancedSiteSettingsForm);

--- a/frontend/components/site/SiteSettings/DeleteSiteForm.jsx
+++ b/frontend/components/site/SiteSettings/DeleteSiteForm.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+
+import AlertBanner from '../../alertBanner';
+
+
+export const DeleteSiteForm = ({
+  siteId,
+  handleSubmit,
+  submitting,
+}) => (
+  <form className="settings-form settings-form-advanced" onSubmit={handleSubmit}>
+    <div className="well">
+      {/* DELETE SITE */}
+      <fieldset>
+        <legend>Delete Site</legend>
+        <p className="well-text">
+          Deleting a Federalist site removes the published site from our servers and
+          disconnects the Federalist admin interface for all users. This will bring the
+          entire site offline and make it inaccessible for users.<br /><br /> <i>Trying
+          to remove a site from your list of Federalist sites? Go to the
+          {' '}
+            <a href={`/sites/${siteId}/users`}>collaborators page</a> and remove yourself.</i>
+        </p>
+        <AlertBanner
+          status="warning"
+          header="Danger zone"
+          message="Are you sure you want to delete this site from Federalist for all users,
+                   remove all published sites, and delete all previews? Only Github repo
+                   administrators can use this feature."
+          alertRole={false}
+        >
+          <button disabled={submitting} className="usa-button usa-button-red" type="submit">
+            Delete
+          </button>
+        </AlertBanner>
+      </fieldset>
+    </div>
+  </form>
+);
+
+DeleteSiteForm.propTypes = {
+  siteId: PropTypes.number.isRequired,
+
+  // the following props are from reduxForm:
+  handleSubmit: PropTypes.func.isRequired,
+  submitting: PropTypes.bool.isRequired,
+};
+
+// create a higher-order component with reduxForm and export that
+export default reduxForm({ form: 'deleteSite' })(DeleteSiteForm);

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -16,13 +16,13 @@ class SiteSettings extends React.Component {
     autoBind(this, 'handleUpdate', 'handleDelete', 'handleCopySite');
   }
 
-  handleDelete(event) {
+  handleDelete() {
     // eslint-disable-next-line no-alert
     if (window.confirm('Are you sure you want to delete this site for all users? This action will also delete all site builds and take down the live site, if published.')) {
-      siteActions.deleteSite(this.props.site.id);
+      return siteActions.deleteSite(this.props.site.id);
     }
 
-    event.preventDefault();
+    return Promise.resolve();
   }
 
   handleUpdate(values) {

--- a/test/frontend/components/site/SiteSettings/AdvancedSiteSettings.test.jsx
+++ b/test/frontend/components/site/SiteSettings/AdvancedSiteSettings.test.jsx
@@ -21,10 +21,10 @@ describe('<AdvancedSiteSettings/>', () => {
   it('should render', () => {
     const props = makeProps();
     const wrapper = shallow(<AdvancedSiteSettings {...props} />);
-    const form = wrapper.find('ReduxForm'); // AdvancedSiteSettingsForm
+    const form = wrapper.find('ReduxForm');
 
     expect(wrapper.exists()).to.be.true;
-    expect(form).to.have.length(1);
+    expect(form).to.have.length(2);
   });
 
   describe('AdvancedSiteSettingsForm', () => {
@@ -34,14 +34,28 @@ describe('<AdvancedSiteSettings/>', () => {
     beforeEach(() => {
       props = makeProps();
       wrapper = shallow(<AdvancedSiteSettings {...props} />);
-      form = wrapper.find('ReduxForm'); // AdvancedSiteSettingsForm
+      form = wrapper.find('ReduxForm').at(0); // AdvancedSiteSettingsForm
     });
 
     it('has props passed down', () => {
-      expect(form.prop('initialValues')).to.deep.equal(props.initialValues);
-      expect(form.prop('siteId')).to.deep.equal(props.siteId);
-      expect(form.prop('onDelete')).to.deep.equal(props.onDelete);
-      expect(form.prop('onSubmit')).to.deep.equal(props.onSubmit);
+      expect(form.prop('initialValues')).to.equal(props.initialValues);
+      expect(form.prop('onSubmit')).to.equal(props.onSubmit);
+    });
+  });
+
+  describe('DeleteSiteForm', () => {
+    let props;
+    let wrapper;
+    let form;
+    beforeEach(() => {
+      props = makeProps();
+      wrapper = shallow(<AdvancedSiteSettings {...props} />);
+      form = wrapper.find('ReduxForm').at(1); // DeleteSiteForm
+    });
+
+    it('has the onDelete handler as onSubmit', () => {
+      expect(form.prop('siteId')).to.equal(props.siteId);
+      expect(form.prop('onSubmit')).to.equal(props.onDelete);
     });
   });
 });

--- a/test/frontend/components/site/SiteSettings/AdvancedSiteSettings.test.jsx
+++ b/test/frontend/components/site/SiteSettings/AdvancedSiteSettings.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+
+import { AdvancedSiteSettings } from '../../../../../frontend/components/site/SiteSettings/AdvancedSiteSettings';
+
+describe('<AdvancedSiteSettings/>', () => {
+  const makeProps = () => (
+    {
+      siteId: 9999,
+      initialValues: {
+        engine: 'jekyll',
+        config: 'boop: beep',
+      },
+      onDelete: spy(),
+      onSubmit: spy(),
+    }
+  );
+
+  it('should render', () => {
+    const props = makeProps();
+    const wrapper = shallow(<AdvancedSiteSettings {...props} />);
+    const form = wrapper.find('ReduxForm'); // AdvancedSiteSettingsForm
+
+    expect(wrapper.exists()).to.be.true;
+    expect(form).to.have.length(1);
+  });
+
+  describe('AdvancedSiteSettingsForm', () => {
+    let props;
+    let wrapper;
+    let form;
+    beforeEach(() => {
+      props = makeProps();
+      wrapper = shallow(<AdvancedSiteSettings {...props} />);
+      form = wrapper.find('ReduxForm'); // AdvancedSiteSettingsForm
+    });
+
+    it('has props passed down', () => {
+      expect(form.prop('initialValues')).to.deep.equal(props.initialValues);
+      expect(form.prop('siteId')).to.deep.equal(props.siteId);
+      expect(form.prop('onDelete')).to.deep.equal(props.onDelete);
+      expect(form.prop('onSubmit')).to.deep.equal(props.onSubmit);
+    });
+  });
+});

--- a/test/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.test.jsx
+++ b/test/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.test.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { spy } from 'sinon';
 
-import ReduxFormAdvancedSiteSettings, { AdvancedSiteSettings } from '../../../../../frontend/components/site/SiteSettings/AdvancedSiteSettings';
+import ReduxFormAdvancedSiteSettings, { AdvancedSiteSettingsForm } from '../../../../../frontend/components/site/SiteSettings/AdvancedSiteSettingsForm';
 
-describe('<AdvancedSiteSettings/>', () => {
+describe('<AdvancedSiteSettingsForm/>', () => {
   const makeProps = () => (
     {
       initialValues: {
@@ -25,7 +25,7 @@ describe('<AdvancedSiteSettings/>', () => {
 
   it('should render', () => {
     const props = makeProps();
-    const wrapper = shallow(<AdvancedSiteSettings {...props} />);
+    const wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
     const alertBanner = wrapper.find('AlertBanner');
 
     expect(wrapper.exists()).to.be.true;
@@ -42,20 +42,20 @@ describe('<AdvancedSiteSettings/>', () => {
 
   it('should have its buttons disabled when pristine', () => {
     const props = makeProps();
-    let wrapper = shallow(<AdvancedSiteSettings {...props} />);
+    let wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
     expect(wrapper.exists()).to.be.true;
     expect(wrapper.find('button.usa-button-secondary').prop('disabled')).to.be.true;
     expect(wrapper.find('button[type="submit"]').prop('disabled')).to.be.true;
 
     props.pristine = false;
-    wrapper = shallow(<AdvancedSiteSettings {...props} />);
+    wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
     expect(wrapper.find('button.usa-button-secondary').prop('disabled')).to.be.false;
     expect(wrapper.find('button[type="submit"]').prop('disabled')).to.be.false;
   });
 
   it('should call onDelete when Delete button is clicked', () => {
     const props = makeProps();
-    const wrapper = shallow(<AdvancedSiteSettings {...props} />);
+    const wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
 
     const deleteButton = wrapper.find('button.usa-button-red');
     expect(props.onDelete.called).to.be.false;
@@ -66,7 +66,7 @@ describe('<AdvancedSiteSettings/>', () => {
   it('should call reset when Reset button is clicked', () => {
     const props = makeProps();
     props.pristine = false;
-    const wrapper = shallow(<AdvancedSiteSettings {...props} />);
+    const wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
     const resetButton = wrapper.find('button.usa-button-secondary');
 
     expect(props.reset.called).to.be.false;
@@ -77,7 +77,7 @@ describe('<AdvancedSiteSettings/>', () => {
   it('should call handleSubmit when form is submitted', () => {
     const props = makeProps();
     props.pristine = false;
-    const wrapper = shallow(<AdvancedSiteSettings {...props} />);
+    const wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
     const form = wrapper.find('form');
 
     expect(props.handleSubmit.called).to.be.false;

--- a/test/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.test.jsx
+++ b/test/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.test.jsx
@@ -12,7 +12,6 @@ describe('<AdvancedSiteSettingsForm/>', () => {
         engine: 'jekyll',
         config: 'boop: beep',
       },
-      onDelete: spy(),
       handleSubmit: spy(),
       reset: spy(),
       pristine: true,
@@ -26,7 +25,6 @@ describe('<AdvancedSiteSettingsForm/>', () => {
   it('should render', () => {
     const props = makeProps();
     const wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
-    const alertBanner = wrapper.find('AlertBanner');
 
     expect(wrapper.exists()).to.be.true;
     expect(wrapper.find('Field')).to.have.length(4);
@@ -34,10 +32,6 @@ describe('<AdvancedSiteSettingsForm/>', () => {
     expect(wrapper.find('Field[name="config"]').exists()).to.be.true;
     expect(wrapper.find('Field[name="demoConfig"]').exists()).to.be.true;
     expect(wrapper.find('Field[name="previewConfig"]').exists()).to.be.true;
-    expect(alertBanner).to.have.length(1);
-    expect(alertBanner.prop('header')).to.be.defined;
-    expect(alertBanner.prop('message')).to.be.defined;
-    expect(alertBanner.prop('alertRole')).to.be.false;
   });
 
   it('should have its buttons disabled when pristine', () => {
@@ -51,16 +45,6 @@ describe('<AdvancedSiteSettingsForm/>', () => {
     wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
     expect(wrapper.find('button.usa-button-secondary').prop('disabled')).to.be.false;
     expect(wrapper.find('button[type="submit"]').prop('disabled')).to.be.false;
-  });
-
-  it('should call onDelete when Delete button is clicked', () => {
-    const props = makeProps();
-    const wrapper = shallow(<AdvancedSiteSettingsForm {...props} />);
-
-    const deleteButton = wrapper.find('button.usa-button-red');
-    expect(props.onDelete.called).to.be.false;
-    deleteButton.simulate('click');
-    expect(props.onDelete.calledOnce).to.be.true;
   });
 
   it('should call reset when Reset button is clicked', () => {

--- a/test/frontend/components/site/SiteSettings/DeleteSiteForm.test.jsx
+++ b/test/frontend/components/site/SiteSettings/DeleteSiteForm.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+
+import ReduxFormDeleteForm, { DeleteSiteForm } from '../../../../../frontend/components/site/SiteSettings/DeleteSiteForm';
+
+describe('<DeleteSiteForm/>', () => {
+  it('should export a ReduxForm-connected component', () => {
+    expect(ReduxFormDeleteForm).to.not.be.null;
+  });
+
+  describe('given default props', () => {
+    const makeProps = () => (
+      {
+        handleSubmit: spy(),
+      }
+    );
+
+    let props;
+    let wrapper;
+    beforeEach(() => {
+      props = makeProps();
+      wrapper = shallow(<DeleteSiteForm {...props} />);
+    });
+
+    it('should render', () => {
+      expect(wrapper.exists()).to.be.true;
+    });
+
+    it('should render alert banner', () => {
+      const alertBanner = wrapper.find('AlertBanner');
+      expect(alertBanner).to.have.length(1);
+      expect(alertBanner.prop('header')).to.be.defined;
+      expect(alertBanner.prop('message')).to.be.defined;
+      expect(alertBanner.prop('alertRole')).to.be.false;
+    });
+
+    it('renders delete button as enabled', () => {
+      const deleteButton = wrapper.find('button[type="submit"]');
+      expect(deleteButton.prop('disabled')).to.not.be.ok;
+    });
+
+    it('should call handleSubmit when submitted', () => {
+      expect(props.handleSubmit.called).to.be.false;
+      wrapper.find('form').simulate('submit');
+      expect(props.handleSubmit.calledOnce).to.be.true;
+    });
+  });
+
+  it('should render delete button as disabled when submitting', () => {
+    const props = {
+      submitting: true,
+      handleSubmit: spy(),
+    };
+    const wrapper = shallow(<DeleteSiteForm {...props} />);
+
+    const deleteButton = wrapper.find('button[type="submit"]');
+    expect(deleteButton.prop('disabled')).to.be.true;
+  });
+});

--- a/test/frontend/components/site/SiteSettings/SiteSettings.test.jsx
+++ b/test/frontend/components/site/SiteSettings/SiteSettings.test.jsx
@@ -74,11 +74,9 @@ describe('<SiteSettings/>', () => {
     global.window = { confirm: () => true };
 
     expect(siteActionsMock.deleteSite.called).to.be.false;
-    const mockEvent = { preventDefault: spy() };
-    wrapper.instance().handleDelete(mockEvent);
+    wrapper.instance().handleDelete();
     expect(siteActionsMock.deleteSite.calledOnce).to.be.true;
     expect(siteActionsMock.deleteSite.calledWith(props.site.id)).to.be.true;
-    expect(mockEvent.preventDefault.calledOnce).to.be.true;
   });
 
   it('calls the addSite action', () => {

--- a/test/frontend/components/site/SiteSettings/SiteSettings.test.jsx
+++ b/test/frontend/components/site/SiteSettings/SiteSettings.test.jsx
@@ -53,7 +53,8 @@ describe('<SiteSettings/>', () => {
 
   it('should render', () => {
     expect(wrapper.exists()).to.be.true;
-    expect(wrapper.find('ReduxForm')).to.have.length(3);
+    expect(wrapper.find('AdvancedSiteSettings')).to.have.length(1);
+    expect(wrapper.find('ReduxForm')).to.have.length(2);
   });
 
   it('should not render if site prop is not defined', () => {


### PR DESCRIPTION
I moved the delete button into its own form so that Redux Forms would handle the state for us.

Fixes #1922 

![peek 2018-08-13 16-11](https://user-images.githubusercontent.com/509703/44063913-7c7bb3e0-9f17-11e8-97b7-9244a2e31636.gif)
