### PR TITLE
Keep the footer where it belongs

### DIFF
--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -47,13 +47,18 @@ $image-path: '../../node_modules/uswds/src/img';
 }
 
 .usa-grid.site {
+  height: inherit;
   padding-left: 0;
   padding-right: 0;
 }
 
 #js-app {
+  height: 100%;
   max-width: 1040px;
   margin: 0 auto;
+  > [data-reactroot] {
+    height: inherit;
+  }
 }
 
 .main-loader {
@@ -65,6 +70,7 @@ $image-path: '../../node_modules/uswds/src/img';
 
 .site-main {
   background-color: white;
+  height: inherit;
   padding-bottom: 5rem;
 }
 
@@ -82,7 +88,7 @@ $image-path: '../../node_modules/uswds/src/img';
   left: 0;
   position: fixed;
   top: 0;
-  width: 18%;
+  width: 50%;
   z-index: -1;
 }
 

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -36,16 +36,17 @@ $image-path: '../../node_modules/uswds/src/img';
 @import "template-items";
 @import "_footer";
 
-html,
-body,
-main,
-.usa-grid.site,
-div[data-reactroot=''] {
-  height: 100%;
+.body {
+  display: flex;
+  flex-flow: column nowrap;
+  min-height: 100vh;
+}
+
+.main-content {
+  flex-grow: 1;
 }
 
 .usa-grid.site {
-  height: 100vh;
   padding-left: 0;
   padding-right: 0;
 }
@@ -53,8 +54,6 @@ div[data-reactroot=''] {
 #js-app {
   max-width: 1040px;
   margin: 0 auto;
-  margin-bottom: $spacing-xxl;
-  min-height: 100%;
 }
 
 .main-loader {
@@ -66,7 +65,6 @@ div[data-reactroot=''] {
 
 .site-main {
   background-color: white;
-  min-height: 100%;
   padding-bottom: 5rem;
 }
 
@@ -84,7 +82,7 @@ div[data-reactroot=''] {
   left: 0;
   position: fixed;
   top: 0;
-  width: 50%;
+  width: 18%;
   z-index: -1;
 }
 

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -82,16 +82,6 @@ $image-path: '../../node_modules/uswds/src/img';
   margin-left: 2em;
 }
 
-.usa-grid.site:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  position: fixed;
-  top: 0;
-  width: 50%;
-  z-index: -1;
-}
-
 @media screen and (max-width: $mobile-size) {
   .flex-center {
     align-items: center;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -82,6 +82,16 @@ $image-path: '../../node_modules/uswds/src/img';
   margin-left: 2em;
 }
 
+.usa-grid.site:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 50%;
+  z-index: -1;
+}
+
 @media screen and (max-width: $mobile-size) {
   .flex-center {
     align-items: center;

--- a/views/base.njk
+++ b/views/base.njk
@@ -65,7 +65,7 @@
     {% block head_extra %}
     {% endblock %}
   </head>
-  <body>
+  <body class="body">
     {% if shouldIncludeTracking %}
       <!-- Google Tag Manager (noscript) -->
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PRPJKWN"
@@ -94,8 +94,10 @@
       {% endif %}
     {% endblock %}
 
-    {% block main_content %}
-    {% endblock %}
+    <div class="main-content">
+      {% block main_content %}
+      {% endblock %}
+    </div>
 
     <footer class="usa-footer usa-footer-medium" role="contentinfo">
       <div class="usa-footer-secondary_section">


### PR DESCRIPTION
Addresses #2104 and #2105.

Updated the layout, such that:
- The entire app has a minimum height of the screen
- The main section of the app will stretch to accommodate content while the banner, header, and footer remain a fixed height
- The blue background behind the left nav is an appropriate width