### PR TITLE
Truncate service name generatation for s3 to account for 50 char limit

### DIFF
--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -42,11 +42,17 @@ function generateS3ServiceName(owner, repository) {
     return serviceName;
   }
 
-  const today = new Date();
-  const day = today.getDate();
-  const month = today.getMonth();
-  const year = today.getFullYear().toString().slice(2);
-  const slicedServiceName = `${serviceName.slice(0, 39)}-${day}${month}${year}`;
+  function makeId() {
+    let result = '';
+    const characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    const charactersLength = characters.length;
+    for (let i = 0; i < 6; i += 1) {
+      result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    return result;
+  }
+
+  const slicedServiceName = `${serviceName.slice(0, 39)}-${makeId()}`;
   return slicedServiceName;
 }
 

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -36,7 +36,18 @@ function generateS3ServiceName(owner, repository) {
     .split(' ')
     .join('-');
 
-  return `owner-${format(owner)}-repo-${format(repository)}`;
+  const serviceName = `o-${format(owner)}-r-${format(repository)}`;
+
+  if (serviceName.length < 47) {
+    return serviceName;
+  }
+
+  const today = new Date();
+  const day = today.getDate();
+  const month = today.getMonth();
+  const year = today.getFullYear().toString().slice(2);
+  const slicedServiceName = `${serviceName.slice(0, 39)}-${day}${month}${year}`;
+  return slicedServiceName;
 }
 
 function isPastAuthThreshold(authDate) {

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -464,7 +464,7 @@ describe('SiteCreator', () => {
           sharedBucket: false,
         };
 
-        const name = `owner-${siteParams.owner}-repo-${siteParams.repository}`;
+        const name = `o-${siteParams.owner}-r-${siteParams.repository}`;
         const guid = 'mapped-12345';
         const appGuid = 'app-12345';
         const routeGuid = 'route-12345';

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -92,7 +92,7 @@ describe('utils', () => {
     it('should concat and lowercase owner and repository name', (done) => {
       const owner = 'Hello';
       const repository = 'Hello World';
-      const expected = 'owner-hello-repo-hello-world';
+      const expected = 'o-hello-r-hello-world';
 
       expect(utils.generateS3ServiceName(owner, repository)).to.equal(expected);
       done();
@@ -101,7 +101,20 @@ describe('utils', () => {
     it('should convert to string when the owner and repository is a number', (done) => {
       const owner = 12345;
       const repository = 'Hello World';
-      const expected = 'owner-12345-repo-hello-world';
+      const expected = 'o-12345-r-hello-world';
+
+      expect(utils.generateS3ServiceName(owner, repository)).to.equal(expected);
+      done();
+    });
+
+    it('should truncate names over 46 characters to account for CF service name limits', (done) => {
+      const owner = 'hello-world-owner';
+      const repository = 'hello-world-really-long-repository-name';
+      const today = new Date();
+      const day = today.getDate();
+      const month = today.getMonth();
+      const year = today.getFullYear().toString().slice(2);
+      const expected = `o-hello-world-owner-r-hello-world-reall-${day}${month}${year}`;
 
       expect(utils.generateS3ServiceName(owner, repository)).to.equal(expected);
       done();

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -110,13 +110,11 @@ describe('utils', () => {
     it('should truncate names over 46 characters to account for CF service name limits', (done) => {
       const owner = 'hello-world-owner';
       const repository = 'hello-world-really-long-repository-name';
-      const today = new Date();
-      const day = today.getDate();
-      const month = today.getMonth();
-      const year = today.getFullYear().toString().slice(2);
-      const expected = `o-hello-world-owner-r-hello-world-reall-${day}${month}${year}`;
+      const output = utils.generateS3ServiceName(owner, repository);
+      const expectedPre = 'o-hello-world-owner-r-hello-world-reall-';
 
-      expect(utils.generateS3ServiceName(owner, repository)).to.equal(expected);
+      expect(output.length).to.equal(46);
+      expect(output.slice(0, 40)).to.equal(expectedPre);
       done();
     });
 


### PR DESCRIPTION
When a user creates a new site if the `owner-<github owner name>-repo-<repository name>` is greater than 50 characters, Cloud Foundry will not create the new service due to the name length.

This fixes the issue by:
- [x] truncates names if greater than 46 characters (allows space for `-key` appending)
- [x] cuts the string at 39 characters and adds `-<DDMMYY>` to improve uniqueness
- [x] changes `owner-<github owner name>-repo-<repository name>` to `o-<github owner name>-r-<repository name>` to allow more characters in owner and repository naming before truncation happens.