### PR TITLE
Use a regex to detect specific message

### DIFF
--- a/frontend/components/alertBanner.js
+++ b/frontend/components/alertBanner.js
@@ -21,22 +21,24 @@ const addRole = (shouldAddRole) => {
   return {};
 };
 
+const genericErrorMsg = (
+  <span>
+    We are experiencing an unexpected problem, please wait a few moments and try the following:
+    <ol>
+      <li>refresh the page</li>
+      <li>log out and back in to your account</li>
+    </ol>
+    If this error persists, please contact us, we apologize for the inconvenience.
+</span>);
+
+const cloudDotGovErrorRegex = /^404 Not Found: Requested route \('.*'\) does not exist./;
+
 const AlertBanner = ({ children, header, message, status, alertRole }) => {
   if (!message) {
     return null;
   }
 
-  const errorMsg = (
-    <span>
-      We are experiencing an unexpected problem, please wait a few moments and try the following:
-      <ol>
-        <li>refresh the page</li>
-        <li>log out and back in to your account</li>
-      </ol>
-      If this error persists, please contact us, we apologize for the inconvenience.
-  </span>);
-
-  const msg = status === 'error' ? errorMsg : message;
+  const msg = cloudDotGovErrorRegex.test(message) ? genericErrorMsg : message;
 
   return (
     <div


### PR DESCRIPTION
Using a VERY generic regex to identify the following messages:

`404 Not Found: Requested route ('federalistapp-staging.18f.gov') does not exist.`
`404 Not Found: Requested route ('federalistapp.18f.gov') does not exist.`

This can be expanded or restricted if necessary.

I *think* this was the message we were getting from Cloud.gov before, but am not 100% sure. We will need to test this in an actual cloud.gov environment to see if it works.