### PR TITLE
Reset and close form on successful submission

### DIFF
--- a/frontend/components/ExpandableArea.jsx
+++ b/frontend/components/ExpandableArea.jsx
@@ -24,7 +24,9 @@ class ExpandableArea extends React.Component {
   }
 
   render() {
-    const { bordered, children, title } = this.props;
+    const {
+      bordered, children, render, title,
+    } = this.props;
     const { isExpanded } = this.state;
 
     return (
@@ -43,7 +45,7 @@ class ExpandableArea extends React.Component {
           className="usa-accordion-content"
           aria-hidden={!isExpanded}
         >
-          {children}
+          {isExpanded && ((render && render(this.toggle)) || children)}
         </div>
       </div>
     );
@@ -52,12 +54,15 @@ class ExpandableArea extends React.Component {
 
 ExpandableArea.propTypes = {
   bordered: PropTypes.bool,
+  render: PropTypes.func,
   title: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
 ExpandableArea.defaultProps = {
   bordered: false,
+  render: null,
+  children: null,
 };
 
 export default ExpandableArea;

--- a/frontend/components/site/SiteSettings/EnvironmentVariableForm.jsx
+++ b/frontend/components/site/SiteSettings/EnvironmentVariableForm.jsx
@@ -14,7 +14,7 @@ export const validateValue = value => ((!value || value.length < 4)
 export const EnvironmentVariableForm = ({
   handleSubmit, invalid, pristine, reset, submitting,
 }) => (
-  <form onSubmit={handleSubmit}>
+  <form onSubmit={data => handleSubmit(data).then(reset)}>
     <fieldset>
       <legend className="sr-only">Add new environment variable</legend>
       <Field

--- a/frontend/components/site/SiteSettings/EnvironmentVariables.jsx
+++ b/frontend/components/site/SiteSettings/EnvironmentVariables.jsx
@@ -87,11 +87,15 @@ class EnvironmentVariables extends Component {
           ? <LoadingIndicator />
           : (
             <Fragment>
-              <ExpandableArea bordered title="Add a new environment variable">
-                <div className="well">
-                  <EnvironmentVariableForm onSubmit={addUEV} />
-                </div>
-              </ExpandableArea>
+              <ExpandableArea
+                bordered
+                title="Add a new environment variable"
+                render={toggle => (
+                  <div className="well">
+                    <EnvironmentVariableForm onSubmit={params => addUEV(params).then(toggle)} />
+                  </div>
+                )}
+              />
               { showTable
                 && (
                 <EnvironmentVariableTable uevs={data} onDelete={deleteUEV} />

--- a/frontend/reducers/form.js
+++ b/frontend/reducers/form.js
@@ -1,19 +1,3 @@
-import { reducer as form } from 'redux-form';
-import {
-  userEnvironmentVariableAddedType as USER_ENVIRONMENT_VARIABLE_ADDED,
-} from '../actions/actionCreators/userEnvironmentVariableActions';
+import { reducer } from 'redux-form';
 
-export default form.plugin({
-  environmentVariable: (state, action) => {
-    switch (action.type) {
-      case USER_ENVIRONMENT_VARIABLE_ADDED:
-        return {
-          ...state,
-          values: {},
-          registeredFields: {},
-        };
-      default:
-        return state;
-    }
-  },
-});
+export default reducer;

--- a/test/frontend/components/site/SiteSettings/EnvironmentVariableForm.test.js
+++ b/test/frontend/components/site/SiteSettings/EnvironmentVariableForm.test.js
@@ -17,6 +17,7 @@ describe('<EnvironmentVariableForm/>', () => {
 
     beforeEach(() => {
       stubs.handleSubmit = sinon.stub();
+      stubs.handleSubmit.resolves();
       stubs.reset = sinon.stub();
       defaultProps = {
         handleSubmit: stubs.handleSubmit,

--- a/test/frontend/components/site/SiteSettings/EnvironmentVariables.test.js
+++ b/test/frontend/components/site/SiteSettings/EnvironmentVariables.test.js
@@ -89,18 +89,10 @@ describe('<EnvironmentVariables/>', () => {
       expect(wrapper.find('LoadingIndicator')).to.have.lengthOf(0);
     });
 
-    it('renders the "new environment variable" section and form', () => {
+    it('renders the "new environment variable" section', () => {
       const wrapper = shallow(<EnvironmentVariables {...props} />);
       const section = wrapper.findWhere(n => n.name() === 'ExpandableArea' && n.prop('title') === 'Add a new environment variable');
       expect(section).to.have.lengthOf(1);
-
-      const form = wrapper.find('ReduxForm');
-      expect(form).to.have.lengthOf(1);
-
-      const params = {};
-      form.first().prop('onSubmit')(params);
-
-      sinon.assert.calledWith(stubs.addUserEnvironmentVariable, siteId, params);
     });
 
     it('does not render the "uev" table', () => {
@@ -123,18 +115,10 @@ describe('<EnvironmentVariables/>', () => {
       expect(wrapper.find('LoadingIndicator')).to.have.lengthOf(0);
     });
 
-    it('renders the "new environment variable" section and form', () => {
+    it('renders the "new environment variable" section', () => {
       const wrapper = shallow(<EnvironmentVariables {...props} />);
       const section = wrapper.findWhere(n => n.name() === 'ExpandableArea' && n.prop('title') === 'Add a new environment variable');
       expect(section).to.have.lengthOf(1);
-
-      const form = wrapper.find('ReduxForm');
-      expect(form).to.have.lengthOf(1);
-
-      const params = {};
-      form.first().prop('onSubmit')(params);
-
-      sinon.assert.calledWith(stubs.addUserEnvironmentVariable, siteId, params);
     });
 
     it('renders the "uev" table', () => {


### PR DESCRIPTION
- Moves the logic for resetting the form out of the reducer and into the component(s).
- Added the option of passing a function as a "render" prop to `ExpandableArea` instead `children`. If provided, the function will be called with the `toggle` function as an argument, so the child component has the ability to close the accordion.
- `ExpandableArea` now does not render the child content when it is closed, previously, the content was just hidden. This is relevant in this case because we want the form to actually unmount, so all state is wiped away.
- The UX now closes the accordion after a successful form submission. This was not my first choice, however, the behavior I was observing was that if the form was submitted successfully by hitting `enter` while the focus was still on an input, the focus remained there after the submission, so when the user clicks elsewhere, the `blur` event is triggered on the input causing the validations to be visible. It would be possible to explicitly set the focus elsewhere after submissions, but this seemed brittle and hacky. I'm not anticipating users needing to speedily add a ton of env vars so I think this is ok.