### PR TITLE
Add route creation and mapping when creating a site with a private bucket

### DIFF
--- a/api/services/S3SiteRemover.js
+++ b/api/services/S3SiteRemover.js
@@ -1,5 +1,6 @@
 const S3Helper = require('./S3Helper');
 const CloudFoundryAPIClient = require('../utils/cfApiClient');
+const config = require('../../config');
 
 const apiClient = new CloudFoundryAPIClient();
 /**
@@ -35,6 +36,15 @@ const deleteObjects = (s3Client, keys) => {
 
 const getKeys = (s3Client, prefix) => s3Client.listObjects(prefix)
   .then(objects => objects.map(o => o.Key));
+
+const removeInfrastructure = (site) => {
+  if (site.s3ServiceName !== config.s3.serviceName && site.awsBucketName !== config.s3.bucket) {
+    return apiClient.deleteRoute(site.awsBucketName)
+      .then(apiClient.deleteServiceInstance(site.s3ServiceName));
+  }
+
+  return Promise.resolve();
+};
 
 const removeSite = (site) => {
   const prefixes = [
@@ -72,4 +82,7 @@ const removeSite = (site) => {
     });
 };
 
-module.exports = { removeSite };
+module.exports = {
+  removeInfrastructure,
+  removeSite,
+};

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -122,13 +122,15 @@ function validateSite(params) {
 
   return apiClient.createSiteBucket(s3ServiceName)
     .then((response) => {
+      const { bucket, region } = response.entity.credentials;
       const s3 = {
         serviceName: s3ServiceName,
-        bucket: response.entity.credentials.bucket,
-        region: response.entity.credentials.region,
+        bucket,
+        region,
       };
 
-      return buildSite(params, s3);
+      return apiClient.createSiteProxyRoute(bucket)
+        .then(() => buildSite(params, s3));
     });
 }
 

--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -165,6 +165,15 @@ class CloudFoundryAPIClient {
     return this.authClient.accessToken();
   }
 
+  parser(body, resolver) {
+    try {
+      const parsed = JSON.parse(body);
+      resolver(parsed);
+    } catch (e) {
+      resolver(body);
+    }
+  }
+
   request(method, path, accessToken, json) {
     return new Promise((resolve, reject) => {
       request({
@@ -183,15 +192,8 @@ class CloudFoundryAPIClient {
         } else if (response.statusCode > 399) {
           const errorMessage = `Received status code: ${response.statusCode}`;
           reject(new Error(body || errorMessage));
-        } else if (typeof body === 'string') {
-          try {
-            const parsed = JSON.parse(body);
-            resolve(parsed);
-          } catch (e) {
-            resolve(body);
-          }
         } else {
-          resolve(body);
+          this.parser(body, resolve);
         }
       });
     });

--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -82,31 +82,18 @@ class CloudFoundryAPIClient {
         )));
   }
 
-  // TODO Check Permissions to Delete Services
-
-  // deleteS3ServiceInstance(name) {
-  //   return this.fetchServiceInstances()
-  //     .then(res => filterEntity(res, name))
-  //     .then(instance => {
-  //       return this.accessToken().then(token => this.request(
-  //         `DELETE`,
-  //         `/v2/service_instances/${instance.metadata.guid}?accepts_incomplete=true`,
-  //         token
-  //       ));
-  //     })
-  // }
-
-  // deleteServiceKey(name) {
-  //   return this.fetchServiceKeys()
-  //     .then(res => filterEntity(res, name))
-  //     .then(key => key.entity.service_instance_guid)
-  //     .then(guid => {
-  //       return this.authClient.accessToken().then(token => this.request(
-  //         `DELETE`,
-  //         `/v2/service_keys/${guid}`
-  //       ));
-  //     })
-  // }
+  deleteServiceInstance(name) {
+    return this.fetchServiceInstance(name)
+      .then(instance => this.accessToken().then(token => this.request(
+        'DELETE',
+        `/v2/service_instances/${instance.metadata.guid}?accepts_incomplete=true&recursive=true&async=true`,
+        token
+      ).then(() => ({
+        metadata: {
+          guid: instance.metadata.guid,
+        },
+      }))));
+  }
 
   fetchServiceInstance(name) {
     return this.fetchServiceInstances()
@@ -197,7 +184,12 @@ class CloudFoundryAPIClient {
           const errorMessage = `Received status code: ${response.statusCode}`;
           reject(new Error(body || errorMessage));
         } else if (typeof body === 'string') {
-          resolve(JSON.parse(body));
+          try {
+            const parsed = JSON.parse(body);
+            resolve(parsed);
+          } catch (e) {
+            resolve(body);
+          }
         } else {
           resolve(body);
         }

--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -66,6 +66,22 @@ class CloudFoundryAPIClient {
       .then(route => this.mapRoute(route.metadata.guid));
   }
 
+  deleteRoute(name) {
+    return this.accessToken()
+      .then(token => this.request(
+        'GET',
+        '/v2/routes',
+        token
+      ))
+      .then(res => filterEntity(res, name, 'host'))
+      .then(entity => this.accessToken()
+        .then(token => this.request(
+          'DELETE',
+          `/v2/routes/${entity.metadata.guid}?recursive=true&async=true`,
+          token
+        )));
+  }
+
   // TODO Check Permissions to Delete Services
 
   // deleteS3ServiceInstance(name) {

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -5,6 +5,28 @@ const moment = require('moment');
 const config = require('../../config');
 const { logger } = require('../../winston');
 
+function filterEntity(res, name, field = 'name') {
+  const filtered = res.resources.filter(item => item.entity[field] === name);
+
+  if (filtered.length === 1) return filtered[0];
+  return Promise.reject(new Error({
+    message: 'Not found',
+    name,
+    field,
+  }));
+}
+
+function firstEntity(res, name) {
+  if (res.resources.length === 0) {
+    return Promise.reject(new Error({
+      message: 'Not found',
+      name,
+    }));
+  }
+
+  return res.resources[0];
+}
+
 function generateS3ServiceName(owner, repository) {
   const format = str => str
     .toString()
@@ -71,6 +93,8 @@ function shouldIncludeTracking() {
 }
 
 module.exports = {
+  filterEntity,
+  firstEntity,
   generateS3ServiceName,
   getDirectoryFiles,
   getSiteDisplayEnv,

--- a/config/env.js
+++ b/config/env.js
@@ -1,4 +1,6 @@
 module.exports = {
+  cfDomainGuid: process.env.CF_DOMAIN_GUID || '123abc-456def-789ghi',
+  cfProxyGuid: process.env.CF_PROXY_GUID || '123abc-456def-789ghi',
   cfSpaceGuid: process.env.CF_SPACE_GUID || '123abc-456def-789ghi',
   cfOauthTokenUrl: process.env.CLOUD_FOUNDRY_OAUTH_TOKEN_URL || 'https://login.example.com/oauth/token',
   cfApiHost: process.env.CLOUD_FOUNDRY_API_HOST || 'https://api.example.com',

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -71,11 +71,15 @@ if (deployUserCreds) {
 
 // Environment Variables
 const cfSpace = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-space`);
+const cfDomain = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-domain`);
+const cfProxy = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-proxy`);
 const cfOauthTokenUrl = process.env.CLOUD_FOUNDRY_OAUTH_TOKEN_URL;
 const cfApiHost = process.env.CLOUD_FOUNDRY_API_HOST;
 
-if (cfSpace && cfOauthTokenUrl && cfApiHost) {
+if (cfSpace && cfOauthTokenUrl && cfApiHost && cfDomain && cfProxy) {
   module.exports.env = {
+    cfDomainGuid: cfDomain.guid,
+    cfProxyGuid: cfProxy.guid,
     cfSpaceGuid: cfSpace.guid,
     cfOauthTokenUrl,
     cfApiHost,

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -12,7 +12,7 @@ module.exports = {
     accessKeyId: '123abc',
     secretAccessKey: '456def',
     region: 'us-gov-west-1',
-    bucket: 's3-bucket',
+    bucket: 'cg-123456789',
     serviceName: 'federalist-dev-s3',
   },
   passport: {

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -41,6 +41,8 @@ module.exports = {
     password: 'deploy_pass',
   },
   env: {
+    cfDomainGuid: '987ihg-654fed-321cba',
+    cfProxyGuid: '867fiv-309ine',
     cfSpaceGuid: '123abc-456def-789ghi',
     cfOauthTokenUrl: 'https://login.example.com/oauth/token',
     cfApiHost: 'https://api.example.com',

--- a/manifest.yml
+++ b/manifest.yml
@@ -19,6 +19,8 @@ services:
 - federalist-production-redis
 - federalist-production-space
 - federalist-deploy-user
+- federalist-production-proxy
+- federalist-production-domain
 env:
   NODE_ENV: production
   APP_ENV: production

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -19,6 +19,8 @@ services:
 - federalist-staging-redis
 - federalist-staging-space
 - federalist-deploy-user
+- federalist-staging-proxy
+- federalist-staging-domain
 env:
   NODE_ENV: production
   APP_ENV: staging

--- a/test/api/support/cfAPINocks.js
+++ b/test/api/support/cfAPINocks.js
@@ -8,8 +8,8 @@ const reqheaders = {
   },
 };
 
-const mockCreateRoute = resource => nock(url, reqheaders)
-  .post('/v2/routes')
+const mockCreateRoute = (resource, body) => nock(url, reqheaders)
+  .post('/v2/routes', body)
   .reply(200, resource);
 
 const mockFetchServiceKeysRequest = resources => nock(url, reqheaders)

--- a/test/api/support/cfAPINocks.js
+++ b/test/api/support/cfAPINocks.js
@@ -8,6 +8,10 @@ const reqheaders = {
   },
 };
 
+const mockCreateRoute = resource => nock(url, reqheaders)
+  .post('/v2/routes')
+  .reply(200, resource);
+
 const mockFetchServiceKeysRequest = resources => nock(url, reqheaders)
   .get('/v2/service_keys')
   .reply(200, resources);
@@ -82,7 +86,12 @@ const mockCreateServiceKey = (body, resources) => {
   return n.reply(200, resources);
 };
 
+const mockMapRoute = resource => nock(url, reqheaders)
+  .post('/v2/route_mappings')
+  .reply(200, resource);
+
 module.exports = {
+  mockCreateRoute,
   mockCreateS3ServiceInstance,
   mockCreateServiceKey,
   mockDefaultCredentials,
@@ -91,4 +100,5 @@ module.exports = {
   mockFetchServiceKeyRequest,
   mockFetchServiceKeysRequest,
   mockFetchS3ServicePlanGUID,
+  mockMapRoute,
 };

--- a/test/api/support/cfAPINocks.js
+++ b/test/api/support/cfAPINocks.js
@@ -27,6 +27,21 @@ const mockDeleteRoute = (host, guid) => {
     .reply(200, { metadata: { guid } });
 };
 
+const mockDeleteService = (name, guid) => {
+  nock(url, reqheaders)
+    .get('/v2/service_instances')
+    .reply(200, {
+      resources: [{
+        metadata: { guid },
+        entity: { name },
+      }],
+    });
+
+  nock(url, reqheaders)
+    .delete(`/v2/service_instances/${guid}?accepts_incomplete=true&recursive=true&async=true`)
+    .reply(200, { metadata: { guid } });
+};
+
 const mockFetchServiceKeysRequest = resources => nock(url, reqheaders)
   .get('/v2/service_keys')
   .reply(200, resources);
@@ -108,6 +123,7 @@ const mockMapRoute = resource => nock(url, reqheaders)
 module.exports = {
   mockCreateRoute,
   mockDeleteRoute,
+  mockDeleteService,
   mockCreateS3ServiceInstance,
   mockCreateServiceKey,
   mockDefaultCredentials,

--- a/test/api/support/cfAPINocks.js
+++ b/test/api/support/cfAPINocks.js
@@ -12,6 +12,21 @@ const mockCreateRoute = (resource, body) => nock(url, reqheaders)
   .post('/v2/routes', body)
   .reply(200, resource);
 
+const mockDeleteRoute = (host, guid) => {
+  nock(url, reqheaders)
+    .get('/v2/routes')
+    .reply(200, {
+      resources: [{
+        metadata: { guid },
+        entity: { host },
+      }],
+    });
+
+  nock(url, reqheaders)
+    .delete(`/v2/routes/${guid}?recursive=true&async=true`)
+    .reply(200, { metadata: { guid } });
+};
+
 const mockFetchServiceKeysRequest = resources => nock(url, reqheaders)
   .get('/v2/service_keys')
   .reply(200, resources);
@@ -92,6 +107,7 @@ const mockMapRoute = resource => nock(url, reqheaders)
 
 module.exports = {
   mockCreateRoute,
+  mockDeleteRoute,
   mockCreateS3ServiceInstance,
   mockCreateServiceKey,
   mockDefaultCredentials,

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -21,7 +21,7 @@ describe('SiteCreator', () => {
       repository,
       user,
       s3ServiceName = 'federalist-dev-s3',
-      awsBucketName = 's3-bucket',
+      awsBucketName = 'cg-123456789',
       awsBucketRegion = 'us-gov-west-1'
     ) => {
       expect(site).to.not.be.undefined;

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const { expect } = require('chai');
 const nock = require('nock');
 const { stub } = require('sinon');
+const config = require('../../../../config/env/test');
 const factory = require('../../support/factory');
 const githubAPINocks = require('../../support/githubAPINocks');
 const mockTokenRequest = require('../../support/cfAuthNock');
@@ -464,6 +465,9 @@ describe('SiteCreator', () => {
         };
 
         const name = `owner-${siteParams.owner}-repo-${siteParams.repository}`;
+        const guid = 'mapped-12345';
+        const appGuid = 'app-12345';
+        const routeGuid = 'route-12345';
         const keyName = `${name}-key`;
         const planName = 'basic-public';
         const planGuid = 'plan-guid';
@@ -512,12 +516,24 @@ describe('SiteCreator', () => {
           resources: [keyResponse],
         };
 
+        const routeResponse = factory.responses.service({ guid: routeGuid });
+        const mapResponse = factory.responses.service({ guid }, {
+          app_guid: appGuid,
+          route_guid: routeGuid,
+        });
+
         mockTokenRequest();
         apiNocks.mockFetchS3ServicePlanGUID(planResponses);
         apiNocks.mockCreateS3ServiceInstance(instanceRequestBody, bucketResponse);
         apiNocks.mockCreateServiceKey(keyRequestBody, keyResponse);
         apiNocks.mockFetchServiceInstancesRequest(buildResponses);
         apiNocks.mockFetchServiceInstanceCredentialsRequest('test-guid', serviceCredentialsResponses);
+        apiNocks.mockCreateRoute(routeResponse, {
+          domain_guid: config.env.cfDomainGuid,
+          space_guid: config.env.cfSpaceGuid,
+          host: bucket,
+        });
+        apiNocks.mockMapRoute(mapResponse);
 
         factory.user().then((model) => {
           user = model;

--- a/test/api/unit/utils/cfApiClient.create.test.js
+++ b/test/api/unit/utils/cfApiClient.create.test.js
@@ -172,4 +172,77 @@ describe('CloudFoundryAPIClient', () => {
         });
     });
   });
+
+  describe('.createRoute', () => {
+    it('should create a new route', (done) => {
+      const host = 'my-route';
+      const guid = '12345';
+      const response = responses.service({ guid }, { host });
+
+      mockTokenRequest();
+      apiNocks.mockCreateRoute(response);
+
+      const apiClient = new CloudFoundryAPIClient();
+      apiClient.createRoute(host)
+        .then((res) => {
+          expect(res.metadata.guid).to.equal(guid);
+          expect(res.entity.host).to.equal(host);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('.mapRoute', () => {
+    it('should map a route to an app', (done) => {
+      const guid = 'mapped-12345';
+      const appGuid = 'app-12345';
+      const routeGuid = 'route-12345';
+      const response = responses.service({ guid }, {
+        app_guid: appGuid,
+        route_guid: routeGuid,
+      });
+
+      mockTokenRequest();
+      apiNocks.mockMapRoute(response);
+
+      const apiClient = new CloudFoundryAPIClient();
+      apiClient.mapRoute(routeGuid)
+        .then((res) => {
+          expect(res.metadata.guid).to.equal(guid);
+          expect(res.entity.app_guid).to.equal(appGuid);
+          expect(res.entity.route_guid).to.equal(routeGuid);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('.createSiteProxyRoute', () => {
+    it('should create and map a route', (done) => {
+      const host = 'my-host';
+      const guid = 'mapped-12345';
+      const appGuid = 'app-12345';
+      const routeGuid = 'route-12345';
+      const routeResponse = responses.service({ guid: routeGuid });
+      const mapResponse = responses.service({ guid }, {
+        app_guid: appGuid,
+        route_guid: routeGuid,
+      });
+
+      mockTokenRequest();
+      apiNocks.mockCreateRoute(routeResponse);
+      apiNocks.mockMapRoute(mapResponse);
+
+      const apiClient = new CloudFoundryAPIClient();
+      apiClient.createSiteProxyRoute(host)
+        .then((res) => {
+          expect(res.metadata.guid).to.equal(guid);
+          expect(res.entity.app_guid).to.equal(appGuid);
+          expect(res.entity.route_guid).to.equal(routeGuid);
+          done();
+        })
+        .catch(done);
+    });
+  });
 });

--- a/test/api/unit/utils/cfApiClient.delete.test.js
+++ b/test/api/unit/utils/cfApiClient.delete.test.js
@@ -42,4 +42,40 @@ describe('CloudFoundryAPIClient Delete', () => {
         });
     });
   });
+
+  describe('.deleteS3Service', () => {
+    it('should delete an S3 service', (done) => {
+      const s3Service = 'this-is-a-s3-service-to-delete';
+      const guid = '123456-abcdef';
+
+      mockTokenRequest();
+      apiNocks.mockDeleteService(s3Service, guid);
+
+      const cfApiClient = new CloudFoundryAPIClient();
+
+      cfApiClient.deleteServiceInstance(s3Service)
+        .then((res) => {
+          expect(res.metadata.guid).to.equal(guid);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should reject when s3 service not found', (done) => {
+      const notService = 'this-is-not-a-s3-service';
+      const s3Service = 'this-is-a-s3-service-to-delete';
+      const guid = '123456-abcdef';
+
+      mockTokenRequest();
+      apiNocks.mockDeleteService(s3Service, guid);
+
+      const cfApiClient = new CloudFoundryAPIClient();
+
+      cfApiClient.deleteServiceInstance(notService)
+        .catch((err) => {
+          expect(err).to.be.an('error');
+          done();
+        });
+    });
+  });
 });

--- a/test/api/unit/utils/cfApiClient.delete.test.js
+++ b/test/api/unit/utils/cfApiClient.delete.test.js
@@ -1,0 +1,45 @@
+const { expect } = require('chai');
+const nock = require('nock');
+const CloudFoundryAPIClient = require('../../../../api/utils/cfApiClient');
+const mockTokenRequest = require('../../support/cfAuthNock');
+const apiNocks = require('../../support/cfAPINocks');
+
+describe('CloudFoundryAPIClient Delete', () => {
+  afterEach(() => nock.cleanAll());
+
+  describe('.deleteRoute', () => {
+    it('should delete a route', (done) => {
+      const routeName = 'a-simple-route-to-be-deleted';
+      const guid = '123456-abcdef';
+
+      mockTokenRequest();
+      apiNocks.mockDeleteRoute(routeName, guid);
+
+      const cfApiClient = new CloudFoundryAPIClient();
+
+      cfApiClient.deleteRoute(routeName)
+        .then((res) => {
+          expect(res.metadata.guid).to.equal(guid);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should reject when route does not exist', (done) => {
+      const notRoute = 'not-a-route';
+      const aRoute = 'a-different-route';
+      const guid = '123456-abcdef';
+
+      mockTokenRequest();
+      apiNocks.mockDeleteRoute(aRoute, guid);
+
+      const cfApiClient = new CloudFoundryAPIClient();
+
+      cfApiClient.deleteRoute(notRoute)
+        .catch((err) => {
+          expect(err).to.be.an('error');
+          done();
+        });
+    });
+  });
+});

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -13,6 +13,81 @@ const MockWebpackConfig = {
 const utils = proxyquire('../../../../api/utils', { '../../webpack.development.config.js': MockWebpackConfig });
 
 describe('utils', () => {
+  describe('.filterEntity', () => {
+    it('should filter out the named entity from an objects resources array', (done) => {
+      const name = 'one';
+      const field = 'name';
+      const entity = { [field]: name };
+      const resources = {
+        resources: [
+          {
+            entity,
+          },
+          {
+            entity: { [field]: 'two' },
+          },
+        ],
+      };
+      const result = utils.filterEntity(resources, name, field);
+
+      expect(result).to.deep.equal({ entity });
+      done();
+    });
+
+    it('should reject a promise if entity not found', (done) => {
+      const name = 'one';
+      const field = 'name';
+      const resources = {
+        resources: [
+          {
+            entity: { [field]: 'two' },
+          },
+        ],
+      };
+
+      utils.filterEntity(resources, name, field)
+        .catch((err) => {
+          expect(err).to.be.an('error');
+          done();
+        });
+    });
+  });
+
+  describe('.firstEntity', () => {
+    it('should return first entity from an objects resources array', (done) => {
+      const name = 'one';
+      const field = 'name';
+      const entity = { [field]: name };
+      const resources = {
+        resources: [
+          {
+            entity,
+          },
+          {
+            entity: { [field]: 'two' },
+          },
+        ],
+      };
+      const result = utils.firstEntity(resources, name);
+
+      expect(result).to.deep.equal({ entity });
+      done();
+    });
+
+    it('should reject a promise if no resources returned', (done) => {
+      const name = 'one';
+      const resources = {
+        resources: [],
+      };
+
+      utils.firstEntity(resources, name)
+        .catch((err) => {
+          expect(err).to.be.an('error');
+          done();
+        });
+    });
+  });
+
   describe('.generateS3ServiceName', () => {
     it('should concat and lowercase owner and repository name', (done) => {
       const owner = 'Hello';


### PR DESCRIPTION
## Description

When a user creates a new site with a private bucket, a new route will be generated and mapped to the `federalist-proxy`, the proxy will point to their private aws bucket endpoint, and will allow users to view the site deployments as normal.

## Implementation

- [x] Add methods to the CF API client to manage routes
- [x] Create and map routes when a site is created
- [x] Remove route when site is deleted