### PR TITLE
Replaced footer mailto federalist-inquiries link with federalist-support

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -128,8 +128,8 @@
             </div>
             <div class="usa-footer-primary-content usa-footer-contact_info">
               <p>
-                <a href="mailto:federalist-inquiries@gsa.gov">
-                  <img src="/images/icons/icon-envelope.svg"/>federalist-inquiries@gsa.gov</a>
+                <a href="mailto:federalist-support@gsa.gov">
+                  <img src="/images/icons/icon-envelope.svg"/>federalist-support@gsa.gov</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Changes this link to federalist-support since the user will only see this if logged in or on the login page. Seems much more likely they will want to reach out to support in this case, not inquiries.