### PR TITLE
Add delay to putBucketWebsite creation

### DIFF
--- a/api/services/S3Helper.js
+++ b/api/services/S3Helper.js
@@ -38,7 +38,7 @@ function createWebsiteParams(bucket) {
   };
 }
 
-function putBucketLogger(type, bucket, message, start, attempt) {
+function putBucketLogger(type, bucket, message, { start, attempt }) {
   const current = new Date().getTime();
 
   logger[type](`\
@@ -123,23 +123,23 @@ class S3Client {
     let attempt = 0;
     const { bucket, client } = this;
     const params = createWebsiteParams(bucket);
-    const startTime = new Date().getTime();
+    const start = new Date().getTime();
 
     return new Promise((resolve, reject) => {
       const request = () => {
         client.putBucketWebsite(params, (err, data) => {
           if (err && attempt < max) {
-            putBucketLogger('info', bucket, 'Retry', startTime, attempt);
+            putBucketLogger('info', bucket, 'Retry', { start, attempt });
             attempt += 1;
             return _.delay(request, 500);
           }
 
           if (err && attempt >= max) {
-            putBucketLogger('error', bucket, err, startTime, attempt);
+            putBucketLogger('error', bucket, err, { start, attempt });
             return reject(err);
           }
 
-          putBucketLogger('info', bucket, 'Success', startTime, attempt);
+          putBucketLogger('info', bucket, 'Success', { start, attempt });
           return resolve(data);
         });
       };

--- a/api/services/S3Helper.js
+++ b/api/services/S3Helper.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk');
+const _ = require('underscore');
 
 const S3_DEFAULT_MAX_KEYS = 1000;
 
@@ -103,26 +104,28 @@ class S3Client {
     });
   }
 
+  // Add delay due to initial credentials provisioning time for S3
+  // ToDo refactor and move `putBucketWebsite` config in site creation flow
   putBucketWebsite(max = 10) {
     let attempt = 0;
     const { client } = this;
     const params = createWebsiteParams(this.bucket);
 
     return new Promise((resolve, reject) => {
-      const request = (res, rej) => {
+      const request = () => {
         client.putBucketWebsite(params, (err, data) => {
           if (err && attempt < max) {
             attempt += 1;
-            return request(res, rej);
+            return _.delay(request, 500);
           }
 
-          if (err && attempt >= max) return rej(err);
+          if (err && attempt >= max) return reject(err);
 
-          return res(data);
+          return resolve(data);
         });
       };
 
-      request(resolve, reject);
+      _.delay(request, 750);
     });
   }
 

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -144,6 +144,8 @@ function buildInfrastructure(params, s3ServiceName) {
       };
 
       return apiClient.createSiteProxyRoute(credentials.bucket)
+        // Add delay due to initial credentials provisioning time for S3
+        // ToDo refactor and move `putBucketWebsite` config in site creation flow
         .then(() => putBucketWebsite(credentials))
         .then(() => buildSite(params, s3));
     });

--- a/test/api/unit/services/S3Helper.test.js
+++ b/test/api/unit/services/S3Helper.test.js
@@ -73,7 +73,6 @@ describe('S3Helper', () => {
   });
 
   describe('.putBucketWebsite', () => {
-
     after(() => {
       AWSMocks.resetMocks();
     });

--- a/test/api/unit/services/S3Helper.test.js
+++ b/test/api/unit/services/S3Helper.test.js
@@ -72,8 +72,7 @@ describe('S3Helper', () => {
     });
   });
 
-  describe('.putBucketWebsite', function specialTest() {
-    this.timeout(10000);
+  describe('.putBucketWebsite', () => {
 
     after(() => {
       AWSMocks.resetMocks();
@@ -103,7 +102,9 @@ describe('S3Helper', () => {
         .catch(done);
     });
 
-    it('should reject with promise', (done) => {
+    it('should reject with promise', function specialTest(done) {
+      this.timeout(10000);
+
       AWSMocks.mocks.S3.putBucketWebsite = (params, callback) => {
         callback(new Error());
       };

--- a/test/api/unit/services/S3Helper.test.js
+++ b/test/api/unit/services/S3Helper.test.js
@@ -72,7 +72,9 @@ describe('S3Helper', () => {
     });
   });
 
-  describe('.putBucketWebsite', () => {
+  describe('.putBucketWebsite', function() {
+    this.timeout(10000);
+
     after(() => {
       AWSMocks.resetMocks();
     });

--- a/test/api/unit/services/S3Helper.test.js
+++ b/test/api/unit/services/S3Helper.test.js
@@ -72,7 +72,7 @@ describe('S3Helper', () => {
     });
   });
 
-  describe('.putBucketWebsite', function() {
+  describe('.putBucketWebsite', function specialTest() {
     this.timeout(10000);
 
     after(() => {


### PR DESCRIPTION
## Description

Add delay with an initial `750` ms and `500` ms for every attempt request after on `putBucketWebsite` config during site creation.  Credentials provisioning is taking longer than expected.

## Refactoring
Revisit at a later date and consider moving the creation of the S3 bucket website config into another part of the initial site creation.

## To Do

- [x] Add logging to the AWS API request for `putBuketWebsite` so we can collect the number of attempts and the average time to success for the new site.