### PR TITLE
Replace "Support" link with "Contact" link in header

### DIFF
--- a/views/navigation.njk
+++ b/views/navigation.njk
@@ -28,8 +28,8 @@
             </a>
           </li>
           <li>
-            <a class="usa-nav-link" href="{{ homepageUrl }}/support/">
-              <span>Support<span>
+            <a class="usa-nav-link" href="{{ homepageUrl }}/contact/">
+              <span>Contact<span>
             </a>
           </li>
           {% if isAuthenticated %}


### PR DESCRIPTION
Currently, this link was just sending the user to the `documentation` page which is not helpful and there is already a link for this next to it. Under the assumption that the user clicks this link to get help, change it to the `contact` page where there are directions on how to get help. This link also exists in the footer, I think it's ok to have it in both places so it's easy for users to get in touch.