### PR TITLE
upgrade sequelize to 5.7

### DIFF
--- a/api/models/index.js
+++ b/api/models/index.js
@@ -12,7 +12,7 @@ const sequelize = new Sequelize(database, username, password, {
   dialect: 'postgres',
   host: postgresConfig.host,
   port: postgresConfig.port,
-  logging: databaseLogger.info,
+  logging: databaseLogger.info.bind(databaseLogger),
 });
 /* eslint-disable no-unused-vars */
 const Build = sequelize.import(path.join(__dirname, '/build'));

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pg": "^7.8.2",
     "pg-native": "^3.0.0",
     "rc": "^1.2.8",
-    "sequelize": "^5.1.0",
+    "sequelize": "^5.7.0",
     "socket.io": "^2.2.0",
     "socket.io-redis": "^5.2.0",
     "underscore": "^1.8.3",

--- a/winston.js
+++ b/winston.js
@@ -14,7 +14,7 @@ const logger = winston.createLogger({
 });
 
 const databaseLogger = winston.createLogger({
-  level: 'warning',
+  level: 'warn',
   format: winston.format.combine(
     winston.format.simple(),
     winston.format.colorize()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3064,11 +3064,6 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
-
 depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -8994,15 +8989,14 @@ sequelize-pool@^1.0.2:
   dependencies:
     bluebird "^3.5.3"
 
-sequelize@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-5.1.0.tgz#b0f4edfd6dd1a1aaa7cf7e9febd0685475d18c97"
-  integrity sha512-LmjEAedMTItkIx0mcBfXVmdkkIQOc+1reuv+UpqSADGvQofZ4Sn9ElUBE8egLgCK4oWjy1Ybsju+YDAJpCv1ww==
+sequelize@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-5.7.0.tgz#3a1df3d730a5f0ad691bca620759215758825282"
+  integrity sha512-BlCq26jzsQLgxUtxchVdNNmoPoPtT3f1LpP/QEpEWhSO9rOiwWcanb6vNZtRdXkvfbwIgELzS6/RsCqJL0CHGA==
   dependencies:
     bluebird "^3.5.0"
     cls-bluebird "^2.1.0"
     debug "^4.1.1"
-    depd "^2.0.0"
     dottie "^2.0.0"
     inflection "1.12.0"
     lodash "^4.17.11"


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-11069