### PR TITLE
Update site's proxy links to point to new bucket name based proxy route

### DIFF
--- a/api/models/site.js
+++ b/api/models/site.js
@@ -1,5 +1,4 @@
 const validator = require('validator');
-const config = require('../../config');
 
 const { branchRegex, isValidYaml } = require('../utils/validators');
 
@@ -67,18 +66,18 @@ function siteUrl() {
   if (this.domain) {
     return domainWithSlash(this.domain);
   }
-  return `${config.app.preview_hostname}/site/${this.owner}/${this.repository}/`;
+  return `https://${this.awsBucketName}.app.cloud.gov/site/${this.owner}/${this.repository}/`;
 }
 
 function demoUrl() {
   if (this.demoDomain) {
     return domainWithSlash(this.demoDomain);
   }
-  return `${config.app.preview_hostname}/demo/${this.owner}/${this.repository}/`;
+  return `https://${this.awsBucketName}.app.cloud.gov/demo/${this.owner}/${this.repository}/`;
 }
 
 function branchPreviewUrl(branch = null) {
-  let url = `${config.app.preview_hostname}/preview/${this.owner}/${this.repository}/`;
+  let url = `https://${this.awsBucketName}.app.cloud.gov/preview/${this.owner}/${this.repository}/`;
   if (branch) {
     url = `${url}${branch}/`;
   }

--- a/frontend/components/branchViewLink.js
+++ b/frontend/components/branchViewLink.js
@@ -7,29 +7,32 @@ import { IconView } from './icons';
 const isDefaultBranch = (branchName, site) => branchName === site.defaultBranch;
 const isDemoBranch = (branchName, site) => branchName === site.demoBranch;
 
-const getUrlAndViewText = (branchName, site, previewHostname) => {
+const getUrlAndViewText = (branchName, site) => {
   if (isDefaultBranch(branchName, site)) {
     return { url: site.viewLink, viewText: 'View site' };
-  } else if (isDemoBranch(branchName, site)) {
+  }
+  if (isDemoBranch(branchName, site)) {
     return { url: site.demoViewLink, viewText: 'View demo' };
   }
   return {
-    url: `${previewHostname}/preview/${site.owner}/${site.repository}/${branchName}/`,
+    url: `https://${site.awsBucketName}.app.cloud.gov/preview/${site.owner}/${site.repository}/${branchName}/`,
     viewText: 'Preview site',
   };
 };
 
-export const BranchViewLink = ({ branchName, site, previewHostname, showIcon }) => {
-  const { url, viewText } = getUrlAndViewText(branchName, site, previewHostname);
+export const BranchViewLink = ({ branchName, site, showIcon }) => {
+  const { url, viewText } = getUrlAndViewText(branchName, site);
 
   if (showIcon) {
     return (
       <a
-        href={url} target="_blank"
+        href={url}
+        target="_blank"
         rel="noopener noreferrer"
         className="view-site-link"
       >
-        { viewText }<IconView />
+        { viewText }
+        <IconView />
       </a>
     );
   }
@@ -39,7 +42,6 @@ export const BranchViewLink = ({ branchName, site, previewHostname, showIcon }) 
 BranchViewLink.propTypes = {
   branchName: PropTypes.string.isRequired,
   site: SITE.isRequired,
-  previewHostname: PropTypes.string.isRequired,
   showIcon: PropTypes.bool,
 };
 
@@ -47,8 +49,4 @@ BranchViewLink.defaultProps = {
   showIcon: false,
 };
 
-const mapStateToProps = state => ({
-  previewHostname: state.FRONTEND_CONFIG.PREVIEW_HOSTNAME,
-});
-
-export default connect(mapStateToProps)(BranchViewLink);
+export default connect()(BranchViewLink);

--- a/frontend/propTypes.js
+++ b/frontend/propTypes.js
@@ -23,6 +23,9 @@ export const SITE = PropTypes.shape({
   defaultBranch: PropTypes.string,
   domain: PropTypes.string,
   engine: PropTypes.string,
+  s3ServiceName: PropTypes.string,
+  awsBucketName: PropTypes.string,
+  awsBucketRegion: PropTypes.string,
   users: PropTypes.arrayOf(USER),
 });
 

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const config = require('../../../../config');
 const factory = require('../../support/factory');
 const { Site } = require('../../../../api/models');
 
@@ -34,7 +33,7 @@ describe('Site model', () => {
       it('should return a proxy link if there is no custom domain', (done) => {
         factory.site({ defaultBranch: 'default-branch' }).then((site) => {
           const viewLink = site.viewLinkForBranch('default-branch');
-          expect(viewLink).to.equal(`${config.app.preview_hostname}/site/${site.owner}/${site.repository}/`);
+          expect(viewLink).to.equal(`https://${site.awsBucketName}.app.cloud.gov/site/${site.owner}/${site.repository}/`);
           done();
         }).catch(done);
       });
@@ -54,7 +53,7 @@ describe('Site model', () => {
         const defaultBranch = 'defau/lt-branch';
         factory.site({ defaultBranch }).then((site) => {
           const viewLink = site.viewLinkForBranch(defaultBranch);
-          expect(viewLink).to.equal(`${config.app.preview_hostname}/site/${site.owner}/${site.repository}/`);
+          expect(viewLink).to.equal(`https://${site.awsBucketName}.app.cloud.gov/site/${site.owner}/${site.repository}/`);
           done();
         }).catch(done);
       });
@@ -64,7 +63,7 @@ describe('Site model', () => {
       it('should return a proxy demo link if there is no demo domain', (done) => {
         factory.site({ demoBranch: 'demo-branch' }).then((site) => {
           const viewLink = site.viewLinkForBranch('demo-branch');
-          expect(viewLink).to.equal(`${config.app.preview_hostname}/demo/${site.owner}/${site.repository}/`);
+          expect(viewLink).to.equal(`https://${site.awsBucketName}.app.cloud.gov/demo/${site.owner}/${site.repository}/`);
           done();
         }).catch(done);
       });
@@ -84,7 +83,7 @@ describe('Site model', () => {
         const demoBranch = 'dem/o-branch';
         factory.site({ demoBranch }).then((site) => {
           const viewLink = site.viewLinkForBranch(demoBranch);
-          expect(viewLink).to.equal(`${config.app.preview_hostname}/demo/${site.owner}/${site.repository}/`);
+          expect(viewLink).to.equal(`https://${site.awsBucketName}.app.cloud.gov/demo/${site.owner}/${site.repository}/`);
           done();
         }).catch(done);
       });
@@ -94,7 +93,7 @@ describe('Site model', () => {
       it('should return a federalist preview link', (done) => {
         factory.site().then((site) => {
           const viewLink = site.viewLinkForBranch('preview-branch');
-          expect(viewLink).to.equal(`${config.app.preview_hostname}/preview/${site.owner}/${site.repository}/preview-branch/`);
+          expect(viewLink).to.equal(`https://${site.awsBucketName}.app.cloud.gov/preview/${site.owner}/${site.repository}/preview-branch/`);
           done();
         }).catch(done);
       });
@@ -102,7 +101,7 @@ describe('Site model', () => {
       it('should return a federalist preview link withouth branch', (done) => {
         factory.site().then((site) => {
           const viewLink = site.viewLinkForBranch();
-          expect(viewLink).to.equal(`${config.app.preview_hostname}/preview/${site.owner}/${site.repository}/`);
+          expect(viewLink).to.equal(`https://${site.awsBucketName}.app.cloud.gov/preview/${site.owner}/${site.repository}/`);
           done();
         }).catch(done);
       });

--- a/test/api/unit/services/GithubBuildStatusReporter.test.js
+++ b/test/api/unit/services/GithubBuildStatusReporter.test.js
@@ -123,7 +123,11 @@ describe('GithubBuildStatusReporter', () => {
 
         factory.build({
           state: 'success',
-          site: factory.site({ owner: 'test-owner', repository: 'test-repo' }),
+          site: factory.site({
+            owner: 'test-owner',
+            repository: 'test-repo',
+            awsBucketName: 'test-bucket',
+          }),
           commitSha,
           branch: 'preview-branch',
         }).then((build) => {
@@ -131,7 +135,7 @@ describe('GithubBuildStatusReporter', () => {
             owner: 'test-owner',
             repo: 'test-repo',
             sha: commitSha,
-            targetURL: `${config.app.preview_hostname}/preview/test-owner/test-repo/preview-branch/`,
+            targetURL: 'https://test-bucket.app.cloud.gov/preview/test-owner/test-repo/preview-branch/',
           });
 
           return GithubBuildStatusReporter.reportBuildStatus(build);

--- a/test/frontend/components/branchViewLink.test.js
+++ b/test/frontend/components/branchViewLink.test.js
@@ -12,6 +12,7 @@ describe('<BranchViewLink/>', () => {
     demoViewLink: 'https://demo-url.com',
     owner: 'test-owner',
     repository: 'test-repo',
+    awsBucketName: 'test-bucket',
   };
 
   let props;
@@ -48,7 +49,8 @@ describe('<BranchViewLink/>', () => {
     const anchor = wrapper.find('a');
     expect(anchor.length).to.equal(1);
     expect(anchor.prop('href')).to.equal(
-      'https://preview-hostname.com/preview/test-owner/test-repo/some-other-branch/');
+      'https://test-bucket.app.cloud.gov/preview/test-owner/test-repo/some-other-branch/'
+    );
     expect(anchor.text()).equal('Preview site');
   });
 
@@ -58,7 +60,8 @@ describe('<BranchViewLink/>', () => {
     const anchor = wrapper.find('a');
     expect(anchor.length).to.equal(1);
     expect(anchor.prop('href')).to.equal(
-      'https://preview-hostname.com/preview/test-owner/test-repo/release_1.2.3/');
+      'https://test-bucket.app.cloud.gov/preview/test-owner/test-repo/release_1.2.3/'
+    );
     expect(anchor.text()).equal('Preview site');
   });
 });


### PR DESCRIPTION
## Description

When a user looks at their sites and each site's builds, the links taking them to view the site's preview or branch view will point to the site's private bucket proxy url. ie `https://<site-bucket-name>.app.cloud.gov`;

## Implementation

Update both the frontend components and the `sites` model to point to the proxy route generated based on the site's AWS bucket name.