### PR TITLE
2069 rename static site engine to site engine

### DIFF
--- a/config/local.sample.js
+++ b/config/local.sample.js
@@ -12,5 +12,7 @@ if (process.env.NODE_ENV !== 'test') {
         ],
       },
     },
+    s3: {},
+    sqs: {},
   };
 }

--- a/frontend/components/AddSite/AddRepoSiteForm.jsx
+++ b/frontend/components/AddSite/AddRepoSiteForm.jsx
@@ -44,7 +44,7 @@ export const AddRepoSiteForm = ({
       <div className="add-repo-site-additional-fields">
         {showNewSiteAlert()}
         <div className="form-group">
-          <label htmlFor="engine">Static site engine</label>
+          <label htmlFor="engine">Site engine</label>
           <Field
             name="engine"
             id="engine"

--- a/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.jsx
+++ b/frontend/components/site/SiteSettings/AdvancedSiteSettingsForm.jsx
@@ -16,7 +16,7 @@ export const AdvancedSiteSettingsForm = ({
 }) => (
   <form className="settings-form settings-form-advanced" onSubmit={handleSubmit}>
     <div className="well">
-      <label htmlFor="engine">Static site engine</label>
+      <label htmlFor="engine">Site engine</label>
       <Field
         name="engine"
         id="engine"

--- a/views/features.njk
+++ b/views/features.njk
@@ -104,7 +104,7 @@
               </div>
               <div class="feature-text">
                 <h5>Customization</h5>
-                <p>Use a static site generator like Jekyll, Hugo, or other tools to deploy custom site designs through Federalist.</p>
+                <p>Use a site generator like Jekyll, Hugo, or other tools to deploy custom site designs through Federalist.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Added stubs for S3 creds for local development config (addresses an issue when i had when firing up the app for the first time)
- Changed from `Static site engine` to `Site engine` in UI and features nunjucks.