### PR TITLE
Update AWS putBucketWebsite config request to retry multiple attempts

### DIFF
--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -143,8 +143,8 @@ function buildInfrastructure(params, s3ServiceName) {
         region: credentials.region,
       };
 
-      return putBucketWebsite(credentials)
-        .then(() => apiClient.createSiteProxyRoute(credentials.bucket))
+      return apiClient.createSiteProxyRoute(credentials.bucket)
+        .then(() => putBucketWebsite(credentials))
         .then(() => buildSite(params, s3));
     });
 }


### PR DESCRIPTION
## Description
After Cloud Foundry generates the credentials for a new site's private bucket, it takes a bit a time (milliseconds) to provision the credentials so we now retry (up to 10 attempts) to add the required website config the new bucket before failing.

## Fixes
Initially we were only trying to configure the bucket's website information once and it was causing a server error because the credentials had not yet been provisioned at time of request when creating a new bucket.