### PR TITLE
serve static files without session/auth

### DIFF
--- a/api/services/devMiddleware.js
+++ b/api/services/devMiddleware.js
@@ -1,0 +1,11 @@
+/* eslint-disable global-require */
+module.exports = () => {
+  const webpack = require('webpack');
+  const webpackDevMiddleware = require('webpack-dev-middleware');
+  const webpackConfig = require('../../webpack.development.config.js');
+  const compiler = webpack(webpackConfig);
+
+  return webpackDevMiddleware(compiler, {
+    publicPath: webpackConfig.output.publicPath,
+  });
+}

--- a/api/services/devMiddleware.js
+++ b/api/services/devMiddleware.js
@@ -8,4 +8,4 @@ module.exports = () => {
   return webpackDevMiddleware(compiler, {
     publicPath: webpackConfig.output.publicPath,
   });
-}
+};

--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ const responses = require('./api/responses');
 const passport = require('./api/services/passport');
 const RateLimit = require('express-rate-limit');
 const router = require('./api/routers');
+const devMiddleware = require('./api/services/devMiddleware');
 const SocketIOSubscriber = require('./api/services/SocketIOSubscriber');
 const jwtHelper = require('./api/services/jwtHelper');
 const FederalistUsersHelper = require('./api/services/FederalistUsersHelper');
@@ -54,30 +55,17 @@ nunjucks.configure('views', {
 // able to access the requesting user's IP in req.ip, so
 // 'trust proxy' must be enabled.
 app.enable('trust proxy');
-const sessionMiddleware = session(config.session);
-app.use(sessionMiddleware);
+app.use(express.static('public'));
+if (process.env.NODE_ENV === 'development') {
+  app.use(devMiddleware());
+}
+app.use(session(config.session));
 app.use(passport.initialize());
 app.use(passport.session());
 app.use((req, res, next) => {
   res.locals.user = req.user;
   return next();
 });
-
-app.use(express.static('public'));
-
-/* eslint-disable global-require */
-if (process.env.NODE_ENV === 'development') {
-  const webpack = require('webpack');
-  const webpackDevMiddleware = require('webpack-dev-middleware');
-  const webpackConfig = require('./webpack.development.config.js');
-  const compiler = webpack(webpackConfig);
-
-  app.use(webpackDevMiddleware(compiler, {
-    publicPath: webpackConfig.output.publicPath,
-  }));
-}
-/* eslint-enable global-require */
-
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json({ limit: '2mb' }));
 app.use(methodOverride());


### PR DESCRIPTION
Serving static files before handling session and authentication. This results in all static files being publicly available and therefore not behind authentication. This is the standard setup, however, given the status quo, its possible, but unlikely, that are now exposing files that we don't want.

This should have the effect of greatly reducing the number of database calls as each time we check the session and authenticate we make a handful of calls.

Also refactors the webpack dev middleware into its own file.

