### PR TITLE
Fix footer nav spacing on medium screens

### DIFF
--- a/frontend/sass/_footer.scss
+++ b/frontend/sass/_footer.scss
@@ -69,18 +69,15 @@
     width: 17px;
   }
 }
-@media screen and (min-width: 600px) {
-  .usa-width-one-sixth:nth-child(3n) {
-    margin-right: 4.82916%;
-  }
-}
 
-li.usa-footer-primary-content,
-li.usa-footer-primary-content:last-child {
-  border: none;
+li.usa-footer-primary-content {
+  border: none !important; // override uswds border on :last-child
+  margin-left: 5%;
 }
 
 @media screen and (max-width: 600px) {
+  // With all these custom rules, we may just want to ditch USWDS for the
+  // footer and make these custom classes
   .usa-footer-primary-section {
     .usa-unstyled-list {
       text-align: left;


### PR DESCRIPTION
#1949

Footer nav links squash together without padding or margin on medium screens
(>600px <1200px).

Logged out at ~620px
![screenshot from 2018-09-06 15-42-43](https://user-images.githubusercontent.com/509703/45188975-89ac4700-b1eb-11e8-86b6-56707eb81966.png)

Logged in at ~800px
![screenshot from 2018-09-06 15-42-10](https://user-images.githubusercontent.com/509703/45188985-97fa6300-b1eb-11e8-806f-17290c30b87c.png)
