### PR TITLE
More robust error message

### DIFF
--- a/frontend/components/alertBanner.js
+++ b/frontend/components/alertBanner.js
@@ -26,7 +26,17 @@ const AlertBanner = ({ children, header, message, status, alertRole }) => {
     return null;
   }
 
-  const msg = status === 'error' ? 'We are experiencing a problem, please refresh the page in a few moments. If this error persists, please contact us.' : message;
+  const errorMsg =
+    <span>
+      We are experiencing an unexpected problem, please wait a few moments and try the following:
+      <ol>
+        <li>refresh the page</li>
+        <li>log out and back in to your account</li>
+      </ol>
+      If this error persists, please contact us, we apologize for the inconvenience.
+    </span>
+
+  const msg = status === 'error' ? errorMsg : message;
 
   return (
     <div


### PR DESCRIPTION
1. The one avenue I thought we could pursue is a dead-end since Connection is a Forbidden header [MDN](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name).
2. Since the error should not occur with zero-downtime deploys and logging out SEEMS to work, I updated the error message to be a bit more descriptive. It is a bit long though (See below)
3. If users report this as an issue, then we can revisit, but I don't this it is high priority right now.

![screen shot 2019-01-29 at 9 55 35 am](https://user-images.githubusercontent.com/6662371/51929018-1bd80600-23ac-11e9-8a80-2ca899388b61.png)
