### PR TITLE
remove whitespace, add extra bottom padding on site list

### DIFF
--- a/frontend/components/siteList/siteList.js
+++ b/frontend/components/siteList/siteList.js
@@ -63,7 +63,7 @@ export const SiteList = ({ sites, alert }) =>
 
     <AlertBanner {...alert} />
     {getSites(sites)}
-    <a href="#top">Return to top</a>
+    <a href="#top" className="back-to-top">Return to top</a>
   </div>;
 
 SiteList.propTypes = {

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -70,7 +70,6 @@ $image-path: '../../node_modules/uswds/src/img';
 
 .site-main {
   background-color: white;
-  height: inherit;
   padding-bottom: 5rem;
 }
 
@@ -90,6 +89,12 @@ $image-path: '../../node_modules/uswds/src/img';
   top: 0;
   width: 50%;
   z-index: -1;
+}
+
+.back-to-top {
+  display: block;
+  padding-bottom: 5rem;
+  padding-top: 2rem;
 }
 
 @media screen and (max-width: $mobile-size) {
@@ -120,6 +125,7 @@ $image-path: '../../node_modules/uswds/src/img';
   }
 
   .site-main {
+    height: inherit;
     padding-left: 3rem;
   }
 


### PR DESCRIPTION
## Removed white space below footer on mobile, added padding below site list, desktop is unchanged.

### Before
![screen shot 2019-02-26 at 10 08 47 am](https://user-images.githubusercontent.com/6662371/53435815-86319580-39ae-11e9-9943-fab3e80c1e87.png)

### After
![screen shot 2019-02-26 at 10 06 48 am](https://user-images.githubusercontent.com/6662371/53435733-51bdd980-39ae-11e9-8983-64c66aec3911.png)

## Extra padding below site list
### Before
![screen shot 2019-02-26 at 10 08 04 am](https://user-images.githubusercontent.com/6662371/53435786-76b24c80-39ae-11e9-94b2-24796ddef9c5.png)

### After
![screen shot 2019-02-26 at 10 07 00 am](https://user-images.githubusercontent.com/6662371/53435740-5aaeab00-39ae-11e9-9594-d378bb185636.png)
