### PR TITLE
Restore error for unauthorized site, refactor for consistent behavior

### DIFF
--- a/frontend/actions/actionCreators/siteActions.js
+++ b/frontend/actions/actionCreators/siteActions.js
@@ -5,7 +5,6 @@ const siteUpdatedType = 'SITE_UPDATED';
 const siteDeletedType = 'SITE_DELETED';
 const siteUserAddedType = 'SITE_USER_ADDED';
 const siteUserRemovedType = 'SITE_USER_REMOVED';
-const setCurrentSiteType = 'SET_CURRENT_SITE';
 const siteUserUpdatedType = 'SITE_USER_UPDATED';
 const siteBranchesReceivedType = 'SITE_BRANCHES_RECIEVED';
 
@@ -44,11 +43,6 @@ const siteUserRemoved = site => ({
   site,
 });
 
-const setCurrentSite = siteId => ({
-  type: setCurrentSiteType,
-  siteId,
-});
-
 const siteUserUpdated = site => ({
   type: siteUserUpdatedType,
   siteId: site.id,
@@ -63,7 +57,6 @@ export {
   siteDeleted, siteDeletedType,
   siteUserAdded, siteUserAddedType,
   siteUserRemoved, siteUserRemovedType,
-  setCurrentSiteType, setCurrentSite,
   siteUserUpdated, siteUserUpdatedType,
   siteBranchesReceivedType,
 };

--- a/frontend/actions/dispatchActions.js
+++ b/frontend/actions/dispatchActions.js
@@ -8,7 +8,6 @@ import {
   siteDeleted as createSiteDeletedAction,
   siteUserAdded as createSiteUserAddedAction,
   siteUserRemoved as siteUserRemovedAction,
-  setCurrentSite as setCurrentSiteAction,
   siteUserUpdated as createSiteUserUpdatedAction,
 } from './actionCreators/siteActions';
 import {
@@ -66,8 +65,6 @@ const dispatchSiteUserUpdatedAction = (site) => {
   dispatch(createSiteUserUpdatedAction(site));
 };
 
-const dispatchSetCurrentSiteAction = siteId => dispatch(setCurrentSiteAction(siteId));
-
 const dispatchResetFormAction = formName => dispatch(reset(formName));
 
 export {
@@ -82,7 +79,6 @@ export {
   dispatchUserRemovedFromSiteAction,
   dispatchShowAddNewSiteFieldsAction,
   dispatchHideAddNewSiteFieldsAction,
-  dispatchSetCurrentSiteAction,
   dispatchResetFormAction,
   dispatchSiteUserUpdatedAction,
 };

--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -15,7 +15,6 @@ import {
   dispatchUserAddedToSiteAction,
   dispatchShowAddNewSiteFieldsAction,
   dispatchHideAddNewSiteFieldsAction,
-  dispatchSetCurrentSiteAction,
   dispatchResetFormAction,
 } from './dispatchActions';
 import userActions from './userActions';
@@ -37,10 +36,6 @@ export default {
     return federalist.fetchSites()
       .then(dispatchSitesReceivedAction)
       .catch(alertError);
-  },
-
-  setCurrentSite(siteId) {
-    dispatchSetCurrentSiteAction(siteId);
   },
 
   addSite(siteToAdd) {

--- a/frontend/components/app.js
+++ b/frontend/components/app.js
@@ -95,7 +95,6 @@ App.propTypes = {
   ),
   sites: PropTypes.shape({
     isLoading: PropTypes.bool.isRequired,
-    currentSite: PropTypes.object,
     data: PropTypes.arrayOf(PropTypes.object).isRequired,
   }),
 };
@@ -108,7 +107,6 @@ App.defaultProps = {
   notifications: [],
   sites: {
     isLoading: false,
-    currentSite: {},
     data: [],
   },
 };

--- a/frontend/components/site/NotificationSettings.jsx
+++ b/frontend/components/site/NotificationSettings.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import { SITE, USER } from '../../propTypes';
 import siteActions from '../../actions/siteActions';
+import { currentSite } from '../../selectors/site';
 
 
 class NotificationSettings extends React.Component {
@@ -65,9 +66,9 @@ NotificationSettings.defaultProps = {
   user: null,
 };
 
-const mapStateToProps = ({ user, sites }) => ({
+const mapStateToProps = ({ user, sites }, { params: { id } }) => ({
   user: user.data,
-  site: sites.currentSite,
+  site: currentSite(sites, id),
 });
 
 export { NotificationSettings };

--- a/frontend/components/site/SiteGitHubBranches.jsx
+++ b/frontend/components/site/SiteGitHubBranches.jsx
@@ -7,6 +7,7 @@ import GitHubLink from '../GitHubLink';
 import BranchViewLink from '../branchViewLink';
 import githubBranchActions from '../../actions/githubBranchActions';
 import buildActions from '../../actions/buildActions';
+import { currentSite } from '../../selectors/site';
 import AlertBanner from '../alertBanner';
 import CreateBuildLink from '../CreateBuildLink';
 import { validBranchName } from '../../util/validators';
@@ -135,9 +136,9 @@ SiteGitHubBranches.defaultProps = {
   githubBranches: null,
 };
 
-const mapStateToProps = ({ githubBranches, sites }) => ({
+const mapStateToProps = ({ githubBranches, sites }, { params: { id } }) => ({
   githubBranches,
-  site: sites.currentSite,
+  site: currentSite(sites, id),
 });
 
 export default connect(mapStateToProps)(SiteGitHubBranches);

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -4,6 +4,7 @@ import autoBind from 'react-autobind';
 import { connect } from 'react-redux';
 
 import publishedFileActions from '../../actions/publishedFileActions';
+import { currentSite } from '../../selectors/site';
 import LoadingIndicator from '../LoadingIndicator';
 import AlertBanner from '../alertBanner';
 
@@ -235,9 +236,9 @@ SitePublishedFilesTable.defaultProps = {
   publishedFiles: null,
 };
 
-const mapStateToProps = ({ publishedFiles, sites }) => ({
+const mapStateToProps = ({ publishedFiles, sites }, { params: { id } }) => ({
   publishedFiles,
-  site: sites.currentSite,
+  site: currentSite(sites, id),
 });
 
 export { SitePublishedFilesTable };

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -9,6 +9,7 @@ import BasicSiteSettings from './BasicSiteSettings';
 import AdvancedSiteSettings from './AdvancedSiteSettings';
 import CopyRepoForm from './CopyRepoForm';
 import siteActions from '../../../actions/siteActions';
+import { currentSite } from '../../../selectors/site';
 
 class SiteSettings extends React.Component {
   constructor(props) {
@@ -122,8 +123,8 @@ SiteSettings.defaultProps = {
   site: null,
 };
 
-const mapStateToProps = ({ sites }) => ({
-  site: sites.currentSite,
+const mapStateToProps = ({ sites }, { params: { id } }) => ({
+  site: currentSite(sites, id),
 });
 
 export { SiteSettings };

--- a/frontend/components/site/SiteUsers.jsx
+++ b/frontend/components/site/SiteUsers.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { SITE, USER } from '../../propTypes';
 import ButtonLink from '../ButtonLink';
 import siteActions from '../../actions/siteActions';
+import { currentSite } from '../../selectors/site';
 import UserActionsTable from './UserActionsTable';
 import { IconGitHub } from '../icons';
 
@@ -91,9 +92,9 @@ SiteUsers.defaultProps = {
   user: null,
 };
 
-const mapStateToProps = ({ user, sites }) => ({
+const mapStateToProps = ({ user, sites }, { params: { id } }) => ({
   user: user.data,
-  site: sites.currentSite,
+  site: currentSite(sites, id),
 });
 
 export { SiteUsers };

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -7,6 +7,7 @@ import { Link } from 'react-router';
 import GitHubLink from '../GitHubLink';
 import { BUILD } from '../../propTypes';
 import buildActions from '../../actions/buildActions';
+import { currentSite } from '../../selectors/site';
 import LoadingIndicator from '../LoadingIndicator';
 import RefreshBuildsButton from './refreshBuildsButton';
 import { duration, timeFrom } from '../../util/datetime';
@@ -264,9 +265,9 @@ SiteBuilds.defaultProps = {
   },
 };
 
-const mapStateToProps = state => ({
-  builds: state.builds,
-  site: state.sites.currentSite,
+const mapStateToProps = ({ builds, sites }, { params: { id } }) => ({
+  builds,
+  site: currentSite(sites, id),
 });
 
 export { SiteBuilds };

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import publishedBranchActions from '../../actions/publishedBranchActions';
+import { currentSite } from '../../selectors/site';
 import LoadingIndicator from '../LoadingIndicator';
 import BranchViewLink from '../branchViewLink';
 import { SITE } from '../../propTypes';
@@ -107,9 +108,9 @@ SitePublishedBranchesTable.defaultProps = {
   site: null,
 };
 
-const mapStateToProps = ({ publishedBranches, sites }) => ({
+const mapStateToProps = ({ publishedBranches, sites }, { params: { id } }) => ({
   publishedBranches,
-  site: sites.currentSite,
+  site: currentSite(sites, id),
 });
 
 export { SitePublishedBranchesTable };

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -66,7 +66,8 @@ export class SiteContainer extends React.Component {
     if (!site) {
       const errorMessage = (
         <span>
-          You don&apos;t have access to this site, please contact the site owner if you believe this is an error.
+          You don&apos;t have access to this site,
+          please contact the site owner if you believe this is an error.
         </span>
       );
       return (

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { ALERT } from '../propTypes';
-import siteActions from '../actions/siteActions';
+import { currentSite } from '../selectors/site';
 import SideNav from './site/SideNav';
 import PagesHeader from './site/PagesHeader';
 import AlertBanner from './alertBanner';
@@ -43,21 +43,6 @@ export const SITE_NAVIGATION_CONFIG = [
 ];
 
 export class SiteContainer extends React.Component {
-  componentDidMount() {
-    const { params: { id } } = this.props;
-    siteActions.setCurrentSite(id);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { params: { id } } = this.props;
-    const { sites } = nextProps;
-    const { currentSite, data } = sites;
-
-    if (data.length && !currentSite) {
-      siteActions.setCurrentSite(id);
-    }
-  }
-
   getPageTitle(pathname) {
     const route = pathname.split('/').pop();
     const routeConf = SITE_NAVIGATION_CONFIG.find(conf => conf.route === route);
@@ -76,20 +61,18 @@ export class SiteContainer extends React.Component {
       return <LoadingIndicator />;
     }
 
-    const site = sites.currentSite;
+    const site = currentSite(sites, params.id);
 
     if (!site) {
       const errorMessage = (
         <span>
-          Apologies; you don&apos;t have access to this site in Federalist!
-          <br />
-          Please contact the site owner if you should have access.
+          You don&apos;t have access to this site, please contact the site owner if you believe this is an error.
         </span>
       );
       return (
         <AlertBanner
           status="error"
-          header="Unavailable"
+          header=""
           message={errorMessage}
         />
       );
@@ -140,7 +123,6 @@ SiteContainer.propTypes = {
   ]),
   sites: PropTypes.shape({
     isLoading: PropTypes.bool.isRequired,
-    currentSite: PropTypes.object.isRequired,
     data: PropTypes.array,
   }),
   alert: ALERT,
@@ -148,7 +130,10 @@ SiteContainer.propTypes = {
 
 SiteContainer.defaultProps = {
   children: null,
-  sites: null,
+  sites: {
+    isLoading: false,
+    data: [],
+  },
   alert: {},
 };
 

--- a/frontend/reducers/sites.js
+++ b/frontend/reducers/sites.js
@@ -7,7 +7,6 @@ import {
   siteBranchesReceivedType as SITE_BRANCHES_RECEIVED,
   siteUserAddedType as SITE_USER_ADDED,
   siteUserRemovedType as SITE_USER_REMOVED,
-  setCurrentSiteType as SET_CURRENT_SITE,
   siteUserUpdatedType as SITE_USER_UPDATED,
 } from '../actions/actionCreators/siteActions';
 
@@ -17,7 +16,6 @@ import {
 
 const initialState = {
   isLoading: false,
-  currentSite: null,
   data: [],
 };
 
@@ -35,22 +33,12 @@ export default function sites(state = initialState, action) {
       return { ...state, isLoading: true };
 
     case SITES_RECEIVED: {
-      let currentSite = null;
       const nextSites = action.sites || state.data;
-      if (state.currentSite) {
-        currentSite = nextSites.find(site => site.id === state.currentSite.id);
-      }
       return {
         ...state,
         isLoading: false,
         data: nextSites,
-        currentSite,
       };
-    }
-
-    case SET_CURRENT_SITE: {
-      const id = Number(action.siteId);
-      return { ...state, currentSite: state.data.find(site => site.id === id) };
     }
 
     case SITE_ADDED:

--- a/frontend/selectors/site/index.js
+++ b/frontend/selectors/site/index.js
@@ -1,0 +1,2 @@
+export const currentSite = (state, id) => state.data.find(site => site.id === Number(id));
+export default { currentSite };

--- a/test/frontend/actions/actionCreators/siteActionsTest.js
+++ b/test/frontend/actions/actionCreators/siteActionsTest.js
@@ -7,7 +7,6 @@ import {
   siteDeleted, siteDeletedType,
   siteUserAdded, siteUserAddedType,
   siteUserRemoved, siteUserRemovedType,
-  setCurrentSite, setCurrentSiteType,
 } from '../../../../frontend/actions/actionCreators/siteActions';
 
 describe('siteActions actionCreators', () => {
@@ -129,17 +128,6 @@ describe('siteActions actionCreators', () => {
       const action = siteUserRemoved(site);
       expect(action.type).to.equal(siteUserRemovedType);
       expect(action.site).to.equal(site);
-    });
-  });
-
-  describe('setCurrentSite', () => {
-    it('constructs properly', () => {
-      const siteId = 1;
-
-      const action = setCurrentSite(siteId);
-
-      expect(action.type).to.equal(setCurrentSiteType);
-      expect(action.siteId).to.equal(siteId);
     });
   });
 });

--- a/test/frontend/actions/dispatchActionsTest.js
+++ b/test/frontend/actions/dispatchActionsTest.js
@@ -17,7 +17,6 @@ describe('dispatchActions', () => {
   let userRemovedFromSiteActionCreator;
   let showAddNewSiteFieldsActionCreator;
   let hideAddNewSiteFieldsActionCreator;
-  let setCurrentSiteActionCreator;
   let reset;
 
   const action = { whatever: 'bub' };
@@ -34,7 +33,6 @@ describe('dispatchActions', () => {
     userRemovedFromSiteActionCreator = stub();
     showAddNewSiteFieldsActionCreator = stub();
     hideAddNewSiteFieldsActionCreator = stub();
-    setCurrentSiteActionCreator = stub();
     pushHistory = stub();
     reset = stub();
 
@@ -47,7 +45,6 @@ describe('dispatchActions', () => {
         siteDeleted: siteDeletedActionCreator,
         siteUserAdded: userAddedToSiteActionCreator,
         siteUserRemoved: userRemovedFromSiteActionCreator,
-        setCurrentSite: setCurrentSiteActionCreator,
       },
       './actionCreators/addNewSiteFieldsActions': {
         showAddNewSiteFields: showAddNewSiteFieldsActionCreator,
@@ -139,13 +136,6 @@ describe('dispatchActions', () => {
     hideAddNewSiteFieldsActionCreator.withArgs(site).returns(action);
 
     fixture.dispatchHideAddNewSiteFieldsAction();
-
-    expect(dispatch.calledOnce).to.be.true;
-  });
-
-  it('dispatchSetCurrentSiteAction', () => {
-    setCurrentSiteActionCreator.withArgs(1).returns(action);
-    fixture.dispatchSetCurrentSiteAction();
 
     expect(dispatch.calledOnce).to.be.true;
   });

--- a/test/frontend/components/siteContainer.test.js
+++ b/test/frontend/components/siteContainer.test.js
@@ -1,13 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 import { SiteContainer } from '../../../frontend/components/siteContainer';
-import siteActions from '../../../frontend/actions/siteActions';
 
 let props;
-let setCurrentSite;
 const site = {
   id: 1,
   defaultBranch: 'master',
@@ -20,7 +17,6 @@ const site = {
 
 describe('<SiteContainer/>', () => {
   beforeEach(() => {
-    setCurrentSite = spy(siteActions, 'setCurrentSite');
     props = {
       alert: {},
       user: {
@@ -34,7 +30,6 @@ describe('<SiteContainer/>', () => {
       sites: {
         isLoading: false,
         data: [site],
-        currentSite: site,
       },
       location: {
         pathname: '',
@@ -45,10 +40,6 @@ describe('<SiteContainer/>', () => {
         fileName: 'boop.txt',
       },
     };
-  });
-
-  afterEach(() => {
-    setCurrentSite.restore();
   });
 
   it('renders a LoadingIndicator while sites are loading', () => {
@@ -62,9 +53,6 @@ describe('<SiteContainer/>', () => {
   it('renders after sites have loaded', () => {
     const wrapper = shallow(<SiteContainer {...props} />);
 
-    wrapper.instance().componentDidMount();
-
-    expect(setCurrentSite.called).to.be.true;
     expect(wrapper.find('LoadingIndicator')).to.have.length(0);
     expect(wrapper.find('SideNav')).to.have.length(1);
     expect(wrapper.find('AlertBanner')).to.have.length(1);
@@ -72,7 +60,7 @@ describe('<SiteContainer/>', () => {
   });
 
   it('renders an error after sites have loaded but no matching site', () => {
-    props.sites.currentSite = null;
+    props.params.id = '2';
     const wrapper = shallow(<SiteContainer {...props} />);
     const alert = wrapper.find('AlertBanner');
 
@@ -82,6 +70,7 @@ describe('<SiteContainer/>', () => {
   });
 
   it('displays a page title if one is configured for the location', () => {
+    // eslint-disable-next-line scanjs-rules/assign_to_pathname
     props.location.pathname = 'settings';
     const wrapper = shallow(<SiteContainer {...props} />);
     expect(wrapper.find('PagesHeader').prop('title')).to.equal('Site settings');

--- a/test/frontend/reducers/sitesTest.js
+++ b/test/frontend/reducers/sitesTest.js
@@ -20,7 +20,6 @@ describe('sitesReducer', () => {
   const initialState = {
     isLoading: false,
     data: [],
-    currentSite: null,
   };
 
   beforeEach(() => {
@@ -33,7 +32,6 @@ describe('sitesReducer', () => {
         siteBranchesReceivedType: SITE_BRANCHES_RECEIVED,
         siteDeletedType: SITE_DELETED,
         siteUserAddedType: SITE_USER_ADDED,
-        setCurrentSiteType: SET_CURRENT_SITE,
       },
       '../actions/actionCreators/buildActions': {
         buildRestartedType: BUILD_RESTARTED,
@@ -252,22 +250,5 @@ describe('sitesReducer', () => {
     expect(actual.data.length).to.equal(2);
     expect(actual.data[0].users[0].username).to.equal('jane');
     expect(actual.data[1]).to.deep.equal(state.data[1]);
-  });
-
-  it('sets the current site', () => {
-    const state = {
-      isLoading: false,
-      data: [{
-        id: 2, owner: 'person2', repository: 'b', users: [],
-      }],
-      currentSite: null,
-    };
-
-    const actual = siteReducer(state, {
-      type: SET_CURRENT_SITE,
-      siteId: 2,
-    });
-
-    expect(actual.currentSite).to.deep.equal(state.data[0]);
   });
 });

--- a/test/frontend/selectors/siteTest.js
+++ b/test/frontend/selectors/siteTest.js
@@ -3,33 +3,20 @@ import { currentSite } from '../../../frontend/selectors/site';
 
 describe('siteSelectors', () => {
   describe('.currentSite', () => {
+    const state = {
+      data: [
+        { id: 2 },
+        { id: 3 },
+      ],
+    };
+
     it('returns the site for the given id', () => {
-      const state = {
-        data: [
-          { id: 2 },
-          { id: 3 },
-        ],
-      };
-
-      const id = '3';
-
-      const site = currentSite(state, id);
-
+      const site = currentSite(state, '3');
       expect(site).to.eq(state.data[1]);
     });
 
     it('returns the null if there is not site for the given id', () => {
-      const state = {
-        data: [
-          { id: 2 },
-          { id: 3 },
-        ],
-      };
-
-      const id = '4';
-
-      const site = currentSite(state, id);
-
+      const site = currentSite(state, '4');
       expect(site).to.be.undefined;
     });
   });

--- a/test/frontend/selectors/siteTest.js
+++ b/test/frontend/selectors/siteTest.js
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import { currentSite } from '../../../frontend/selectors/site';
+
+describe('siteSelectors', () => {
+  describe('.currentSite', () => {
+    it('returns the site for the given id', () => {
+      const state = {
+        data: [
+          { id: 2 },
+          { id: 3 },
+        ],
+      };
+
+      const id = '3';
+
+      const site = currentSite(state, id);
+
+      expect(site).to.eq(state.data[1]);
+    });
+
+    it('returns the null if there is not site for the given id', () => {
+      const state = {
+        data: [
+          { id: 2 },
+          { id: 3 },
+        ],
+      };
+
+      const id = '4';
+
+      const site = currentSite(state, id);
+
+      expect(site).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
This actually restores the previous behavior of showing an error when attempting to access a site to which the user does not have access. The implementation was resulting in an infinite loop of updates to the SiteContainer component when trying to set the "currentSite" if the sites loaded after the component. This PR removes the ambiguous behavior since the children of the SiteContainer don't render until the sites have loaded, they can explicitly get the "current site" from the sites and the path parameter.

This is theoretically more work, but is not ambiguous and much simpler to reason about and maintain.

Regarding the initial issue of turning this into a 404, I'm still open to it, I would think a custom error message would be necessary though so we can communicate appropriately with the user. Since the user is authenticated I'm less concerned about leaking info about whether a site exists or not, it seems more likely they are following a link that was shared with them...thoughts?

- removes setCurrentSite redux action
- removes currentSite from site data
- adds currentSite selector
- updates and adds new test