### PR TITLE
Add site, demo, preview link attributes to site serializer

### DIFF
--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -1,6 +1,7 @@
 const yaml = require('js-yaml');
 const { Site, User } = require('../models');
 const userSerializer = require('../serializers/user');
+const { buildSiteLink } = require('../utils/site');
 
 const toJSON = (site) => {
   const object = Object.assign({}, site.get({
@@ -9,6 +10,9 @@ const toJSON = (site) => {
 
   delete object.site_users__user_sites;
 
+  object.demoViewLink = buildSiteLink('demo', object);
+  object.previewLink = buildSiteLink('preview', object);
+  object.viewLink = buildSiteLink('site', object);
   object.createdAt = object.createdAt.toISOString();
   object.updatedAt = object.updatedAt.toISOString();
 

--- a/api/utils/site.js
+++ b/api/utils/site.js
@@ -1,0 +1,15 @@
+function buildSiteLink(deployment, site) {
+  const domain = `https://${site.awsBucketName}.app.cloud.gov`;
+  const path = `/${deployment}/${site.owner}/${site.repository}`;
+  let link = `${domain}${path}`;
+
+  if (deployment === 'site' && site.domain) {
+    link = site.domain;
+  } else if (deployment === 'demo' && site.demoDomain) {
+    link = site.demoDomain;
+  }
+
+  return `${link.replace(/\/+$/, '')}/`;
+}
+
+module.exports = { buildSiteLink };

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -6,6 +6,11 @@
     "engine",
     "owner",
     "repository",
+    "s3ServiceName",
+    "awsBucketName",
+    "viewLink",
+    "demoViewLink",
+    "previewLink",
     "users"
   ],
   "properties": {
@@ -45,6 +50,21 @@
       "format": "date-time"
     },
     "repository": {
+      "type": "string"
+    },
+    "s3ServiceName": {
+      "type": "string"
+    },
+    "awsBucketName": {
+      "type": "string"
+    },
+    "viewLink": {
+      "type": "string"
+    },
+    "demoViewLink": {
+      "type": "string"
+    },
+    "previewLink": {
       "type": "string"
     },
     "users": {

--- a/test/api/unit/utils/site.test.js
+++ b/test/api/unit/utils/site.test.js
@@ -1,0 +1,48 @@
+const { expect } = require('chai');
+
+const { buildSiteLink } = require('../../../../api/utils/site');
+const factory = require('../../support/factory');
+
+describe('buildSiteLink', () => {
+  const awsBucketName = 'federalist-bucket';
+
+  it('should return a site domain when site domain is set', async () => {
+    const deployment = 'site';
+    const domain = 'https://example.gov/';
+    const site = await factory.site({ awsBucketName, domain });
+    expect(buildSiteLink(deployment, site)).to.eql(domain);
+  });
+
+  it('should return proxy domain with the site path when no site domain', async () => {
+    const deployment = 'site';
+    const domain = null;
+    const site = await factory.site({ awsBucketName, domain });
+    expect(buildSiteLink(deployment, site)).to.eql(
+      `https://${awsBucketName}.app.cloud.gov/site/${site.owner}/${site.repository}/`
+    );
+  });
+
+  it('should return a site demo domain when site has demoDomain', async () => {
+    const deployment = 'demo';
+    const demoDomain = 'https://demo.example.gov/';
+    const site = await factory.site({ awsBucketName, demoDomain });
+    expect(buildSiteLink(deployment, site)).to.eql(demoDomain);
+  });
+
+  it('should return proxy domain with the demo path when no demoDomain', async () => {
+    const deployment = 'demo';
+    const demoDomain = null;
+    const site = await factory.site({ awsBucketName, demoDomain });
+    expect(buildSiteLink(deployment, site)).to.eql(
+      `https://${awsBucketName}.app.cloud.gov/demo/${site.owner}/${site.repository}/`
+    );
+  });
+
+  it('should return a proxy route domain with the preview path', async () => {
+    const deployment = 'preview';
+    const site = await factory.site({ awsBucketName });
+    expect(buildSiteLink(deployment, site)).to.eql(
+      `https://${awsBucketName}.app.cloud.gov/preview/${site.owner}/${site.repository}/`
+    );
+  });
+});


### PR DESCRIPTION
## Description

Updates `site` serializer with `viewLink`, `demoViewLink`, and `previewLink` to fix broken links in front end app's site page header to view the site domain, the site branches to view, and site published file branch view.

Closes #2484 