### PR TITLE
Remove unnecessary promise

### DIFF
--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -30,10 +30,10 @@ function filterEntity(res, name, field = 'name') {
 
 function firstEntity(res, name) {
   if (res.resources.length === 0) {
-    return Promise.reject(new Error(JSON.stringify({
+    throw new Error(JSON.stringify({
       message: 'Not found',
       name,
-    })));
+    }));
   }
 
   return res.resources[0];

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -54,7 +54,7 @@ describe('utils', () => {
   });
 
   describe('.firstEntity', () => {
-    it('should return first entity from an objects resources array', (done) => {
+    it('should return first entity from an objects resources array', () => {
       const name = 'one';
       const field = 'name';
       const entity = { [field]: name };
@@ -68,23 +68,21 @@ describe('utils', () => {
           },
         ],
       };
+
       const result = utils.firstEntity(resources, name);
 
       expect(result).to.deep.equal({ entity });
-      done();
     });
 
-    it('should reject a promise if no resources returned', (done) => {
+    it('should throw an error if no resources returned', () => {
       const name = 'one';
       const resources = {
         resources: [],
       };
 
-      utils.firstEntity(resources, name)
-        .catch((err) => {
-          expect(err).to.be.an('error');
-          done();
-        });
+      const fn = () => utils.firstEntity(resources, name);
+
+      expect(fn).to.throw();
     });
   });
 


### PR DESCRIPTION
As part of an effort to address some code quality and performance issues in the app, I'd like to regularly devote a small amount of time to refactoring. A long description of my reasoning is below, but in this PR, we address a small example in a function only used in one place.

I do have one question about this code, why is it necessary to stringify the error details?

**Promises**
In general, a Promise should only be created when required, that is, when we need to do something asynchronously because it will take some time and we don't want to block the thread. Given that we use libraries that return Promises already, to which we can just chain more work, we should be creating very few promises of our own. One exception is converting callback-based functions to Promise-based ones.

In addition to being a best practice, there is a very small performance hit to creating unnecessary Promises, in that the work is rescheduled to happen later in the next run of the event loop. For synchronous, server-side code, this is unnecessary. And, its generally less code!

The reason for some of this, might be a misunderstanding of how Promises work:

1. Errors: If an error is thrown from code executing inside a promise, the next `catch` clause will catch it, it is not necessary for the error to be wrapped in a new Promise, ie `Promise.reject()`. Ex.

```
const somethingThatReturnsAPromise = () => Promise.resolve();

const iThrow = () => { throw new Error('Hello!'); }

somethingThatReturnsAPromise()
  .then(iThrow)
  .catch(err => console.log(`I caught an error!: ${err}`));
```

2. Synchronous code in Promises: It is not necessary to return a Promise in a `then` clause in order to continue chaining. The following works just fine:

```
const somethingThatReturnsAPromise = () => Promise.resolve();

somethingThatReturnsAPromise()
  .then(() => 42)
  .then(answer => console.log(`the answer is: ${answer}`));
```

Overall, fewer promises (more synchronous code) makes the code easier to understand, test, and refactor.

Moreover, I would like to start using the `async/await` syntax where appropriate as I find that it simplifies understanding asynchronous code by presenting in a way that appears synchronous. This also enables "early return" from functions that is easier to understand. One toy example, not addressed here looks like:

```
async (req, res) => {
  const site = await Site.findById(req.params.id);
  if (!site) {
    return res.status(404).send("Not found.");
  }

  ..continue doing things with site
  }
}
```

