### PR TITLE
Handle new logs with source 'ALL'

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,7 +4,7 @@ engines:
     enabled: false
   eslint:
     enabled: true
-    channel: "eslint-3"
+    channel: "eslint-5"
     checks:
       import/no-unresolved:
         enabled: false

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,6 @@ module.exports = {
   plugins: finalPlugins,
   rules: finalRules,
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 9,
   },
 };

--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -1,3 +1,4 @@
+const Seq = require('sequelize');
 const { wrapHandlers } = require('../utils');
 const buildLogSerializer = require('../serializers/build-log');
 const { Build, BuildLog } = require('../models');
@@ -34,6 +35,11 @@ module.exports = wrapHandlers({
 
   find: async (req, res) => {
     const limit = 5;
+    // A page is set to a maximum of 200,000 characters. Assuming
+    // a each log line is about 200 characters, that is roughly
+    // equal to 1,000 lines
+    const lineLimit = 5 * 1000;
+
     const { params, user } = req;
     const { build_id: buildId, page = 1 } = params;
 
@@ -43,13 +49,33 @@ module.exports = wrapHandlers({
       return res.notFound();
     }
 
-    const buildLogs = await BuildLog.findAll({
-      where: { build: build.id },
+    // I think it will be more efficient to aggregate these at the db level...
+    // attributes: [[Seq.fn('STRING_AGG', Seq.col('output'), '\n'), 'output']]
+    // group: ['build', 'source']
+    let buildLogs = await BuildLog.findAll({
+      where: {
+        build: build.id,
+        source: 'ALL',
+      },
       order: [['id', 'ASC']],
-      offset: (limit * (page - 1)),
-      limit,
+      offset: (lineLimit * (page - 1)),
+      lineLimit,
       include: [Build],
     });
+
+    // Support legacy build logs
+    if (buildLogs.length === 0) {
+      buildLogs = await BuildLog.findAll({
+        where: {
+          build: build.id,
+          source: { [Seq.Op.ne]: 'ALL' },
+        },
+        order: [['id', 'ASC']],
+        offset: (limit * (page - 1)),
+        limit,
+        include: [Build],
+      });
+    }
 
     const serializedBuildLogs = await buildLogSerializer.serialize(buildLogs);
 

--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -1,4 +1,3 @@
-const siteAuthorizer = require('../authorizers/site');
 const buildLogSerializer = require('../serializers/build-log');
 const { Build, BuildLog } = require('../models');
 
@@ -12,71 +11,51 @@ function decodeb64(str) {
 module.exports = {
   create: (req, res) => {
     Promise.resolve(Number(req.params.build_id))
-    .then((id) => {
-      if (isNaN(id)) { throw 404; }
-      return Build.findByPk(id);
-    })
-    .then((build) => {
-      if (!build) {
-        throw 404;
-      } else if (build.token !== req.params.token) {
-        throw 403;
-      }
-
-      return BuildLog.create({
-        build: build.id,
-        output: decodeb64(req.body.output),
-        source: req.body.source,
-      });
-    })
-    .then(buildLog => buildLogSerializer.serialize(buildLog))
-    .then((buildLogJSON) => { res.json(buildLogJSON); })
-    .catch((err) => {
-      res.error(err);
-    });
-  },
-
-  find: (req, res) => {
-    let build;
-    const limit = 5;
-
-    const isPlaintext = req.query.format &&
-      req.query.format.toLowerCase() === 'text';
-
-    return Promise.resolve(Number(req.params.build_id))
       .then((id) => {
-        if (isNaN(id)) {
-          throw 404;
-        }
+        if (isNaN(id)) { throw 404; }
         return Build.findByPk(id);
-      }).then((model) => {
-        build = model;
+      })
+      .then((build) => {
         if (!build) {
           throw 404;
+        } else if (build.token !== req.params.token) {
+          throw 403;
         }
-        return siteAuthorizer.findOne(req.user, { id: build.site });
+
+        return BuildLog.create({
+          build: build.id,
+          output: decodeb64(req.body.output),
+          source: req.body.source,
+        });
       })
-      .then(() =>
-        Promise.resolve(Number(req.params.page) || 1)
-        .then(page => BuildLog.findAll({
-          attributes: ['id'],
-          where: { build: build.id },
-          order: [['id', 'ASC']],
-          offset: (limit * (page - 1)),
-          limit,
-        }))
-      )
-      .then(buildLogs => buildLogSerializer.serialize(buildLogs, { isPlaintext }))
-      .then((serializedBuildLogs) => {
-        if (isPlaintext) {
-          // .findAll always resolves to an array, so join is available
-          res.type('text').send(serializedBuildLogs.join('\n\n'));
-        } else {
-          res.json(serializedBuildLogs);
-        }
-      })
+      .then(buildLog => buildLogSerializer.serialize(buildLog))
+      .then((buildLogJSON) => { res.json(buildLogJSON); })
       .catch((err) => {
         res.error(err);
       });
+  },
+
+  find: async (req, res) => {
+    const limit = 5;
+    const { params, user } = req;
+    const { build_id: buildId, page = 1 } = params;
+
+    const build = await Build.forUser(user).findByPk(buildId);
+
+    if (!build) {
+      return res.status(404).send('Not Found');
+    }
+
+    const buildLogs = await BuildLog.findAll({
+      where: { build: build.id },
+      order: [['id', 'ASC']],
+      offset: (limit * (page - 1)),
+      limit,
+      include: [Build],
+    });
+
+    const serializedBuildLogs = await buildLogSerializer.serialize(buildLogs);
+
+    return res.json(serializedBuildLogs);
   },
 };

--- a/api/responses/error.js
+++ b/api/responses/error.js
@@ -1,3 +1,5 @@
+const { DatabaseError } = require('sequelize');
+
 module.exports = (error = {}, { res }) => {
   let finalError = error;
 
@@ -9,6 +11,10 @@ module.exports = (error = {}, { res }) => {
     finalError = {
       status: 400,
       message: 'The request parameters were invalid.',
+    };
+  } else if (error instanceof DatabaseError) {
+    finalError = {
+      status: 404,
     };
   }
 

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -121,6 +121,28 @@ function shouldIncludeTracking() {
   return config.app.app_env === 'production';
 }
 
+function mapValues(fn, obj) {
+  const reducer = (acc, key) => {
+    acc[key] = fn(obj[key]);
+    return acc;
+  };
+  return Object.keys(obj).reduce(reducer, {});
+}
+
+function wrapHandler(fn) {
+  return (...args) => fn(...args).catch(args[1].error);
+  // We really want to just call `next` (args[2]) with the error
+  // but we currently have this other error handling that is short
+  // circuiting the typical Express error handling stack. Save
+  // refactoring it for another day.
+  // This will call `res.error(err)`, see logic in api/responses.
+  // return (...args) => fn(...args).catch(args[2]);
+}
+
+function wrapHandlers(handlers) {
+  return mapValues(wrapHandler, handlers);
+}
+
 module.exports = {
   filterEntity,
   firstEntity,
@@ -131,5 +153,8 @@ module.exports = {
   loadAssetManifest,
   loadDevelopmentManifest,
   loadProductionManifest,
+  mapValues,
   shouldIncludeTracking,
+  wrapHandler,
+  wrapHandlers,
 };

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const ConnectSession = require('connect-session-sequelize');
 const nunjucks = require('nunjucks');
 const flash = require('connect-flash');
 const http = require('http');
+const { SequelizeDatabaseError } = require('sequelize');
 const io = require('socket.io');
 const redis = require('redis');
 const redisAdapter = require('socket.io-redis');
@@ -150,9 +151,12 @@ app.use((err, req, res, next) => {
 });
 
 // Generic error handler
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line
 app.use((err, _req, res, _next) => {
-  res.status(500).send({ message: `An unexpected error occurred: ${err.message}` });
+  if (err instanceof SequelizeDatabaseError) {
+    return res.status(404).send('Not Found');
+  }
+  return res.status(500).send({ message: `An unexpected error occurred: ${err.message}` });
 });
 
 socket.use((_socket, next) => {

--- a/app.js
+++ b/app.js
@@ -7,7 +7,6 @@ const ConnectSession = require('connect-session-sequelize');
 const nunjucks = require('nunjucks');
 const flash = require('connect-flash');
 const http = require('http');
-const { SequelizeDatabaseError } = require('sequelize');
 const io = require('socket.io');
 const redis = require('redis');
 const redisAdapter = require('socket.io-redis');
@@ -153,10 +152,7 @@ app.use((err, req, res, next) => {
 // Generic error handler
 // eslint-disable-next-line
 app.use((err, _req, res, _next) => {
-  if (err instanceof SequelizeDatabaseError) {
-    return res.status(404).send('Not Found');
-  }
-  return res.status(500).send({ message: `An unexpected error occurred: ${err.message}` });
+  res.status(500).send({ message: `An unexpected error occurred: ${err.message}` });
 });
 
 socket.use((_socket, next) => {

--- a/frontend/components/site/downloadBuildLogsButton.jsx
+++ b/frontend/components/site/downloadBuildLogsButton.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import autoBind from 'react-autobind';
 import fileDownload from 'js-file-download';
 import { BUILD_LOG } from '../../propTypes';
+import { groupLogs } from '../../util';
 
 class DownloadBuildLogsButton extends React.Component {
   constructor(props) {
@@ -11,14 +12,15 @@ class DownloadBuildLogsButton extends React.Component {
   }
 
   downloadBuildLogs() {
-    let buildLogsData = this.props.buildLogsData || [];
-    buildLogsData = buildLogsData.map(data => [`Source: ${data.source}`, `Timestamp: ${(new Date(data.createdAt)).toISOString()}`, `Output:\n${data.output}`].join('\n'));
-    fileDownload(buildLogsData.join('\n\n'), `build-log-${this.props.buildId}.txt`);
+    const { buildLogsData = [], buildId } = this.props;
+    const groupedLogs = groupLogs(buildLogsData);
+    const text = Object.keys(groupedLogs).map(source => `${source}\n${groupedLogs[source].join('\n')}`).join('\n\n');
+    fileDownload(text, `build-log-${buildId}.txt`);
   }
 
   render() {
     return (
-      <button className="usa-button" onClick={this.downloadBuildLogs}>Download logs</button>
+      <button type="button" className="usa-button" onClick={this.downloadBuildLogs}>Download logs</button>
     );
   }
 }

--- a/frontend/components/site/siteBuildLogTable.jsx
+++ b/frontend/components/site/siteBuildLogTable.jsx
@@ -2,25 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { BUILD_LOG } from '../../propTypes';
+import { groupLogs } from '../../util';
 
 function SiteBuildLogTable({ buildLogs }) {
+  const groupedLogs = groupLogs(buildLogs);
+
   return (
     <table className="usa-table-borderless log-table log-table__site-build-log table-full-width">
       <tbody className="log-data">
-        {buildLogs.map((log => (
-          <tr key={log.id}>
+        {Object.keys(groupedLogs).map(source => (
+          <tr>
             <td>
-              {log.source !== 'ALL' && (
+              {source !== 'ALL' && (
               <pre className="log-source-header">
-                <span name={`${log.source}-${log.id}`}>{log.source}</span>
+                <span>{source}</span>
               </pre>
               )}
               <pre>
-                {log.output}
+                {groupedLogs[source].join('\n')}
               </pre>
             </td>
           </tr>
-        )))}
+        ))}
       </tbody>
     </table>
   );

--- a/frontend/util/index.js
+++ b/frontend/util/index.js
@@ -8,3 +8,11 @@ export function getSafeRepoName(name) {
     .replace(/^-+/g, '') // remove starting hyphens
     .replace(/-+$/g, ''); // remove ending hyphens
 }
+
+export function groupLogs(logs) {
+  return logs.reduce((groups, log) => {
+    // eslint-disable-next-line no-param-reassign
+    groups[log.source] = (groups[log.source] || []).concat([log.output]);
+    return groups;
+  }, {});
+}

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "babel-preset-stage-2": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^3.5.0",
+    "chai-as-promised": "^7.1.1",
     "chai-fetch-mock": "^1.0.1",
     "concurrently": "^3.4.0",
     "cookie": "^0.3.1",

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -140,21 +140,11 @@ async function createData({ githubUsername }) {
       source: 'fake-build-step1',
       build: site2Builds[0].id,
     }),
-    BuildLog.create({
+    Promise.all(Array(20).fill(0).map(() => BuildLog.create({
       output: log('This log has a source of ALL'),
       source: 'ALL',
       build: site2Builds[0].id,
-    }),
-    BuildLog.create({
-      output: log('This log has a source of ALL'),
-      source: 'ALL',
-      build: site2Builds[0].id,
-    }),
-    BuildLog.create({
-      output: log('This log has a source of ALL'),
-      source: 'ALL',
-      build: site2Builds[0].id,
-    }),
+    }))),
   ]);
 
   console.log('Creating user actions...');

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -1,15 +1,27 @@
 /* eslint-disable no-console */
 const inquirer = require('inquirer');
+Promise.props = require('promise-props');
 
 const cleanDatabase = require('../api/utils/cleanDatabase');
 const {
   ActionType,
   Build,
   BuildLog,
-  Site,
   User,
   UserAction,
 } = require('../api/models');
+const { site: siteFactory } = require('../test/api/support/factory');
+
+const loremIpsum = `
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Nullam fringilla, arcu ut ultricies auctor, elit quam
+  consequat neque, eu blandit metus lorem non turpis.
+  Ut luctus nec turpis pellentesque dignissim. Vivamus
+  porttitor tellus turpis, a tempor velit tincidunt at.
+  Aenean laoreet nulla ut porta semper.
+`.replace(/\s\s+/g, ' ');
+
+const log = msg => `${(new Date()).toUTCString()} INFO [main] - ${msg}`;
 
 async function createData({ githubUsername }) {
   console.log('Cleaning database...');
@@ -19,39 +31,41 @@ async function createData({ githubUsername }) {
   await ActionType.createDefaultActionTypes();
 
   console.log('Creating users...');
-  const user1 = await User.create({
-    username: githubUsername,
-    email: `${githubUsername}@example.com`,
-  });
+  const [user1, user2] = await Promise.all([
+    User.create({
+      username: githubUsername,
+      email: `${githubUsername}@example.com`,
+    }),
 
-  const user2 = await User.create({
-    username: 'fake-user',
-    email: 'fake-user@example.com',
-    githubAccessToken: 'fake-access-token',
-    githubUserId: 123456,
-  });
+    User.create({
+      username: 'fake-user',
+      email: 'fake-user@example.com',
+      githubAccessToken: 'fake-access-token',
+      githubUserId: 123456,
+    }),
+  ]);
 
   console.log('Creating sites...');
-  const site1 = await Site.create({
-    demoBranch: 'demo-branch',
-    demoDomain: 'https://demo.example.gov',
-    defaultBranch: 'master',
-    domain: 'https://example.gov',
-    engine: 'jekyll',
-    owner: user1.username,
-    repository: 'example-site',
-    s3ServiceName: 'federalist-dev-s3',
-    awsBucketName: 'cg-123456789',
-    awsBucketRegion: 'us-gov-west-1',
-  });
+  const [site1, site2] = await Promise.all([
+    siteFactory({
+      demoBranch: 'demo-branch',
+      demoDomain: 'https://demo.example.gov',
+      domain: 'https://example.gov',
+      owner: user1.username,
+      repository: 'example-site',
+      users: [user1, user2],
+    }),
 
-  await Promise.all([
-    site1.addUser(user1.id),
-    site1.addUser(user2.id),
+    siteFactory({
+      engine: 'node.js',
+      owner: user1.username,
+      repository: 'example-node-site',
+      users: [user1],
+    }),
   ]);
 
   console.log('Creating builds...');
-  const builds = await Promise.all([
+  const site1Builds = await Promise.all([
     Build.create({
       branch: site1.defaultBranch,
       completedAt: new Date(),
@@ -80,19 +94,70 @@ async function createData({ githubUsername }) {
     }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe2' })),
   ]);
 
-  console.log('Creating build logs...');
-  await Promise.all(builds.map(build => BuildLog.create({
-    output: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              Nullam fringilla, arcu ut ultricies auctor, elit quam
-              consequat neque, eu blandit metus lorem non turpis.
-              Ut luctus nec turpis pellentesque dignissim. Vivamus
-              porttitor tellus turpis, a tempor velit tincidunt at.
-              Aenean laoreet nulla ut porta semper.`.replace(/\s\s+/g, ' '),
-    source: 'fake-build-step',
-    build: build.id,
-  })));
+  const site2Builds = await Promise.all([
+    Build.create({
+      branch: site2.defaultBranch,
+      completedAt: new Date(),
+      source: 'fake-build',
+      state: 'success',
+      site: site2.id,
+      user: user1.id,
+      token: 'fake-token',
+    }),
+    Build.create({
+      branch: 'dc/fixes',
+      source: 'fake-build',
+      site: site2.id,
+      user: user1.id,
+      token: 'fake-token',
+    }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe1' })),
+  ]);
 
-  console.log('Creatign user actions...');
+  console.log('Creating build logs...');
+  await Promise.all([
+    BuildLog.create({
+      output: loremIpsum,
+      source: 'fake-build-step1',
+      build: site1Builds[0].id,
+    }),
+    BuildLog.create({
+      output: loremIpsum,
+      source: 'fake-build-step2',
+      build: site1Builds[0].id,
+    }),
+    BuildLog.create({
+      output: loremIpsum,
+      source: 'fake-build-step1',
+      build: site1Builds[1].id,
+    }),
+    BuildLog.create({
+      output: loremIpsum,
+      source: 'fake-build-step1',
+      build: site1Builds[2].id,
+    }),
+    BuildLog.create({
+      output: log('This log should not be visible'),
+      source: 'fake-build-step1',
+      build: site2Builds[0].id,
+    }),
+    BuildLog.create({
+      output: log('This log has a source of ALL'),
+      source: 'ALL',
+      build: site2Builds[0].id,
+    }),
+    BuildLog.create({
+      output: log('This log has a source of ALL'),
+      source: 'ALL',
+      build: site2Builds[0].id,
+    }),
+    BuildLog.create({
+      output: log('This log has a source of ALL'),
+      source: 'ALL',
+      build: site2Builds[0].id,
+    }),
+  ]);
+
+  console.log('Creating user actions...');
   const removeAction = await ActionType.findOne({ where: { action: 'remove' } });
   await UserAction.create({
     userId: user1.id,

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const inquirer = require('inquirer');
 
 const cleanDatabase = require('../api/utils/cleanDatabase');
@@ -17,119 +18,119 @@ const confirm = {
   message: 'This will DELETE all data in your development database. Are you sure you want to continue?',
 };
 
-function createSite(user, params) {
-  return Site.create(params)
-    .then(site => site.addUser(user.id).then(() => site));
-}
+// questions to collect necessary info to bootstrap the db
+const questions = [{
+  type: 'input',
+  name: 'githubUsername',
+  message: 'What is your GitHub username?',
+}];
 
-inquirer.prompt(confirm).then(({ userAgrees }) => {
-  // exit if the user did not agree to the confirmation
-  if (!userAgrees) {
-    // eslint-disable-next-line no-console
-    console.log('Exiting without making any changes.');
-    process.exit();
-  }
+inquirer.prompt(confirm)
+  .then(async ({ userAgrees }) => {
+    // exit if the user did not agree to the confirmation
+    if (!userAgrees) {
+      console.log('Exiting without making any changes.');
+      process.exit();
+    }
 
-  // questions to collect necessary info to bootstrap the db
-  const questions = [{
-    type: 'input',
-    name: 'githubUsername',
-    message: 'What is your GitHub username?',
-  }];
+    const { githubUsername } = await inquirer.prompt(questions);
 
-  inquirer.prompt(questions).then(({ githubUsername }) => {
-    const thisUserId = 1;
-    const thisSiteId = 1;
+    console.log('Cleaning database...');
+    await cleanDatabase();
 
-    cleanDatabase()
-      .then(() => ActionType.createDefaultActionTypes())
-      // create a user for the given github username
-      .then(() => User.create({
-        id: thisUserId,
-        username: githubUsername,
-        email: `${githubUsername}@example.com`,
-      }))
-      // create a site for the user
-      .then(thisUser => createSite(thisUser, {
-        id: thisSiteId,
-        demoBranch: 'demo-branch',
-        demoDomain: 'https://demo.example.gov',
-        defaultBranch: 'master',
-        domain: 'https://example.gov',
-        engine: 'jekyll',
-        owner: thisUser.username,
-        repository: 'example-site',
-        s3ServiceName: 'federalist-dev-s3',
-        awsBucketName: 'cg-123456789',
-        awsBucketRegion: 'us-gov-west-1',
-      }))
-      // create a build for the site
-      .then(site => Promise.all([
-        Build.create({
-          branch: site.defaultBranch,
-          completedAt: new Date(),
-          source: 'fake-build',
-          state: 'success',
-          site: site.id,
-          user: thisUserId,
-          token: 'fake-token',
-        }),
-        Build.create({
-          branch: site.defaultBranch,
-          source: 'fake-build',
-          site: site.id,
-          user: thisUserId,
-          token: 'fake-token',
-        }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe1' })),
-        Build.create({
-          branch: site.demoBranch,
-          source: 'fake-build',
-          site: site.id,
-          user: thisUserId,
-          token: 'fake-token',
-          state: 'error',
-          error: 'Something bad happened here',
-          completedAt: new Date(),
-        }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe2' })),
-      ]))
-      // create a build log for the build
-      .then(builds => builds.map(build => BuildLog.create({
-        output: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                 Nullam fringilla, arcu ut ultricies auctor, elit quam
-                 consequat neque, eu blandit metus lorem non turpis.
-                 Ut luctus nec turpis pellentesque dignissim. Vivamus
-                 porttitor tellus turpis, a tempor velit tincidunt at.
-                 Aenean laoreet nulla ut porta semper.`.replace(/\s\s+/g, ' '),
-        source: 'fake-build-step',
-        build: build.id,
-      })))
-      // create another user
-      .then(() => User.create({
-        id: 2,
-        username: 'fake-user',
-        email: 'fake-user@example.com',
-        githubAccessToken: 'fake-access-token',
-        githubUserId: 123456,
-      }))
-      // add the other user to example site
-      .then(fakeUser => fakeUser
-        .addSite(thisSiteId)
-        .then(() => fakeUser))
-      // create a useraction of removing the other user
-      .then(fakeUser => ActionType.findOne({ where: { action: 'remove' } })
-        .then(removeAction => UserAction.create({
-          userId: thisUserId,
-          targetId: fakeUser.id,
-          targetType: 'user',
-          actionId: removeAction.id,
-          siteId: thisSiteId,
-        })))
-      .then(() => {
-        /* eslint-disable no-console */
-        console.log('Done!');
-        console.log('You may have to log out and then back in to your local development instance of Federalist.');
-        /* eslint-enable no-console */
-        process.exit();
-      });
+    console.log('Creating default action types...');
+    await ActionType.createDefaultActionTypes();
+
+    console.log('Creating users...');
+    const user1 = await User.create({
+      username: githubUsername,
+      email: `${githubUsername}@example.com`,
+    });
+
+    const user2 = await User.create({
+      username: 'fake-user',
+      email: 'fake-user@example.com',
+      githubAccessToken: 'fake-access-token',
+      githubUserId: 123456,
+    });
+
+    console.log('Creating sites...');
+    const site1 = await Site.create({
+      demoBranch: 'demo-branch',
+      demoDomain: 'https://demo.example.gov',
+      defaultBranch: 'master',
+      domain: 'https://example.gov',
+      engine: 'jekyll',
+      owner: user1.username,
+      repository: 'example-site',
+      s3ServiceName: 'federalist-dev-s3',
+      awsBucketName: 'cg-123456789',
+      awsBucketRegion: 'us-gov-west-1',
+    });
+
+    await Promise.all([
+      site1.addUser(user1.id),
+      site1.addUser(user2.id),
+    ]);
+
+    console.log('Creating builds...');
+    const builds = await Promise.all([
+      Build.create({
+        branch: site1.defaultBranch,
+        completedAt: new Date(),
+        source: 'fake-build',
+        state: 'success',
+        site: site1.id,
+        user: user1.id,
+        token: 'fake-token',
+      }),
+      Build.create({
+        branch: site1.defaultBranch,
+        source: 'fake-build',
+        site: site1.id,
+        user: user1.id,
+        token: 'fake-token',
+      }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe1' })),
+      Build.create({
+        branch: site1.demoBranch,
+        source: 'fake-build',
+        site: site1.id,
+        user: user1.id,
+        token: 'fake-token',
+        state: 'error',
+        error: 'Something bad happened here',
+        completedAt: new Date(),
+      }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe2' })),
+    ]);
+
+    console.log('Creating build logs...');
+    await Promise.all(builds.map(build => BuildLog.create({
+      output: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              Nullam fringilla, arcu ut ultricies auctor, elit quam
+              consequat neque, eu blandit metus lorem non turpis.
+              Ut luctus nec turpis pellentesque dignissim. Vivamus
+              porttitor tellus turpis, a tempor velit tincidunt at.
+              Aenean laoreet nulla ut porta semper.`.replace(/\s\s+/g, ' '),
+      source: 'fake-build-step',
+      build: build.id,
+    })));
+
+    // create a useraction of removing the other user
+    const removeAction = await ActionType.findOne({ where: { action: 'remove' } });
+    await UserAction.create({
+      userId: user1.id,
+      targetId: user2.id,
+      targetType: 'user',
+      actionId: removeAction.id,
+      siteId: site1.id,
+    });
+
+    console.log('Done!');
+    console.log('You may have to log out and then back in to your local development instance of Federalist.');
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('Uh oh, we have a problem!');
+    console.error(error);
+    process.exit(1);
   });
-});

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -11,6 +11,98 @@ const {
   UserAction,
 } = require('../api/models');
 
+async function createData({ githubUsername }) {
+  console.log('Cleaning database...');
+  await cleanDatabase();
+
+  console.log('Creating default action types...');
+  await ActionType.createDefaultActionTypes();
+
+  console.log('Creating users...');
+  const user1 = await User.create({
+    username: githubUsername,
+    email: `${githubUsername}@example.com`,
+  });
+
+  const user2 = await User.create({
+    username: 'fake-user',
+    email: 'fake-user@example.com',
+    githubAccessToken: 'fake-access-token',
+    githubUserId: 123456,
+  });
+
+  console.log('Creating sites...');
+  const site1 = await Site.create({
+    demoBranch: 'demo-branch',
+    demoDomain: 'https://demo.example.gov',
+    defaultBranch: 'master',
+    domain: 'https://example.gov',
+    engine: 'jekyll',
+    owner: user1.username,
+    repository: 'example-site',
+    s3ServiceName: 'federalist-dev-s3',
+    awsBucketName: 'cg-123456789',
+    awsBucketRegion: 'us-gov-west-1',
+  });
+
+  await Promise.all([
+    site1.addUser(user1.id),
+    site1.addUser(user2.id),
+  ]);
+
+  console.log('Creating builds...');
+  const builds = await Promise.all([
+    Build.create({
+      branch: site1.defaultBranch,
+      completedAt: new Date(),
+      source: 'fake-build',
+      state: 'success',
+      site: site1.id,
+      user: user1.id,
+      token: 'fake-token',
+    }),
+    Build.create({
+      branch: site1.defaultBranch,
+      source: 'fake-build',
+      site: site1.id,
+      user: user1.id,
+      token: 'fake-token',
+    }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe1' })),
+    Build.create({
+      branch: site1.demoBranch,
+      source: 'fake-build',
+      site: site1.id,
+      user: user1.id,
+      token: 'fake-token',
+      state: 'error',
+      error: 'Something bad happened here',
+      completedAt: new Date(),
+    }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe2' })),
+  ]);
+
+  console.log('Creating build logs...');
+  await Promise.all(builds.map(build => BuildLog.create({
+    output: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              Nullam fringilla, arcu ut ultricies auctor, elit quam
+              consequat neque, eu blandit metus lorem non turpis.
+              Ut luctus nec turpis pellentesque dignissim. Vivamus
+              porttitor tellus turpis, a tempor velit tincidunt at.
+              Aenean laoreet nulla ut porta semper.`.replace(/\s\s+/g, ' '),
+    source: 'fake-build-step',
+    build: build.id,
+  })));
+
+  console.log('Creatign user actions...');
+  const removeAction = await ActionType.findOne({ where: { action: 'remove' } });
+  await UserAction.create({
+    userId: user1.id,
+    targetId: user2.id,
+    targetType: 'user',
+    actionId: removeAction.id,
+    siteId: site1.id,
+  });
+}
+
 const confirm = {
   type: 'confirm',
   default: false,
@@ -26,108 +118,19 @@ const questions = [{
 }];
 
 inquirer.prompt(confirm)
-  .then(async ({ userAgrees }) => {
+  .then(({ userAgrees }) => {
     // exit if the user did not agree to the confirmation
     if (!userAgrees) {
       console.log('Exiting without making any changes.');
       process.exit();
     }
-
-    const { githubUsername } = await inquirer.prompt(questions);
-
-    console.log('Cleaning database...');
-    await cleanDatabase();
-
-    console.log('Creating default action types...');
-    await ActionType.createDefaultActionTypes();
-
-    console.log('Creating users...');
-    const user1 = await User.create({
-      username: githubUsername,
-      email: `${githubUsername}@example.com`,
-    });
-
-    const user2 = await User.create({
-      username: 'fake-user',
-      email: 'fake-user@example.com',
-      githubAccessToken: 'fake-access-token',
-      githubUserId: 123456,
-    });
-
-    console.log('Creating sites...');
-    const site1 = await Site.create({
-      demoBranch: 'demo-branch',
-      demoDomain: 'https://demo.example.gov',
-      defaultBranch: 'master',
-      domain: 'https://example.gov',
-      engine: 'jekyll',
-      owner: user1.username,
-      repository: 'example-site',
-      s3ServiceName: 'federalist-dev-s3',
-      awsBucketName: 'cg-123456789',
-      awsBucketRegion: 'us-gov-west-1',
-    });
-
-    await Promise.all([
-      site1.addUser(user1.id),
-      site1.addUser(user2.id),
-    ]);
-
-    console.log('Creating builds...');
-    const builds = await Promise.all([
-      Build.create({
-        branch: site1.defaultBranch,
-        completedAt: new Date(),
-        source: 'fake-build',
-        state: 'success',
-        site: site1.id,
-        user: user1.id,
-        token: 'fake-token',
-      }),
-      Build.create({
-        branch: site1.defaultBranch,
-        source: 'fake-build',
-        site: site1.id,
-        user: user1.id,
-        token: 'fake-token',
-      }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe1' })),
-      Build.create({
-        branch: site1.demoBranch,
-        source: 'fake-build',
-        site: site1.id,
-        user: user1.id,
-        token: 'fake-token',
-        state: 'error',
-        error: 'Something bad happened here',
-        completedAt: new Date(),
-      }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe2' })),
-    ]);
-
-    console.log('Creating build logs...');
-    await Promise.all(builds.map(build => BuildLog.create({
-      output: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              Nullam fringilla, arcu ut ultricies auctor, elit quam
-              consequat neque, eu blandit metus lorem non turpis.
-              Ut luctus nec turpis pellentesque dignissim. Vivamus
-              porttitor tellus turpis, a tempor velit tincidunt at.
-              Aenean laoreet nulla ut porta semper.`.replace(/\s\s+/g, ' '),
-      source: 'fake-build-step',
-      build: build.id,
-    })));
-
-    // create a useraction of removing the other user
-    const removeAction = await ActionType.findOne({ where: { action: 'remove' } });
-    await UserAction.create({
-      userId: user1.id,
-      targetId: user2.id,
-      targetType: 'user',
-      actionId: removeAction.id,
-      siteId: site1.id,
-    });
-
+  })
+  .then(() => inquirer.prompt(questions))
+  .then(createData)
+  .then(() => {
     console.log('Done!');
     console.log('You may have to log out and then back in to your local development instance of Federalist.');
-    process.exit(0);
+    process.exit();
   })
   .catch((error) => {
     console.error('Uh oh, we have a problem!');

--- a/test/api/bootstrap.test.js
+++ b/test/api/bootstrap.test.js
@@ -1,3 +1,8 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+
 Promise.props = require('promise-props');
 
 require('./support/aws-mocks');

--- a/test/api/requests/build-logs.test.js
+++ b/test/api/requests/build-logs.test.js
@@ -223,20 +223,24 @@ describe('Build Log API', () => {
       authenticatedSession().then(cookie => request(app)
         .get('/v0/build/fake-id/log')
         .set('Cookie', cookie)
-        .expect(404)).then((response) => {
+        .expect(404))
+      .then((response) => {
         validateAgainstJSONSchema('GET', '/build/{build_id}/log', 404, response.body);
         done();
-      }).catch(done);
+      })
+      .catch(done);
     });
 
     it('should response with a 404 if the given build does not exist', (done) => {
       authenticatedSession().then(cookie => request(app)
         .get('/v0/build/-100/log')
         .set('Cookie', cookie)
-        .expect(404)).then((response) => {
+        .expect(404))
+      .then((response) => {
         validateAgainstJSONSchema('GET', '/build/{build_id}/log', 404, response.body);
         done();
-      }).catch(done);
+      })
+      .catch(done);
     });
 
     describe('build logs with source =`ALL`', () => {

--- a/test/api/requests/build-logs.test.js
+++ b/test/api/requests/build-logs.test.js
@@ -239,7 +239,7 @@ describe('Build Log API', () => {
       }).catch(done);
     });
 
-    describe.only('build logs with source =`ALL`', () => {
+    describe('build logs with source =`ALL`', () => {
       let build;
       let cookie;
 

--- a/test/api/requests/build-logs.test.js
+++ b/test/api/requests/build-logs.test.js
@@ -1,12 +1,12 @@
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const request = require('supertest');
 const app = require('../../../app');
 const factory = require('../support/factory');
 const { authenticatedSession } = require('../support/session');
 const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
-const { BuildLog, Site, User } = require('../../../api/models');
+const { BuildLog } = require('../../../api/models');
 
-describe('Build Log API', () => {
+describe.only('Build Log API', () => {
   describe('POST /v0/build/:build_id/log/:token', () => {
     const encode64 = str => Buffer.from(str, 'utf8').toString('base64');
 
@@ -34,21 +34,21 @@ describe('Build Log API', () => {
         expect(logs[0]).to.have.property('output', 'This is the output for build.sh');
         done();
       })
-      .catch(done);
+        .catch(done);
     });
 
     it('should respond with a 400 if the params are not correct', (done) => {
       factory.build().then(build => request(app)
-          .post(`/v0/build/${build.id}/log/${build.token}`)
-          .type('json')
-          .send({ src: 'build.sh', otpt: encode64('This is the output for build.sh') })
-          .expect(400)).then((response) => {
-            validateAgainstJSONSchema('POST', '/build/{build_id}/log/{token}', 400, response.body);
-            done();
-          }).catch(done);
+        .post(`/v0/build/${build.id}/log/${build.token}`)
+        .type('json')
+        .send({ src: 'build.sh', otpt: encode64('This is the output for build.sh') })
+        .expect(400)).then((response) => {
+        validateAgainstJSONSchema('POST', '/build/{build_id}/log/{token}', 400, response.body);
+        done();
+      }).catch(done);
     });
 
-    it('should respond with a 403 and not create a build log for an invalid build token', (done) => {
+    it('should respond with a 404 and not create a build log for an invalid build token', (done) => {
       let build;
 
       factory.build().then((model) => {
@@ -58,16 +58,16 @@ describe('Build Log API', () => {
           .post(`/v0/build/${build.id}/log/invalid-token`)
           .type('json')
           .send({ source: 'build.sh', output: encode64('This is the output for build.sh') })
-          .expect(403);
+          .expect(404);
       }).then((response) => {
-        validateAgainstJSONSchema('POST', '/build/{build_id}/log/{token}', 403, response.body);
+        validateAgainstJSONSchema('POST', '/build/{build_id}/log/{token}', 404, response.body);
 
         return BuildLog.findAll({ where: { build: build.id } });
       }).then((logs) => {
         expect(logs).to.be.empty;
         done();
       })
-      .catch(done);
+        .catch(done);
     });
 
     it('should respond with a 404 if no build is found for the given id', (done) => {
@@ -89,20 +89,20 @@ describe('Build Log API', () => {
         .type('json')
         .send({ src: 'build.sh', otpt: encode64('This is the output for build.sh') })
         .expect(404)).then((response) => {
-          validateAgainstJSONSchema('POST', '/build/{build_id}/log/{token}', 400, response.body);
-          done();
-        }).catch(done);
+        validateAgainstJSONSchema('POST', '/build/{build_id}/log/{token}', 404, response.body);
+        done();
+      }).catch(done);
     });
   });
 
   describe('GET /v0/build/:build_id/log', () => {
     it('should require authentication', (done) => {
       factory.buildLog().then(buildLog => request(app)
-          .get(`/v0/build/${buildLog.build}/log`)
-          .expect(403)).then((response) => {
-            validateAgainstJSONSchema('GET', '/build/{build_id}/log', 403, response.body);
-            done();
-          }).catch(done);
+        .get(`/v0/build/${buildLog.build}/log`)
+        .expect(403)).then((response) => {
+        validateAgainstJSONSchema('GET', '/build/{build_id}/log', 403, response.body);
+        done();
+      }).catch(done);
     });
 
     describe('successfully fetching build logs', () => {
@@ -112,19 +112,17 @@ describe('Build Log API', () => {
         const buildPromise = factory.build({ user: userPromise, site: sitePromise });
 
         return Promise.props({ user: userPromise, site: sitePromise, build: buildPromise })
-        .then(({ build, user }) =>
-          Promise.all([
+          .then(({ build, user }) => Promise.all([
             Promise.all(Array(3).fill(0).map(() => factory.buildLog({ build }))),
             authenticatedSession(user),
-          ])
-        ).then(([logs, cookie]) => {
-          const buildId = logs[0].get({ plain: true }).build;
+          ])).then(([logs, cookie]) => {
+            const buildId = logs[0].get({ plain: true }).build;
 
-          return request(app)
-            .get(`/v0/build/${buildId}/log`)
-            .set('Cookie', cookie)
-            .expect(200);
-        });
+            return request(app)
+              .get(`/v0/build/${buildId}/log`)
+              .set('Cookie', cookie)
+              .expect(200);
+          });
       };
 
       const expectedResponse = (response, done) => {
@@ -136,36 +134,34 @@ describe('Build Log API', () => {
 
       it('should render builds logs for the given build', (done) => {
         prepareAndFetchLogData()
-        .then(response => expectedResponse(response, done))
-        .catch(done);
+          .then(response => expectedResponse(response, done))
+          .catch(done);
       });
 
       it('should render logs if user is not associated to the build', (done) => {
         prepareAndFetchLogData()
-        .then(response => expectedResponse(response, done))
-        .catch(done);
+          .then(response => expectedResponse(response, done))
+          .catch(done);
       });
     });
 
     describe('successfully fetching build logs with pagination', () => {
-      const fetchLogData = ({ logLen, page }) => {
+      const fetchLogData = ({ logLen, page }, status = 200) => {
         const userPromise = factory.user();
         const sitePromise = factory.site({ users: Promise.all([userPromise]) });
         const buildPromise = factory.build({ user: userPromise, site: sitePromise });
 
         return Promise.props({ user: userPromise, build: buildPromise })
-          .then(({ user, build }) =>
-            Promise.props({
-              logs: Promise.all(Array(logLen).fill(0).map(() => factory.buildLog({ build }))),
-              cookie: authenticatedSession(user),
-              page,
-            })
-          ).then(({ logs, cookie }) => {
+          .then(({ user, build }) => Promise.props({
+            logs: Promise.all(Array(logLen).fill(0).map(() => factory.buildLog({ build }))),
+            cookie: authenticatedSession(user),
+            page,
+          })).then(({ logs, cookie }) => {
             const buildId = logs[0].get({ plain: true }).build;
             return request(app)
               .get(`/v0/build/${buildId}/log/page/${page}`)
               .set('Cookie', cookie)
-              .expect(200);
+              .expect(status);
           });
       };
 
@@ -176,65 +172,34 @@ describe('Build Log API', () => {
         done();
       };
 
-      it('should render builds logs for the given build on page 0', (done) => {
-        fetchLogData({ logLen: 4, page: 0 })
-        .then(response => expectedResponse(4, response, done))
-        .catch(done);
-      });
-
-      it('should render builds logs for the given build on page NaN', (done) => {
-        fetchLogData({ logLen: 4, page: NaN })
-        .then(response => expectedResponse(4, response, done))
-        .catch(done);
-      });
-
       it('should render builds logs for the given build on page 1', (done) => {
         fetchLogData({ logLen: 6, page: 1 })
-        .then(response => expectedResponse(5, response, done))
-        .catch(done);
+          .then(response => expectedResponse(5, response, done))
+          .catch(done);
       });
 
       it('should render builds logs for the given build on page 2', (done) => {
         fetchLogData({ logLen: 8, page: 2 })
-        .then(response => expectedResponse(3, response, done))
-        .catch(done);
+          .then(response => expectedResponse(3, response, done))
+          .catch(done);
       });
 
       it('should render builds logs for the given build on empty page 3', (done) => {
         fetchLogData({ logLen: 10, page: 3 })
-        .then(response => expectedResponse(0, response, done))
-        .catch(done);
+          .then(response => expectedResponse(0, response, done))
+          .catch(done);
+      });
+
+      it('should respond with a 404 if page is 0', (done) => {
+        fetchLogData({ logLen: 10, page: 0 }, 404)
+          .then((response) => {
+            validateAgainstJSONSchema('GET', '/build/{build_id}/log', 404, response.body);
+            done();
+          });
       });
     });
 
-    it('should return plaintext logs when ?format=text', (done) => {
-      let build;
-
-      factory.build().then((model) => {
-        build = model;
-        return Promise.all(Array(3).fill(0).map(() => factory.buildLog({ build })));
-      })
-      .then(() => Site.findByPk(build.site, { include: [User] }))
-      .then((site) => {
-        const user = site.Users[0];
-        return authenticatedSession(user);
-      })
-      .then(cookie => request(app)
-        .get(`/v0/build/${build.id}/log?format=text`)
-        .set('Cookie', cookie)
-        .expect(200)
-        .expect('Content-Type', /text\/plain/)
-      )
-      .then((response) => {
-        expect(response.text.match(/Source: clone.sh/g).length).to.equal(3);
-        expect(response.text.match(/Timestamp:/g).length).to.equal(3);
-        expect(response.text.match(/Output:\nThis is output from the build container/g).length).to.equal(3);
-        done();
-      })
-      .catch(done);
-    });
-
-    it("should respond with a 403 if the given build is not associated with one of the user's sites", (done) => {
+    it("should respond with a 404 if the given build is not associated with one of the user's sites", (done) => {
       let build;
 
       factory.build().then((model) => {
@@ -242,17 +207,16 @@ describe('Build Log API', () => {
 
         return Promise.all(Array(3).fill(0).map(() => factory.buildLog()));
       })
-      .then(() => factory.user()).then(user => authenticatedSession(user))
-      .then(cookie => request(app)
-        .get(`/v0/build/${build.id}/log`)
-        .set('Cookie', cookie)
-        .expect(403)
-      )
-      .then((response) => {
-        validateAgainstJSONSchema('GET', '/build/{build_id}/log', 403, response.body);
-        done();
-      })
-      .catch(done);
+        .then(() => factory.user()).then(user => authenticatedSession(user))
+        .then(cookie => request(app)
+          .get(`/v0/build/${build.id}/log`)
+          .set('Cookie', cookie)
+          .expect(404))
+        .then((response) => {
+          validateAgainstJSONSchema('GET', '/build/{build_id}/log', 404, response.body);
+          done();
+        })
+        .catch(done);
     });
 
     it('should response with a 404 if the given build does not exist', (done) => {
@@ -260,9 +224,9 @@ describe('Build Log API', () => {
         .get('/v0/build/fake-id/log')
         .set('Cookie', cookie)
         .expect(404)).then((response) => {
-          validateAgainstJSONSchema('GET', '/build/{build_id}/log', 404, response.body);
-          done();
-        }).catch(done);
+        validateAgainstJSONSchema('GET', '/build/{build_id}/log', 404, response.body);
+        done();
+      }).catch(done);
     });
 
     it('should response with a 404 if the given build does not exist', (done) => {
@@ -270,9 +234,9 @@ describe('Build Log API', () => {
         .get('/v0/build/-100/log')
         .set('Cookie', cookie)
         .expect(404)).then((response) => {
-          validateAgainstJSONSchema('GET', '/build/{build_id}/log', 404, response.body);
-          done();
-        }).catch(done);
+        validateAgainstJSONSchema('GET', '/build/{build_id}/log', 404, response.body);
+        done();
+      }).catch(done);
     });
   });
 });

--- a/test/api/support/factory/site.js
+++ b/test/api/support/factory/site.js
@@ -28,6 +28,7 @@ function makeAttributes(overrides = {}) {
     s3ServiceName: 'federalist-dev-s3',
     awsBucketName: 'cg-123456789',
     awsBucketRegion: 'us-gov-west-1',
+    defaultBranch: 'master',
     users,
   }, overrides);
 }

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -72,11 +72,15 @@ describe('Build model', () => {
 
   describe('.completeJob(message)', () => {
     it('should mark a build errored with a message', (done) => {
-      factory.build().then(build => build.updateJobStatus({ status: 'error', message: 'this is an error' })).then((build) => {
-        expect(build.state).to.equal('error');
-        expect(build.error).to.equal('this is an error');
-        done();
-      })
+      factory.build()
+        .then(build =>
+          build.updateJobStatus({ status: 'error', message: 'this is an error' })
+        )
+        .then((build) => {
+          expect(build.state).to.equal('error');
+          expect(build.error).to.equal('this is an error');
+          done();
+        })
         .catch(done);
     });
 
@@ -103,11 +107,15 @@ describe('Build model', () => {
     });
 
     it('should sanitize GitHub access tokens from error message', (done) => {
-      factory.build().then(build => build.updateJobStatus({ status: 'error', message: 'http://123abc@github.com' })).then((build) => {
-        expect(build.state).to.equal('error');
-        expect(build.error).not.to.match(/123abc/);
-        done();
-      })
+      factory.build()
+        .then(build =>
+          build.updateJobStatus({ status: 'error', message: 'http://123abc@github.com' })
+        )
+        .then((build) => {
+          expect(build.state).to.equal('error');
+          expect(build.error).not.to.match(/123abc/);
+          done();
+        })
         .catch(done);
     });
   });
@@ -117,11 +125,13 @@ describe('Build model', () => {
       Build.create({
         user: 1,
         site: null,
-      }).then(() => done(new Error('Expected a validation error'))).catch((err) => {
-        expect(err.name).to.equal('SequelizeValidationError');
-        expect(err.errors[0].path).to.equal('site');
-        done();
       })
+        .then(() => done(new Error('Expected a validation error')))
+        .catch((err) => {
+          expect(err.name).to.equal('SequelizeValidationError');
+          expect(err.errors[0].path).to.equal('site');
+          done();
+        })
         .catch(done);
     });
 
@@ -129,11 +139,13 @@ describe('Build model', () => {
       Build.create({
         user: null,
         site: 1,
-      }).then(() => done(new Error('Expected a validation error'))).catch((err) => {
-        expect(err.name).to.equal('SequelizeValidationError');
-        expect(err.errors[0].path).to.equal('user');
-        done();
       })
+        .then(() => done(new Error('Expected a validation error')))
+        .catch((err) => {
+          expect(err.name).to.equal('SequelizeValidationError');
+          expect(err.errors[0].path).to.equal('user');
+          done();
+        })
         .catch(done);
     });
 

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -116,7 +116,6 @@ describe('Build model', () => {
         
       return expect(buildPromise).to.be
         .rejectedWith(ValidationError, 'Validation error: Validation is on branch failed');
-
     });
 
     it('requires a valid branch name before saving no end slash', () => {

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -60,7 +60,7 @@ describe('Build model', () => {
 
     it('should update the site\'s publishedAt timestamp if the build is successful', async () => {
       const site = await factory.site();
-      const build = await factory.build({ site: site });
+      const build = await factory.build({ site });
       
       expect(site.publishedAt).to.be.null;
 

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const { stub } = require('sinon');
-const { SequelizeDatabaseError } = require('sequelize');
+const { DatabaseError } = require('sequelize');
 const SQS = require('../../../../api/services/SQS');
 const factory = require('../../support/factory');
 const { Build, Site } = require('../../../../api/models');
@@ -218,7 +218,7 @@ describe('Build model', () => {
 
       const buildQuery = Build.findByPk(pk);
 
-      return expect(buildQuery).to.be.rejectedWith(SequelizeDatabaseError);
+      return expect(buildQuery).to.be.rejectedWith(DatabaseError);
     });
 
     it('throws when pk is non-number string', () => {
@@ -226,7 +226,7 @@ describe('Build model', () => {
 
       const buildQuery = Build.findByPk(pk);
 
-      return expect(buildQuery).to.be.rejectedWith(SequelizeDatabaseError);
+      return expect(buildQuery).to.be.rejectedWith(DatabaseError);
     });
   });
 

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -88,6 +88,7 @@ describe('Build model', () => {
         site: sitePromise,
         build: factory.build({ site: sitePromise }),
       }).then((promisedValues) => {
+        // eslint-disable-next-line prefer-destructuring
         site = promisedValues.site;
         expect(site.publishedAt).to.be.null;
 

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const { stub } = require('sinon');
-const { DatabaseError } = require('sequelize');
+const { DatabaseError, ValidationError } = require('sequelize');
 const SQS = require('../../../../api/services/SQS');
 const factory = require('../../support/factory');
 const { Build, Site } = require('../../../../api/models');
@@ -81,96 +81,66 @@ describe('Build model', () => {
   });
 
   describe('validations', () => {
-    it.only('should require a site object before saving', () => {
-      // Build.create({
-      //   user: 1,
-      //   site: null,
-      // })
-      //   .then(() =>
-      //     done(new Error('Expected a validation error'))
-      //   )
-      //   .catch((err) => {
-      //     expect(err.name).to.equal('SequelizeValidationError');
-      //     expect(err.errors[0].path).to.equal('site');
-      //     done();
-      //   })
-      //   .catch(done);
+    it('should require a site object before saving', () => {
+      const buildPromise = Build.create({ user: 1, site: null });
 
-        const build = Build.create({ user: 1, site: null });
-        return expect(build).to.be.rejectedWith(SequelizeValidationError, 'site')
+      return expect(buildPromise).to.be
+        .rejectedWith(ValidationError, 'notNull Violation: Build.site cannot be null');
     });
 
-    it('should require a user object before saving', (done) => {
-      Build.create({
-        user: null,
-        site: 1,
-      })
-        .then(() =>
-          done(new Error('Expected a validation error'))
-        )
-        .catch((err) => {
-          expect(err.name).to.equal('SequelizeValidationError');
-          expect(err.errors[0].path).to.equal('user');
-          done();
-        })
-        .catch(done);
+    it('should require a user object before saving', () => {
+      const buildPromise = Build.create({ user: null, site: 1 });
+
+      return expect(buildPromise).to.be
+        .rejectedWith(ValidationError, 'notNull Violation: Build.user cannot be null');
     });
 
-    it('should require a valid sha before saving', (done) => {
-      Build.create({
+    it('should require a valid sha before saving', () => {
+      const buildPromise = Build.create({
         user: 1,
         site: 1,
-        commitSha: 'not-a-real-sha.biz',
-      })
-        .then(done)
-        .catch((error) => {
-          expect(error.name).to.equal('SequelizeValidationError');
-          expect(error.errors[0].path).to.equal('commitSha');
-          done();
-        });
+        commitSha: 'not-a-real-sha.biz'
+      });
+      
+      return expect(buildPromise).to.be
+        .rejectedWith(ValidationError, 'Validation error: Validation is on commitSha failed');
     });
 
-    it('requires a valid branch name before saving', (done) => {
-      Build.create({
+    it('requires a valid branch name before saving', () => {
+      const buildPromise = Build.create({
         user: 1,
         site: 1,
         commitSha: 'a172b66c31e19d456a448041a5b3c2a70c32d8b7',
         branch: 'not*real',
-      })
-        .then(done)
-        .catch((error) => {
-          expect(error.name).to.equal('SequelizeValidationError');
-          expect(error.errors[0].path).to.equal('branch');
-          done();
-        });
+      });
+        
+      return expect(buildPromise).to.be
+        .rejectedWith(ValidationError, 'Validation error: Validation is on branch failed');
+
     });
-    it('requires a valid branch name before saving no end slash', (done) => {
-      Build.create({
+
+    it('requires a valid branch name before saving no end slash', () => {
+      const buildPromise = Build.create({
         user: 1,
         site: 1,
         commitSha: 'a172b66c31e19d456a448041a5b3c2a70c32d8b7',
         branch: 'not-real/',
-      })
-        .then(done)
-        .catch((error) => {
-          expect(error.name).to.equal('SequelizeValidationError');
-          expect(error.errors[0].path).to.equal('branch');
-          done();
-        });
+      });
+
+      return expect(buildPromise).to.be
+        .rejectedWith(ValidationError, 'Validation error: Validation is on branch failed');
     });
-    it('requires a valid branch name before saving no begin /', (done) => {
-      Build.create({
+
+    it('requires a valid branch name before saving no begin /', () => {
+      const buildPromise = Build.create({
         user: 1,
         site: 1,
         commitSha: 'a172b66c31e19d456a448041a5b3c2a70c32d8b7',
         branch: '/not-real',
-      })
-        .then(done)
-        .catch((error) => {
-          expect(error.name).to.equal('SequelizeValidationError');
-          expect(error.errors[0].path).to.equal('branch');
-          done();
-        });
+      });
+
+      return expect(buildPromise).to.be
+        .rejectedWith(ValidationError, 'Validation error: Validation is on branch failed');
     });
   });
 

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { stub } = require('sinon');
+const { SequelizeDatabaseError } = require('sequelize');
 const SQS = require('../../../../api/services/SQS');
 const factory = require('../../support/factory');
 const { Build, Site } = require('../../../../api/models');
@@ -30,7 +31,7 @@ describe('Build model', () => {
         expect(build.token).to.be.okay;
         done();
       })
-      .catch(done);
+        .catch(done);
     });
 
     it('should not override a build token if one exists', (done) => {
@@ -47,7 +48,7 @@ describe('Build model', () => {
         expect(build.token).to.equal('123abc');
         done();
       })
-      .catch(done);
+        .catch(done);
     });
   });
 
@@ -71,14 +72,12 @@ describe('Build model', () => {
 
   describe('.completeJob(message)', () => {
     it('should mark a build errored with a message', (done) => {
-      factory.build().then(build =>
-        build.updateJobStatus({ status: 'error', message: 'this is an error' })
-      ).then((build) => {
+      factory.build().then(build => build.updateJobStatus({ status: 'error', message: 'this is an error' })).then((build) => {
         expect(build.state).to.equal('error');
         expect(build.error).to.equal('this is an error');
         done();
       })
-      .catch(done);
+        .catch(done);
     });
 
     it('should update the site\'s publishedAt timestamp if the build is successful', (done) => {
@@ -94,23 +93,21 @@ describe('Build model', () => {
 
         return promisedValues.build.updateJobStatus({ status: 'success' });
       }).then(() => Site.findByPk(site.id))
-      .then((model) => {
-        expect(model.publishedAt).to.be.a('date');
-        expect(new Date().getTime() - model.publishedAt.getTime()).to.be.below(500);
-        done();
-      })
-      .catch(done);
+        .then((model) => {
+          expect(model.publishedAt).to.be.a('date');
+          expect(new Date().getTime() - model.publishedAt.getTime()).to.be.below(500);
+          done();
+        })
+        .catch(done);
     });
 
     it('should sanitize GitHub access tokens from error message', (done) => {
-      factory.build().then(build =>
-        build.updateJobStatus({ status: 'error', message: 'http://123abc@github.com' })
-      ).then((build) => {
+      factory.build().then(build => build.updateJobStatus({ status: 'error', message: 'http://123abc@github.com' })).then((build) => {
         expect(build.state).to.equal('error');
         expect(build.error).not.to.match(/123abc/);
         done();
       })
-      .catch(done);
+        .catch(done);
     });
   });
 
@@ -119,28 +116,24 @@ describe('Build model', () => {
       Build.create({
         user: 1,
         site: null,
-      }).then(() =>
-        done(new Error('Expected a validation error'))
-      ).catch((err) => {
+      }).then(() => done(new Error('Expected a validation error'))).catch((err) => {
         expect(err.name).to.equal('SequelizeValidationError');
         expect(err.errors[0].path).to.equal('site');
         done();
       })
-      .catch(done);
+        .catch(done);
     });
 
     it('should require a user object before saving', (done) => {
       Build.create({
         user: null,
         site: 1,
-      }).then(() =>
-        done(new Error('Expected a validation error'))
-      ).catch((err) => {
+      }).then(() => done(new Error('Expected a validation error'))).catch((err) => {
         expect(err.name).to.equal('SequelizeValidationError');
         expect(err.errors[0].path).to.equal('user');
         done();
       })
-      .catch(done);
+        .catch(done);
     });
 
     it('should require a valid sha before saving', (done) => {
@@ -149,12 +142,12 @@ describe('Build model', () => {
         site: 1,
         commitSha: 'not-a-real-sha.biz',
       })
-      .then(done)
-      .catch((error) => {
-        expect(error.name).to.equal('SequelizeValidationError');
-        expect(error.errors[0].path).to.equal('commitSha');
-        done();
-      });
+        .then(done)
+        .catch((error) => {
+          expect(error.name).to.equal('SequelizeValidationError');
+          expect(error.errors[0].path).to.equal('commitSha');
+          done();
+        });
     });
 
     it('requires a valid branch name before saving', (done) => {
@@ -164,12 +157,12 @@ describe('Build model', () => {
         commitSha: 'a172b66c31e19d456a448041a5b3c2a70c32d8b7',
         branch: 'not*real',
       })
-      .then(done)
-      .catch((error) => {
-        expect(error.name).to.equal('SequelizeValidationError');
-        expect(error.errors[0].path).to.equal('branch');
-        done();
-      });
+        .then(done)
+        .catch((error) => {
+          expect(error.name).to.equal('SequelizeValidationError');
+          expect(error.errors[0].path).to.equal('branch');
+          done();
+        });
     });
     it('requires a valid branch name before saving no end slash', (done) => {
       Build.create({
@@ -178,12 +171,12 @@ describe('Build model', () => {
         commitSha: 'a172b66c31e19d456a448041a5b3c2a70c32d8b7',
         branch: 'not-real/',
       })
-      .then(done)
-      .catch((error) => {
-        expect(error.name).to.equal('SequelizeValidationError');
-        expect(error.errors[0].path).to.equal('branch');
-        done();
-      });
+        .then(done)
+        .catch((error) => {
+          expect(error.name).to.equal('SequelizeValidationError');
+          expect(error.errors[0].path).to.equal('branch');
+          done();
+        });
     });
     it('requires a valid branch name before saving no begin /', (done) => {
       Build.create({
@@ -192,12 +185,69 @@ describe('Build model', () => {
         commitSha: 'a172b66c31e19d456a448041a5b3c2a70c32d8b7',
         branch: '/not-real',
       })
-      .then(done)
-      .catch((error) => {
-        expect(error.name).to.equal('SequelizeValidationError');
-        expect(error.errors[0].path).to.equal('branch');
-        done();
-      });
+        .then(done)
+        .catch((error) => {
+          expect(error.name).to.equal('SequelizeValidationError');
+          expect(error.errors[0].path).to.equal('branch');
+          done();
+        });
+    });
+  });
+
+  describe('querying', () => {
+    it('does not return a build when pk is null', async () => {
+      const pk = null;
+
+      const buildQuery = await Build.findByPk(pk);
+
+      expect(buildQuery).to.be.null;
+    });
+
+    it('returns a build when pk is a string', async () => {
+      const build = await factory.build();
+      const pk = String(build.id);
+
+      const buildQuery = await Build.findByPk(pk);
+
+      expect(buildQuery).to.not.be.null;
+      expect(buildQuery.id).to.equal(build.id);
+    });
+
+    it('throws when pk is Nan', () => {
+      const pk = NaN;
+
+      const buildQuery = Build.findByPk(pk);
+
+      return expect(buildQuery).to.be.rejectedWith(SequelizeDatabaseError);
+    });
+
+    it('throws when pk is non-number string', () => {
+      const pk = 'foobar';
+
+      const buildQuery = Build.findByPk(pk);
+
+      return expect(buildQuery).to.be.rejectedWith(SequelizeDatabaseError);
+    });
+  });
+
+  describe('forUser scope', () => {
+    it('returns the build for the associated user', async () => {
+      const user = await factory.user();
+      const build = await factory.build({ user });
+
+      const buildQuery = await Build.forUser(user).findByPk(build.id);
+
+      expect(buildQuery).to.not.be.null;
+      expect(buildQuery.id).to.equal(build.id);
+    });
+
+    it('does not return the build for a different user', async () => {
+      const user = { id: 99999 };
+      const build = await factory.build();
+
+      const buildQuery = await Build.forUser(user).findByPk(build.id);
+
+      expect(buildQuery).to.be.null;
     });
   });
 });

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -20,34 +20,38 @@ describe('Build model', () => {
     it('should add a build token', (done) => {
       let build;
 
-      factory.site().then((site) => {
-        build = Build.build({
-          site: site.id,
-          user: 1,
-        });
+      factory.site()
+        .then((site) => {
+          build = Build.build({
+            site: site.id,
+            user: 1,
+          });
 
-        return build.validate();
-      }).then(() => {
-        expect(build.token).to.be.okay;
-        done();
-      })
+          return build.validate();
+        })
+        .then(() => {
+          expect(build.token).to.be.okay;
+          done();
+        })
         .catch(done);
     });
 
     it('should not override a build token if one exists', (done) => {
       let build;
 
-      factory.site().then((site) => {
-        build = Build.build({
-          site: site.id,
-          token: '123abc',
-          user: 1,
-        });
-        return build.validate();
-      }).then(() => {
-        expect(build.token).to.equal('123abc');
-        done();
-      })
+      factory.site()
+        .then((site) => {
+          build = Build.build({
+            site: site.id,
+            token: '123abc',
+            user: 1,
+          });
+          return build.validate();
+        })
+        .then(() => {
+          expect(build.token).to.equal('123abc');
+          done();
+        })
         .catch(done);
     });
   });
@@ -55,7 +59,9 @@ describe('Build model', () => {
   describe('after create hook', () => {
     it('should send a build new build message', (done) => {
       factory.build()
-        .then(build => build.updateJobStatus({ status: 'complete' }))
+        .then(build =>
+          build.updateJobStatus({ status: 'complete' })
+        )
         .then((build) => {
           const queuedBuild = sendMessageStub.getCall(0).args[0];
           const buildCount = sendMessageStub.getCall(0).args[1];
@@ -126,7 +132,9 @@ describe('Build model', () => {
         user: 1,
         site: null,
       })
-        .then(() => done(new Error('Expected a validation error')))
+        .then(() =>
+          done(new Error('Expected a validation error'))
+        )
         .catch((err) => {
           expect(err.name).to.equal('SequelizeValidationError');
           expect(err.errors[0].path).to.equal('site');
@@ -140,7 +148,9 @@ describe('Build model', () => {
         user: null,
         site: 1,
       })
-        .then(() => done(new Error('Expected a validation error')))
+        .then(() =>
+          done(new Error('Expected a validation error'))
+        )
         .catch((err) => {
           expect(err.name).to.equal('SequelizeValidationError');
           expect(err.errors[0].path).to.equal('user');

--- a/test/frontend/util/index.test.js
+++ b/test/frontend/util/index.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { getSafeRepoName } from '../../../frontend/util';
+import { getSafeRepoName, groupLogs } from '../../../frontend/util';
 
 describe('getSafeRepoName', () => {
   it('returns safe repo names', () => {
@@ -10,5 +10,21 @@ describe('getSafeRepoName', () => {
     expect(getSafeRepoName('cleans    spaces')).to.equal('cleans-spaces');
     expect(getSafeRepoName('#cleans@@weird**characters!')).to.equal('cleans-weird-characters');
     expect(getSafeRepoName('periods.are.ok')).to.equal('periods.are.ok');
+  });
+});
+
+describe.only('groupLogs', () => {
+  it('groups the logs by source', () => {
+    const logs = [
+      { source: 'source1', output: 'hello' },
+      { source: 'source2', output: 'foo' },
+      { source: 'source1', output: 'world' },
+      { source: 'source2', output: 'bar' },
+    ];
+
+    expect(groupLogs(logs)).to.deep.equal({
+      source1: ['hello', 'world'],
+      source2: ['foo', 'bar'],
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,6 +2163,13 @@ cfenv@^1.0.0:
     ports "1.1.x"
     underscore "1.9.x"
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
 chai-fetch-mock@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/chai-fetch-mock/-/chai-fetch-mock-1.2.0.tgz#a12e165698239545b50e679013dac22a3b011c83"


### PR DESCRIPTION
Update the API to query for new style logs that will have a record per log message. Some refactoring along the way including updates to the `create-dev-data` script.

Update the UI to handle many log record per source.

Add some additional patterns for async request handlers and error handling.