### PR TITLE
display the site in the delete popup

### DIFF
--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -18,7 +18,7 @@ class SiteSettings extends React.Component {
 
   handleDelete() {
     // eslint-disable-next-line no-alert
-    if (window.confirm('Are you sure you want to delete this site for all users? This action will also delete all site builds and take down the live site, if published.')) {
+    if (window.confirm(`${this.props.site.owner}/${this.props.site.repository}\nAre you sure you want to delete this site for all users? This action will also delete all site builds and take down the live site, if published.`)) {
       return siteActions.deleteSite(this.props.site.id);
     }
 


### PR DESCRIPTION
when the delete site popup appears, i want to make sure i'm deleting the correct site.

before:
<img width="444" alt="Screen Shot 2019-11-20 at 9 06 19 PM" src="https://user-images.githubusercontent.com/1261794/69296317-a7d84a00-0bd9-11ea-9d56-1f98a594cfb5.png">

after:
<img width="447" alt="Screen Shot 2019-11-20 at 9 05 38 PM" src="https://user-images.githubusercontent.com/1261794/69296316-a7d84a00-0bd9-11ea-98db-8e3239ac38f3.png">
