### PR TITLE
Trim the fat on build logs serialization

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,5 +30,10 @@ ratings:
   paths:
   - "**.js"
   - "**.jsx"
-exclude_paths:
-- node_modules/
+exclude_patterns:
+  - "node_modules/"
+  - "migrations/"
+  - "test/"
+  - "scripts/"
+  - "coverage/"
+  - "migrate.js"

--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -58,7 +58,6 @@ module.exports = wrapHandlers({
       order: [['id', 'ASC']],
       offset: (lineLimit * (page - 1)),
       lineLimit,
-      include: [Build],
     });
 
     // Support legacy build logs
@@ -71,11 +70,10 @@ module.exports = wrapHandlers({
         order: [['id', 'ASC']],
         offset: (limit * (page - 1)),
         limit,
-        include: [Build],
       });
     }
 
-    const serializedBuildLogs = await buildLogSerializer.serialize(buildLogs);
+    const serializedBuildLogs = await buildLogSerializer.serializeMany(buildLogs);
 
     return res.ok(serializedBuildLogs);
   },

--- a/api/serializers/build-log.js
+++ b/api/serializers/build-log.js
@@ -4,7 +4,7 @@ const whitelist = [
   'createdAt',
   'output',
   'source',
-]
+];
 
 function serialize(buildLog) {
   const object = buildLog.get({

--- a/api/serializers/build-log.js
+++ b/api/serializers/build-log.js
@@ -1,43 +1,22 @@
-const { BuildLog, Build } = require('../models');
-const buildSerializer = require('../serializers/build');
+const { pick } = require('../utils');
 
-function toJSON(buildLog) {
+const whitelist = [
+  'createdAt',
+  'output',
+  'source',
+]
+
+function serialize(buildLog) {
   const object = buildLog.get({
     plain: true,
   });
-  object.createdAt = object.createdAt.toISOString();
-  object.updatedAt = object.updatedAt.toISOString();
-  return object;
+  const filtered = pick(whitelist, object);
+  filtered.createdAt = filtered.createdAt.toISOString();
+  return filtered;
 }
 
-function serializeObject(buildLog) {
-  const json = toJSON(buildLog);
-  json.build = buildSerializer.toJSON(buildLog.Build);
-  delete json.Build;
-  return json;
+function serializeMany(buildLogs) {
+  return buildLogs.map(serialize);
 }
 
-function serializePlaintext(buildLog) {
-  // Serializes a buildLog as a text-based representation
-  return [
-    `Source: ${buildLog.source}`,
-    `Timestamp: ${buildLog.createdAt.toISOString()}`,
-    `Output:\n${buildLog.output}`,
-  ].join('\n');
-}
-
-function serialize(serializable, { isPlaintext } = {}) {
-  const serializationFn = isPlaintext ? serializePlaintext : serializeObject;
-
-  if (serializable.length !== undefined) {
-    const buildLogIds = serializable.map(buildLog => buildLog.id);
-    const query = BuildLog.findAll({ where: { id: buildLogIds }, include: [Build] });
-
-    return query.then(buildLogs => buildLogs.map(serializationFn));
-  }
-
-  const query = BuildLog.findByPk(serializable.id, { include: [Build] });
-  return query.then(serializationFn);
-}
-
-module.exports = { serialize, toJSON };
+module.exports = { serialize, serializeMany };

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -142,7 +142,7 @@ function pick(keys, obj) {
   const objKeys = Object.keys(obj);
   const pickedObj = keys.reduce((picked, key) => {
     if (objKeys.includes(key)) {
-      picked[key] = obj[key];
+      picked[key] = obj[key]; // eslint-disable-line no-param-reassign
     }
     return picked;
   }, {});

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -138,6 +138,17 @@ function wrapHandlers(handlers) {
   return mapValues(wrapHandler, handlers);
 }
 
+function pick(keys, obj) {
+  const objKeys = Object.keys(obj);
+  const pickedObj = keys.reduce((picked, key) => {
+    if (objKeys.includes(key)) {
+      picked[key] = obj[key];
+    }
+    return picked;
+  }, {});
+  return pickedObj;
+}
+
 module.exports = {
   filterEntity,
   firstEntity,
@@ -149,6 +160,7 @@ module.exports = {
   loadDevelopmentManifest,
   loadProductionManifest,
   mapValues,
+  pick,
   shouldIncludeTracking,
   wrapHandler,
   wrapHandlers,

--- a/public/swagger/BuildLog.json
+++ b/public/swagger/BuildLog.json
@@ -1,23 +1,11 @@
 {
   "type": "object",
   "required": [
-    "id",
-    "build",
     "createdAt",
     "output",
-    "source",
-    "updatedAt"
+    "source"
   ],
   "properties": {
-    "id": {
-      "type": "integer"
-    },
-    "build": {
-      "type": "object",
-      "not": {
-        "required": ["token"]
-      }
-    },
     "createdAt": {
       "type": "string"
     },
@@ -25,9 +13,6 @@
       "type": "string"
     },
     "source": {
-      "type": "string"
-    },
-    "updatedAt": {
       "type": "string"
     }
   }

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -158,7 +158,7 @@ async function createData({ githubUsername }) {
       output: log('This log should not be visible'),
       source: 'fake-build-step1',
       build: nodeSiteBuilds[0].id,
-    }
+    },
   ]);
 
   await BuildLog.bulkCreate(
@@ -170,7 +170,7 @@ async function createData({ githubUsername }) {
   );
 
   await BuildLog.bulkCreate(
-    Array(2000).fill(0).map((_v, idx) =>({
+    Array(2000).fill(0).map((_v, idx) => ({
       output: log(`Message ${idx}`),
       source: 'ALL',
       build: goSiteBuilds[0].id,

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -46,7 +46,7 @@ async function createData({ githubUsername }) {
   ]);
 
   console.log('Creating sites...');
-  const [site1, site2] = await Promise.all([
+  const [site1, nodeSite, goSite] = await Promise.all([
     siteFactory({
       demoBranch: 'demo-branch',
       demoDomain: 'https://demo.example.gov',
@@ -60,6 +60,13 @@ async function createData({ githubUsername }) {
       engine: 'node.js',
       owner: user1.username,
       repository: 'example-node-site',
+      users: [user1],
+    }),
+
+    siteFactory({
+      engine: 'hugo',
+      owner: user1.username,
+      repository: 'example-go-site',
       users: [user1],
     }),
   ]);
@@ -94,58 +101,81 @@ async function createData({ githubUsername }) {
     }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe2' })),
   ]);
 
-  const site2Builds = await Promise.all([
+  const nodeSiteBuilds = await Promise.all([
     Build.create({
-      branch: site2.defaultBranch,
+      branch: nodeSite.defaultBranch,
       completedAt: new Date(),
       source: 'fake-build',
       state: 'success',
-      site: site2.id,
+      site: nodeSite.id,
       user: user1.id,
       token: 'fake-token',
     }),
     Build.create({
       branch: 'dc/fixes',
       source: 'fake-build',
-      site: site2.id,
+      site: nodeSite.id,
       user: user1.id,
       token: 'fake-token',
     }).then(build => build.update({ commitSha: '57ce109dcc2cb8675ccbc2d023f40f82a2deabe1' })),
   ]);
 
+  const goSiteBuilds = await Promise.all([
+    Build.create({
+      branch: goSite.defaultBranch,
+      completedAt: new Date(),
+      source: 'fake-build',
+      state: 'success',
+      site: goSite.id,
+      user: user1.id,
+      token: 'fake-token',
+    }),
+  ]);
+
   console.log('Creating build logs...');
-  await Promise.all([
-    BuildLog.create({
+  await BuildLog.bulkCreate([
+    {
       output: loremIpsum,
       source: 'fake-build-step1',
       build: site1Builds[0].id,
-    }),
-    BuildLog.create({
+    },
+    {
       output: loremIpsum,
       source: 'fake-build-step2',
       build: site1Builds[0].id,
-    }),
-    BuildLog.create({
+    },
+    {
       output: loremIpsum,
       source: 'fake-build-step1',
       build: site1Builds[1].id,
-    }),
-    BuildLog.create({
+    },
+    {
       output: loremIpsum,
       source: 'fake-build-step1',
       build: site1Builds[2].id,
-    }),
-    BuildLog.create({
+    },
+    {
       output: log('This log should not be visible'),
       source: 'fake-build-step1',
-      build: site2Builds[0].id,
-    }),
-    Promise.all(Array(20).fill(0).map(() => BuildLog.create({
+      build: nodeSiteBuilds[0].id,
+    }
+  ]);
+
+  await BuildLog.bulkCreate(
+    Array(20).fill(0).map(() => ({
       output: log('This log has a source of ALL'),
       source: 'ALL',
-      build: site2Builds[0].id,
-    }))),
-  ]);
+      build: nodeSiteBuilds[0].id,
+    }))
+  );
+
+  await BuildLog.bulkCreate(
+    Array(2000).fill(0).map((_v, idx) =>({
+      output: log(`Message ${idx}`),
+      source: 'ALL',
+      build: goSiteBuilds[0].id,
+    }))
+  );
 
   console.log('Creating user actions...');
   const removeAction = await ActionType.findOne({ where: { action: 'remove' } });

--- a/test/api/unit/serializers/build-log.test.js
+++ b/test/api/unit/serializers/build-log.test.js
@@ -1,70 +1,36 @@
-const expect = require('chai').expect;
-const validateJSONSchema = require('jsonschema').validate;
+const { expect } = require('chai');
+const { validate: validateJSONSchema } = require('jsonschema');
 
 const buildLogSchema = require('../../../../public/swagger/BuildLog.json');
 const factory = require('../../support/factory');
 
 const BuildLogSerializer = require('../../../../api/serializers/build-log');
 
-function plaintextLineIsOk(line) {
-  expect(line.indexOf('Source: clone.sh')).to.equal(0);
-  expect(line.indexOf('Timestamp:')).to.be.greaterThan(-1);
-  expect(line.indexOf('Output:')).to.be.greaterThan(-1);
-  expect(line.indexOf('This is output from the build container')).to.be.greaterThan(-1);
-}
+const arraySchema = {
+  type: 'array',
+  items: buildLogSchema,
+};
 
 describe('BuildLogSerializer', () => {
   describe('.serialize(serializable)', () => {
-    it('should serialize an object correctly', (done) => {
-      factory.buildLog()
-        .then(buildLog => BuildLogSerializer.serialize(buildLog))
-        .then((object) => {
-          const result = validateJSONSchema(object, buildLogSchema);
-          expect(result.errors).to.be.empty;
-          done();
-        })
-        .catch(done);
+    it('should serialize an object correctly', async () => {
+      const buildLog = await factory.buildLog();
+      
+      const object = BuildLogSerializer.serialize(buildLog);
+      
+      const result = validateJSONSchema(object, buildLogSchema);
+      expect(result.errors).to.be.empty;
     });
 
-    it('should serialize an array correctly', (done) => {
-      const buildLogs = Array(3).fill(0).map(() => factory.buildLog());
+    describe('.serialize(serializable)', () => {
+      it('should serialize an array of objects correctly', async () => {
+        const buildLogs = await Promise.all(Array(3).fill(0).map(() => factory.buildLog()));
 
-      Promise.all(buildLogs)
-        .then(logs => BuildLogSerializer.serialize(logs))
-        .then((object) => {
-          const arraySchema = {
-            type: 'array',
-            items: buildLogSchema,
-          };
-          const result = validateJSONSchema(object, arraySchema);
-          expect(result.errors).to.be.empty;
-          done();
-        })
-        .catch(done);
-    });
-
-    it('should serialize an object to plaintext when specified', (done) => {
-      factory.buildLog()
-        .then(buildLog => BuildLogSerializer.serialize(buildLog, { isPlaintext: true }))
-        .then((text) => {
-          plaintextLineIsOk(text);
-          done();
-        })
-        .catch(done);
-    });
-
-    it('should serialize an array to rows of plaintext when specified', (done) => {
-      const buildLogs = Array(3).fill(0).map(() => factory.buildLog());
-
-      Promise.all(buildLogs)
-        .then(logs => BuildLogSerializer.serialize(logs, { isPlaintext: true }))
-        .then((arr) => {
-          expect(arr).to.be.an('array');
-          expect(arr.length).to.equal(3);
-          arr.forEach(plaintextLineIsOk);
-          done();
-        })
-        .catch(done);
+        const object = BuildLogSerializer.serializeMany(buildLogs);
+            
+        const result = validateJSONSchema(object, arraySchema);
+        expect(result.errors).to.be.empty;
+      });
     });
   });
 });

--- a/test/api/unit/serializers/build-log.test.js
+++ b/test/api/unit/serializers/build-log.test.js
@@ -15,9 +15,9 @@ describe('BuildLogSerializer', () => {
   describe('.serialize(serializable)', () => {
     it('should serialize an object correctly', async () => {
       const buildLog = await factory.buildLog();
-      
+
       const object = BuildLogSerializer.serialize(buildLog);
-      
+
       const result = validateJSONSchema(object, buildLogSchema);
       expect(result.errors).to.be.empty;
     });
@@ -27,7 +27,7 @@ describe('BuildLogSerializer', () => {
         const buildLogs = await Promise.all(Array(3).fill(0).map(() => factory.buildLog()));
 
         const object = BuildLogSerializer.serializeMany(buildLogs);
-            
+
         const result = validateJSONSchema(object, arraySchema);
         expect(result.errors).to.be.empty;
       });

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -301,4 +301,20 @@ describe('utils', () => {
       expect(spy.calledWith(error));
     });
   });
+
+  describe('.pick', () => {
+    it('returns an object only containing specified keys', () => {
+      const keys = ['foo', 'bar'];
+      const obj = {
+        foo: 'hi',
+        bar: undefined,
+        baz: 'bye'
+      };
+
+      expect(utils.pick(keys, obj)).to.deep.equal({
+        foo: 'hi',
+        bar: undefined,
+      });
+    });
+  });
 });

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -308,7 +308,7 @@ describe('utils', () => {
       const obj = {
         foo: 'hi',
         bar: undefined,
-        baz: 'bye'
+        baz: 'bye',
       };
 
       expect(utils.pick(keys, obj)).to.deep.equal({


### PR DESCRIPTION
- Removes unused feature to serialize to plain text
- Reduces serialized build log to include only the fields we need
- Removes extra querying for build logs and builds
- Makes serializing an array explicit
- Creates a repeatable pattern for implementing serializers that could be abstracted
- Adds seeds data for 2k build logs for better local testing