### PR TITLE
2103 tables and horizontal space

### DIFF
--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -157,14 +157,14 @@ class SiteBuilds extends React.Component {
 
                   return (
                     <tr key={build.id}>
-                      <td scope="row">
+                      <th scope="row">
                         <div className="truncate">
                           { build.branch }
                         </div>
                         { SiteBuilds.commitLink(build) }
                         { previewBuilds[build.branch] === build.id &&
                         <BranchViewLink branchName={build.branch} site={site} showIcon /> }
-                      </td>
+                      </th>
                       <td>{ SiteBuilds.getUsername(build) }</td>
                       <td>{ timeFrom(build.completedAt) }</td>
                       <td>{ duration(build.createdAt, build.completedAt) }</td>

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -120,12 +120,12 @@ class SiteBuilds extends React.Component {
             >
               Auto Refresh: <b>{autoRefresh ? 'ON' : 'OFF'}</b>
             </a>
+            <RefreshBuildsButton site={site} />
           </div>
-          <RefreshBuildsButton site={site} />
         </div>
         { builds.isLoading ?
           <LoadingIndicator /> :
-          <div>
+          <div className="table-container">
             <table
               className="usa-table-borderless log-table log-table__site-builds table-full-width"
             >
@@ -157,13 +157,14 @@ class SiteBuilds extends React.Component {
 
                   return (
                     <tr key={build.id}>
-                      <th scope="row">
-                        { build.branch }
+                      <td scope="row">
+                        <div className="truncate">
+                          { build.branch }
+                        </div>
                         { SiteBuilds.commitLink(build) }
-                        { previewBuilds[build.branch] === build.id && <br /> }
                         { previewBuilds[build.branch] === build.id &&
                         <BranchViewLink branchName={build.branch} site={site} showIcon /> }
-                      </th>
+                      </td>
                       <td>{ SiteBuilds.getUsername(build) }</td>
                       <td>{ timeFrom(build.completedAt) }</td>
                       <td>{ duration(build.createdAt, build.completedAt) }</td>

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -112,9 +112,9 @@ export class SiteContainer extends React.Component {
             fileName={params.fileName}
             viewLink={site.viewLink}
           />
-          <div className="">
-            {children}
-          </div>
+
+          {children}
+
         </div>
       </div>
     );

--- a/frontend/sass/_log-tools.scss
+++ b/frontend/sass/_log-tools.scss
@@ -1,6 +1,11 @@
 .log-tools {
-  float: right;
+  display: flex;
+  justify-content: flex-end;
   text-align: right;
+
+  a {
+    display: block;
+  }
 
   :last-child {
     margin-right: 0;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -47,13 +47,18 @@ $image-path: '../../node_modules/uswds/src/img';
 }
 
 .usa-grid.site {
+  height: inherit;
   padding-left: 0;
   padding-right: 0;
 }
 
 #js-app {
+  height: 100%;
   max-width: 1040px;
   margin: 0 auto;
+  > [data-reactroot] {
+    height: inherit;
+  }
 }
 
 .main-loader {
@@ -65,6 +70,7 @@ $image-path: '../../node_modules/uswds/src/img';
 
 .site-main {
   background-color: white;
+  height: inherit;
   padding-bottom: 5rem;
 }
 
@@ -82,7 +88,7 @@ $image-path: '../../node_modules/uswds/src/img';
   left: 0;
   position: fixed;
   top: 0;
-  width: 18%;
+  width: 50%;
   z-index: -1;
 }
 

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -134,3 +134,14 @@ $image-path: '../../node_modules/uswds/src/img';
     display: none;
   }
 }
+
+.table-container {
+  overflow-x: scroll;
+}
+
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 150px;
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -36,16 +36,17 @@ $image-path: '../../node_modules/uswds/src/img';
 @import "template-items";
 @import "_footer";
 
-html,
-body,
-main,
-.usa-grid.site,
-div[data-reactroot=''] {
-  height: 100%;
+.body {
+  display: flex;
+  flex-flow: column nowrap;
+  min-height: 100vh;
+}
+
+.main-content {
+  flex-grow: 1;
 }
 
 .usa-grid.site {
-  height: 100vh;
   padding-left: 0;
   padding-right: 0;
 }
@@ -53,8 +54,6 @@ div[data-reactroot=''] {
 #js-app {
   max-width: 1040px;
   margin: 0 auto;
-  margin-bottom: $spacing-xxl;
-  min-height: 100%;
 }
 
 .main-loader {
@@ -66,7 +65,6 @@ div[data-reactroot=''] {
 
 .site-main {
   background-color: white;
-  min-height: 100%;
   padding-bottom: 5rem;
 }
 
@@ -84,7 +82,7 @@ div[data-reactroot=''] {
   left: 0;
   position: fixed;
   top: 0;
-  width: 50%;
+  width: 18%;
   z-index: -1;
 }
 

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -82,16 +82,6 @@ $image-path: '../../node_modules/uswds/src/img';
   margin-left: 2em;
 }
 
-.usa-grid.site:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  position: fixed;
-  top: 0;
-  width: 50%;
-  z-index: -1;
-}
-
 @media screen and (max-width: $mobile-size) {
   .flex-center {
     align-items: center;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -82,6 +82,16 @@ $image-path: '../../node_modules/uswds/src/img';
   margin-left: 2em;
 }
 
+.usa-grid.site:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 50%;
+  z-index: -1;
+}
+
 @media screen and (max-width: $mobile-size) {
   .flex-center {
     align-items: center;

--- a/views/base.njk
+++ b/views/base.njk
@@ -65,7 +65,7 @@
     {% block head_extra %}
     {% endblock %}
   </head>
-  <body>
+  <body class="body">
     {% if shouldIncludeTracking %}
       <!-- Google Tag Manager (noscript) -->
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PRPJKWN"
@@ -94,8 +94,10 @@
       {% endif %}
     {% endblock %}
 
-    {% block main_content %}
-    {% endblock %}
+    <div class="main-content">
+      {% block main_content %}
+      {% endblock %}
+    </div>
 
     <footer class="usa-footer usa-footer-medium" role="contentinfo">
       <div class="usa-footer-secondary_section">


### PR DESCRIPTION
Allow builds table to scroll horizontally when necessary and limit width of repo name.
Limits the width of that table cell to 150 px, we can change this if its too short/long.

Depends on #2113 

<img width="1280" alt="screen shot 2019-01-25 at 5 15 43 pm" src="https://user-images.githubusercontent.com/6662371/51780730-bf33cd00-20c5-11e9-99a5-0e956ed47b1a.png">
