### PR TITLE
Update default 404 error config to match garden build

### DIFF
--- a/api/services/S3Helper.js
+++ b/api/services/S3Helper.js
@@ -24,12 +24,12 @@ function createPagedResults(totalMaxObjects, isTruncated, objects) {
   return pagedResults;
 }
 
-function createWebsiteParams(bucket) {
+function createWebsiteParams(owner, repository, bucket) {
   return {
     Bucket: bucket,
     WebsiteConfiguration: {
       ErrorDocument: {
-        Key: '404.html',
+        Key: `site/${owner}/${repository}/404/index.html`,
       },
       IndexDocument: {
         Suffix: 'index.html',
@@ -119,10 +119,10 @@ class S3Client {
 
   // Add delay due to initial credentials provisioning time for S3
   // ToDo refactor and move `putBucketWebsite` config in site creation flow
-  putBucketWebsite(max = 10) {
+  putBucketWebsite(owner, repository, max = 10) {
     let attempt = 0;
     const { bucket, client } = this;
-    const params = createWebsiteParams(bucket);
+    const params = createWebsiteParams(owner, repository, bucket);
     const start = new Date().getTime();
 
     return new Promise((resolve, reject) => {

--- a/api/services/S3Helper.js
+++ b/api/services/S3Helper.js
@@ -29,7 +29,7 @@ function createWebsiteParams(owner, repository, bucket) {
     Bucket: bucket,
     WebsiteConfiguration: {
       ErrorDocument: {
-        Key: `site/${owner}/${repository}/404/index.html`,
+        Key: `site/${owner}/${repository}/404.html`,
       },
       IndexDocument: {
         Suffix: 'index.html',

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -123,7 +123,7 @@ const setupBucket = (build, buildCount) => {
         region,
       });
 
-      return s3Client.putBucketWebsite();
+      return s3Client.putBucketWebsite(build.Site.owner, build.Site.repository);
     });
 };
 

--- a/test/api/unit/services/S3Helper.test.js
+++ b/test/api/unit/services/S3Helper.test.js
@@ -84,7 +84,7 @@ describe('S3Helper', () => {
         Bucket: config.s3.bucket,
         WebsiteConfiguration: {
           ErrorDocument: {
-            Key: `site/${owner}/${repository}/404/index.html`,
+            Key: `site/${owner}/${repository}/404.html`,
           },
           IndexDocument: {
             Suffix: 'index.html',

--- a/test/api/unit/services/S3Helper.test.js
+++ b/test/api/unit/services/S3Helper.test.js
@@ -78,11 +78,13 @@ describe('S3Helper', () => {
     });
 
     it('should successfully send params to bucket', (done) => {
+      const owner = 'an-owner';
+      const repository = 'a-reposistory';
       const expected = {
         Bucket: config.s3.bucket,
         WebsiteConfiguration: {
           ErrorDocument: {
-            Key: '404.html',
+            Key: `site/${owner}/${repository}/404/index.html`,
           },
           IndexDocument: {
             Suffix: 'index.html',
@@ -96,7 +98,7 @@ describe('S3Helper', () => {
       };
 
       const client = new S3Helper.S3Client(config.s3);
-      client.putBucketWebsite()
+      client.putBucketWebsite(owner, repository)
         .then(done)
         .catch(done);
     });

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -47,6 +47,8 @@ describe('SQS', () => {
 
     it('should send a formatted build message and setup S3 bucket config on first built', (done) => {
       const oldSendMessage = SQS.sqsClient.sendMessage;
+      const owner = 'owner';
+      const repository = 'formatted-message-repo';
       SQS.sqsClient.sendMessage = (params) => {
         SQS.sqsClient.sendMessage = oldSendMessage;
         expect(params).to.have.property('MessageBody');
@@ -59,7 +61,7 @@ describe('SQS', () => {
           Bucket: config.s3.bucket,
           WebsiteConfiguration: {
             ErrorDocument: {
-              Key: '404.html',
+              Key: `site/${owner}/${repository}/404/index.html`,
             },
             IndexDocument: {
               Suffix: 'index.html',
@@ -73,8 +75,8 @@ describe('SQS', () => {
         branch: 'master',
         state: 'processing',
         Site: {
-          owner: 'owner',
-          repository: 'formatted-message-repo',
+          owner,
+          repository,
           engine: 'jekyll',
           defaultBranch: 'master',
           s3ServiceName: config.s3.serviceName,

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -61,7 +61,7 @@ describe('SQS', () => {
           Bucket: config.s3.bucket,
           WebsiteConfiguration: {
             ErrorDocument: {
-              Key: `site/${owner}/${repository}/404/index.html`,
+              Key: `site/${owner}/${repository}/404.html`,
             },
             IndexDocument: {
               Suffix: 'index.html',


### PR DESCRIPTION
## Description

Updates a site with a private S3 bucket's 404 error page to `site/<OWNER>/<REPOSITORY>/404/index.html` to lineup with `federalist-garden-build`'s default 404 build update.

See https://github.com/18F/federalist-garden-build/pull/170