### PR TITLE
Updates to nav, footer

### DIFF
--- a/frontend/sass/_footer.scss
+++ b/frontend/sass/_footer.scss
@@ -19,7 +19,7 @@
 .usa-footer {
   position: inherit;
   width: 100%;
-  bottom: 0;  
+  bottom: 0;
   .usa-footer-primary-link {
     color: $color-white;
     font-weight: $font-weight-normal;
@@ -105,6 +105,26 @@ li.usa-footer-primary-content {
         .usa-footer-primary-link {
           padding-top: 0;
         }
+      }
+    }
+  }
+}
+
+.usa-footer .usa-nav-primary {
+  display: block;
+  margin-bottom: 1rem;
+
+  li:first-child .usa-nav-link {
+    padding-left: 1rem;
+  }
+
+  .usa-nav-link {
+    font-size: 1.75rem;
+
+    &:hover {
+      border: none;
+      span {
+        border: none;
       }
     }
   }

--- a/views/base.njk
+++ b/views/base.njk
@@ -103,6 +103,23 @@
       <div class="usa-footer-secondary_section">
         <div class="usa-grid">
           <div class="usa-footer-contact-links usa-width-one-half">
+            <ul class="usa-nav-primary">
+              <li>
+                <a class="usa-nav-link" href="{{ homepageUrl }}/features/">
+                  <span>Features</span>
+                </a>
+              </li>
+              <li>
+                <a class="usa-nav-link" href="{{ homepageUrl }}/success-stories/">
+                  <span>Success Stories</span>
+                </a>
+              </li>
+              <li>
+                <a class="usa-nav-link" href="{{ homepageUrl }}/contact/">
+                  <span>Contact<span>
+                </a>
+              </li>
+            </ul>
             <div class="usa-footer-primary-content usa-footer-contact_info">
               <p>
                 <a href="https://github.com/18F/federalist/">

--- a/views/navigation.njk
+++ b/views/navigation.njk
@@ -15,39 +15,24 @@
           <img src="/images/close.svg" alt="close">
         </button>
         <ul class="usa-nav-primary">
+          {% if isAuthenticated %}
+            <li>
+              <a class="usa-nav-link" href="{{ homepageUrl }}/">
+                <span>Sites</span>
+              </a>
+            </li>
+          {% endif %}
           <li>
-            <a class="usa-nav-link" href="{{ homepageUrl }}/">
-              <span>Home</span>
+            <a class="usa-nav-link" href="{{ homepageUrl }}/documentation/">
+              <span>Documentation<span>
             </a>
           </li>
           <li>
-            <a class="usa-nav-link" href="{{ homepageUrl }}/features/">
-              <span>Features</span>
-            </a>
-          </li>
-          <li>
-            <a class="usa-nav-link" href="{{ homepageUrl }}/case-studies/">
-              <span>Case Studies</span>
-            </a>
-          </li>
-          <li>
-            <a class="usa-nav-link" href="{{ homepageUrl }}/pages/using-federalist/">
+            <a class="usa-nav-link" href="{{ homepageUrl }}/support/">
               <span>Support<span>
             </a>
           </li>
-          <li>
-            <a class="usa-nav-link" href="{{ homepageUrl }}/contact/">
-              <span>Contact<span>
-            </a>
-          </li>
-
           {% if isAuthenticated %}
-            <li>
-              <a class="usa-nav-link" href="/sites">
-                <span>Manage Sites</span>
-              </a>
-            </li>
-          </li>
           <li class="nav-action">
             <a class="usa-button usa-button-white" href="/logout">Log out</a>
           </li>


### PR DESCRIPTION
Resolves #2118 

1) Move "Features", "Success Stories" (formerly "Case Studies"), "Contact" from nav to footer
2) Rename "Home" to "Sites", and it only appears when authenticated. I originally removed "Home" but felt it was clearer to have it there and renamed.
3) Added separate "Documentation" and "Support" links to nav
4) Updated links to match new urls from https://github.com/18F/federalist.18f.gov/pull/289

Images below:

### Nav (not authenticated)
<img width="1280" alt="nav - not authenticated" src="https://user-images.githubusercontent.com/6662371/55116680-5b1d8d00-50a5-11e9-8857-0203d9396a89.png">

### Nav (authenticated)
<img width="1280" alt="nav - authenticated" src="https://user-images.githubusercontent.com/6662371/55116679-5b1d8d00-50a5-11e9-8ffc-c2921f9fb877.png">

### Footer
<img width="1280" alt="footer" src="https://user-images.githubusercontent.com/6662371/55116681-5b1d8d00-50a5-11e9-87c0-217326530216.png">
