### PR TITLE
Query routes using host filter so no pagination is needed

### DIFF
--- a/api/responses/serverError.js
+++ b/api/responses/serverError.js
@@ -1,7 +1,7 @@
 const { logger } = require('../../winston');
 
 module.exports = (error = {}, { res }) => {
-  logger.error('Sending 500: ', error);
+  logger.error('Sending 500: %o', error);
 
   res.status(500);
   return res.json({

--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -66,14 +66,14 @@ class CloudFoundryAPIClient {
       .then(route => this.mapRoute(route.metadata.guid));
   }
 
-  deleteRoute(name) {
+  deleteRoute(host) {
     return this.accessToken()
       .then(token => this.request(
         'GET',
-        '/v2/routes',
+        `/v2/routes?q=host:${host}`,
         token
       ))
-      .then(res => filterEntity(res, name, 'host'))
+      .then(res => filterEntity(res, host, 'host'))
       .then(entity => this.accessToken()
         .then(token => this.request(
           'DELETE',
@@ -190,8 +190,7 @@ class CloudFoundryAPIClient {
         json,
       }, (error, response, body) => {
         if (error) {
-          const stringed = JSON.stringify(error, null, 2);
-          reject(new Error(stringed));
+          reject(error);
         } else if (response.statusCode > 399) {
           const errorMessage = `Received status code: ${response.statusCode}`;
           reject(new Error(body || errorMessage));

--- a/test/api/support/cfAPINocks.js
+++ b/test/api/support/cfAPINocks.js
@@ -14,7 +14,7 @@ const mockCreateRoute = (resource, body) => nock(url, reqheaders)
 
 const mockDeleteRoute = (host, guid) => {
   nock(url, reqheaders)
-    .get('/v2/routes')
+    .get(`/v2/routes?q=host:${host}`)
     .reply(200, {
       resources: [{
         metadata: { guid },


### PR DESCRIPTION
## Description

When a user delete's a site, a query for the route guid is need to delete the route.  When the route results were not listed in the first page, the route query was not paginating through the next list.  To fix this, we now query the routes based on the `host` name.

Acceptance Criteria:
- [x] Query routes using the `host` filter to avoid pagination
- [x] Allow winston logger to parse object errors [see issue.](https://github.com/winstonjs/winston/issues/1217#issuecomment-371230555)