### PR TITLE
Prevent default like a boss

### DIFF
--- a/frontend/components/site/NotificationSettings.jsx
+++ b/frontend/components/site/NotificationSettings.jsx
@@ -17,7 +17,8 @@ class NotificationSettings extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
-  handleSubmit() {
+  handleSubmit(e) {
+    e.preventDefault();
   // eslint-disable-next-line no-alert
     siteActions.updateSiteUser(this.props.site.id, { buildNotificationSetting: this.state.value });
   }


### PR DESCRIPTION
Prevent Default on the event, so a navigation event doesn't happen that cancels the request. Special thanks to @rahearn !