### PR TITLE
Updated branch table styles to be more inline with build table

### DIFF
--- a/frontend/components/site/SiteGitHubBranches.jsx
+++ b/frontend/components/site/SiteGitHubBranches.jsx
@@ -26,14 +26,12 @@ export class SiteGitHubBranches extends React.Component {
 
     return (
       <span>
-        <BranchViewLink branchName={name} site={this.props.site} />
         <CreateBuildLink
           handlerParams={{ commit: commit.sha, branch: name, siteId: this.props.site.id }}
           handleClick={buildActions.createBuild}
           className="usa-button usa-button-secondary"
         >
-          <br />
-          Rebuild branch
+          Rebuild
         </CreateBuildLink>
       </span>
     );
@@ -45,8 +43,13 @@ export class SiteGitHubBranches extends React.Component {
     return (
       <tr key={name}>
         <td>
-          <GitHubLink text={name} owner={owner} repository={repository} branch={name} />
+          <span className="commit-link">
+            <GitHubLink text={name} owner={owner} repository={repository} branch={name} />
+          </span>
           { isDefault && ' (live branch)' }{ isDemo && ' (demo branch)' }
+          <div className="branch-link">
+            { isLinkable(name) && <BranchViewLink branchName={name} site={this.props.site} showIcon />}
+          </div>
         </td>
         <td className="table-actions">
           {this.renderRowActions(name, commit)}

--- a/frontend/sass/_tables.scss
+++ b/frontend/sass/_tables.scss
@@ -8,7 +8,7 @@
   }
 }
 
-.log-table {
+.table-full-width.log-table {
   font-size: 1.45rem;
 
   pre {
@@ -32,6 +32,11 @@
 
   th, td {
     min-width: 124px;
+    padding: 1.5rem 1rem;
+  }
+
+  .branch-link {
+    margin-top: 1.5rem;
   }
 }
 
@@ -46,8 +51,6 @@
   }
 
   .commit-link {
-    font-weight: bold;
-
     * {
       vertical-align: top;
     }

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -158,3 +158,7 @@ $image-path: '../../node_modules/uswds/src/img';
     width: 83%;
   }
 }
+
+.commit-link {
+  font-weight: bold;
+}


### PR DESCRIPTION
<img width="872" alt="Screen Shot 2019-04-08 at 5 14 37 PM" src="https://user-images.githubusercontent.com/6662371/55764767-d8d88580-5a21-11e9-8277-db4f14091c1a.png">
