### PR TITLE
Create repo from template in web application

### DIFF
--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -175,6 +175,22 @@ module.exports = {
     })
     .catch(handleCreateRepoError),
 
+  createRepoFromTemplate: (user, owner, name, template) => githubClient(user.githubAccessToken)
+    .then((github) => {
+      const params = {
+        template_owner: template.owner,
+        template_repo: template.repo,
+        name,
+      };
+
+      if (user.username.toLowerCase() !== owner.toLowerCase()) {
+        params.owner = owner;
+      }
+
+      return github.repos.createUsingTemplate(params);
+    })
+    .catch(handleCreateRepoError),
+
   getRepository: (user, owner, repo) => githubClient(user.githubAccessToken)
     .then(github => getRepository(github, { owner, repo }))
     .catch((err) => {

--- a/api/services/SQS.js
+++ b/api/services/SQS.js
@@ -46,8 +46,6 @@ const buildLogCallbackURL = build => [
   build.token,
 ].join('/');
 
-const sourceForBuild = build => build.source || {};
-
 const buildUEVs = uevs => (uevs
   ? uevs.map(uev => ({
     name: uev.name,
@@ -64,15 +62,13 @@ const generateDefaultCredentials = build => ({
   BUCKET: config.s3.bucket,
   BASEURL: baseURLForBuild(build),
   CACHE_CONTROL: buildConfig.cacheControl,
-  BRANCH: sourceForBuild(build).branch || build.branch,
+  BRANCH: build.branch,
   CONFIG: siteConfig(build),
   REPOSITORY: build.Site.repository,
   OWNER: build.Site.owner,
   SITE_PREFIX: sitePrefixForBuild(buildUrl(build, build.Site)),
   GITHUB_TOKEN: build.User.githubAccessToken,
   GENERATOR: build.Site.engine,
-  SOURCE_REPO: sourceForBuild(build).repository,
-  SOURCE_OWNER: sourceForBuild(build).owner,
   SKIP_LOGGING: config.app.app_env === 'development',
   AUTH_BASEURL: process.env.APP_HOSTNAME,
   AUTH_ENDPOINT: 'external/auth/github',

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -197,7 +197,7 @@ function createSiteFromTemplate({ siteParams, user, template }) {
   return validateSite(params)
     .then((model) => {
       site = model;
-      return GitHub.createRepo(user, owner, repository);
+      return GitHub.createRepoFromTemplate(user, owner, repository, template);
     })
     .then(() => saveAndBuildSite({ site, user, template }));
 }

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -19,24 +19,11 @@ function paramsForNewSite(params) {
   };
 }
 
-function paramsForNewBuildSource(template) {
-  if (template) {
-    return {
-      repository: template.repo,
-      owner: template.owner,
-      branch: template.branch,
-    };
-  }
-
-  return null;
-}
-
-function paramsForNewBuild({ user, site, template = {} }) {
+function paramsForNewBuild({ user, site }) {
   return {
     user: user.id,
     site: site.id,
     branch: site.defaultBranch,
-    source: paramsForNewBuildSource(template),
   };
 }
 
@@ -154,7 +141,7 @@ function validateSite(params) {
  *
  * returns the new site record
  */
-function saveAndBuildSite({ site, user, template }) {
+function saveAndBuildSite({ site, user }) {
   let model;
 
   return GitHub.setWebhook(site, user.id)
@@ -165,7 +152,6 @@ function saveAndBuildSite({ site, user, template }) {
       const buildParams = paramsForNewBuild({
         site: model,
         user,
-        template,
       });
 
       return Promise.all([
@@ -186,20 +172,17 @@ function createSiteFromExistingRepo({ siteParams, user }) {
     .then(site => saveAndBuildSite({ site, user }));
 }
 
-function createSiteFromTemplate({ siteParams, user, template }) {
-  const params = Object.assign({}, siteParams, {
+async function createSiteFromTemplate({ siteParams, user, template }) {
+  const params = {
+    ...siteParams,
     defaultBranch: template.branch,
     engine: template.engine,
-  });
+  };
   const { owner, repository } = params;
-  let site;
 
-  return validateSite(params)
-    .then((model) => {
-      site = model;
-      return GitHub.createRepoFromTemplate(user, owner, repository, template);
-    })
-    .then(() => saveAndBuildSite({ site, user, template }));
+  const site = await validateSite(params);
+  await GitHub.createRepoFromTemplate(user, owner, repository, template);
+  return saveAndBuildSite({ site, user });
 }
 
 function createSiteFromSource({ siteParams, user }) {
@@ -210,7 +193,7 @@ function createSiteFromSource({ siteParams, user }) {
     .then(() => checkGithubOrg({ user, owner: source.owner }))
     .then(() => GitHub.createRepo(user, owner, repository))
     .then(() => validateSite(siteParams))
-    .then(site => saveAndBuildSite({ site, user, template: siteParams.source }));
+    .then(site => saveAndBuildSite({ site, user }));
 }
 
 function createSite({ user, siteParams }) {

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -1443,8 +1443,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
-          // eslint-disable-next-line prefer-destructuring
-          site = results.site;
+          ({ site } = results.site);
 
           return request(app)
             .put(`/v0/site/${site.id}`)

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -577,10 +577,7 @@ describe('Site API', () => {
         cookie: authenticatedSession(userPromise),
       })
         .then((models) => {
-          // eslint-disable-next-line prefer-destructuring
-          user = models.user;
-          // eslint-disable-next-line prefer-destructuring
-          site = models.site;
+          ({ user, site } = models.user);
 
           return request(app)
             .post('/v0/site/user')
@@ -1187,8 +1184,7 @@ describe('Site API', () => {
         site: sitePromise,
         cookie: sessionPromise,
       }).then((results) => {
-        // eslint-disable-next-line prefer-destructuring
-        site = results.site;
+        ({ site } = results.site);
         nock.cleanAll();
         githubAPINocks.repo({
           owner: site.owner,
@@ -1407,8 +1403,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
-          // eslint-disable-next-line prefer-destructuring
-          site = results.site;
+          ({ site } = results.site);
 
           return request(app)
             .put(`/v0/site/${site.id}`)
@@ -1486,8 +1481,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
-          // eslint-disable-next-line prefer-destructuring
-          site = results.site;
+          ({ site } = results.site);
 
           return request(app)
             .put(`/v0/site/${site.id}`)

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -1184,7 +1184,7 @@ describe('Site API', () => {
         site: sitePromise,
         cookie: sessionPromise,
       }).then((results) => {
-        ({ site } = results.site);
+        ({ site } = results);
         nock.cleanAll();
         githubAPINocks.repo({
           owner: site.owner,
@@ -1443,7 +1443,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
-          ({ site } = results.site);
+          ({ site } = results);
 
           return request(app)
             .put(`/v0/site/${site.id}`)
@@ -1480,7 +1480,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
-          ({ site } = results.site);
+          ({ site } = results);
 
           return request(app)
             .put(`/v0/site/${site.id}`)

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -351,7 +351,7 @@ describe('Site API', () => {
 
       cfMockServices(siteOwner, siteRepository);
 
-      const createRepoNock = githubAPINocks.createRepoForOrg({
+      const createRepoNock = githubAPINocks.createRepoUsingTemplate({
         org: siteOwner,
         repo: siteRepository,
       });
@@ -577,7 +577,9 @@ describe('Site API', () => {
         cookie: authenticatedSession(userPromise),
       })
         .then((models) => {
+          // eslint-disable-next-line prefer-destructuring
           user = models.user;
+          // eslint-disable-next-line prefer-destructuring
           site = models.site;
 
           return request(app)
@@ -1185,6 +1187,7 @@ describe('Site API', () => {
         site: sitePromise,
         cookie: sessionPromise,
       }).then((results) => {
+        // eslint-disable-next-line prefer-destructuring
         site = results.site;
         nock.cleanAll();
         githubAPINocks.repo({
@@ -1404,6 +1407,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
+          // eslint-disable-next-line prefer-destructuring
           site = results.site;
 
           return request(app)
@@ -1444,6 +1448,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
+          // eslint-disable-next-line prefer-destructuring
           site = results.site;
 
           return request(app)
@@ -1481,6 +1486,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
+          // eslint-disable-next-line prefer-destructuring
           site = results.site;
 
           return request(app)

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -577,7 +577,7 @@ describe('Site API', () => {
         cookie: authenticatedSession(userPromise),
       })
         .then((models) => {
-          ({ user, site } = models.user);
+          ({ user, site } = models);
 
           return request(app)
             .post('/v0/site/user')
@@ -1403,7 +1403,7 @@ describe('Site API', () => {
         cookie: cookiePromise,
       })
         .then((results) => {
-          ({ site } = results.site);
+          ({ site } = results);
 
           return request(app)
             .put(`/v0/site/${site.id}`)

--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -1,8 +1,7 @@
 const nock = require('nock');
 const config = require('../../../config');
 
-const withAuth = (nok, accessToken) =>
-  nok.matchHeader('authorization', `token ${accessToken}`);
+const withAuth = (nok, accessToken) => nok.matchHeader('authorization', `token ${accessToken}`);
 
 const getAccessToken = ({ authorizationCode, accessToken, scope } = {}) => {
   /* eslint-disable no-param-reassign */
@@ -23,9 +22,9 @@ const getAccessToken = ({ authorizationCode, accessToken, scope } = {}) => {
         client_secret: config.passport.github.options.clientSecret,
         code: authorizationCode,
       };
-      return body.client_id === expectedBody.client_id &&
-        body.client_secret === expectedBody.client_secret &&
-        body.code === expectedBody.code;
+      return body.client_id === expectedBody.client_id
+        && body.client_secret === expectedBody.client_secret
+        && body.code === expectedBody.code;
     })
     .reply(200, {
       token_type: 'bearer',
@@ -34,7 +33,9 @@ const getAccessToken = ({ authorizationCode, accessToken, scope } = {}) => {
     });
 };
 
-const createRepoForOrg = ({ accessToken, org, repo, response } = {}) => {
+const createRepoForOrg = ({
+  accessToken, org, repo, response,
+} = {}) => {
   let createRepoNock = nock('https://api.github.com');
 
   if (org && repo) {
@@ -98,7 +99,49 @@ const createRepoForUser = ({ accessToken, repo, response } = {}) => {
   return createRepoNock.reply(...resp);
 };
 
-const user = ({ accessToken, githubUserID, username, email } = {}) => {
+const createRepoUsingTemplate = ({
+  accessToken, repo, owner, template, response,
+} = {}) => {
+  let createRepoNock = nock('https://api.github.com');
+
+  if (repo && template) {
+    const params = {
+      name: repo,
+    };
+
+    if (owner) {
+      params.owner = owner;
+    }
+
+    createRepoNock = createRepoNock.post(`/repos/${template.owner}/${template.repo}/generate`, params);
+  } else {
+    createRepoNock = createRepoNock.post(/\/repos\/.+\/.+\/generate/);
+  }
+
+  if (accessToken) {
+    createRepoNock = withAuth(createRepoNock, accessToken);
+  }
+
+  createRepoNock = createRepoNock.query(true);
+
+  const typicalResponse = {
+    owner: { login: 'your-name-here' },
+    name: repo,
+  };
+
+  let resp = response || 201;
+  if (typeof resp === 'number') {
+    resp = [resp, typicalResponse];
+  } else if (resp[1] === undefined) {
+    resp[1] = typicalResponse;
+  }
+
+  return createRepoNock.reply(...resp);
+};
+
+const user = ({
+  accessToken, githubUserID, username, email,
+} = {}) => {
   /* eslint-disable no-param-reassign */
   accessToken = accessToken || 'access-token-123abc';
 
@@ -132,7 +175,7 @@ const userOrganizations = ({ accessToken, organizations, response } = {}) => {
     orgsNock = withAuth(orgsNock, accessToken);
   }
 
-  return orgsNock.get(`/user/orgs`)
+  return orgsNock.get('/user/orgs')
     .reply(response || 200, organizations);
 };
 
@@ -142,8 +185,10 @@ const githubAuth = (username, organizations) => {
   userOrganizations({ organizations });
 };
 
-// eslint-disable-next-line no-shadow
-const repo = ({ accessToken, owner, repo, username, response } = {}) => {
+const repo = ({
+  // eslint-disable-next-line no-shadow
+  accessToken, owner, repo, username, response,
+} = {}) => {
   let webhookNock = nock('https://api.github.com');
 
   if (owner && repo) {
@@ -180,8 +225,10 @@ const repo = ({ accessToken, owner, repo, username, response } = {}) => {
   return webhookNock.reply(...resp);
 };
 
-// eslint-disable-next-line no-shadow
-const status = ({ accessToken, owner, repo, sha, state, targetURL, response } = {}) => {
+const status = ({
+  // eslint-disable-next-line no-shadow
+  accessToken, owner, repo, sha, state, targetURL, response,
+} = {}) => {
   let path;
   if (owner && repo && sha) {
     path = `/repos/${owner}/${repo}/statuses/${sha}`;
@@ -197,7 +244,7 @@ const status = ({ accessToken, owner, repo, sha, state, targetURL, response } = 
     const appEnv = config.app.app_env;
     if (appEnv === 'production' && body.context !== 'federalist/build') {
       return false;
-    } else if (appEnv !== 'production' && body.context !== `federalist-${appEnv}/build`) {
+    } if (appEnv !== 'production' && body.context !== `federalist-${appEnv}/build`) {
       return false;
     }
 
@@ -222,8 +269,10 @@ const status = ({ accessToken, owner, repo, sha, state, targetURL, response } = 
   return statusNock.reply(...resp);
 };
 
-// eslint-disable-next-line no-shadow
-const webhook = ({ accessToken, owner, repo, response } = {}) => {
+const webhook = ({
+  // eslint-disable-next-line no-shadow
+  accessToken, owner, repo, response,
+} = {}) => {
   let webhookNock = nock('https://api.github.com');
 
   if (owner && repo) {
@@ -254,8 +303,10 @@ const webhook = ({ accessToken, owner, repo, response } = {}) => {
   return webhookNock.reply(...resp);
 };
 
-// eslint-disable-next-line no-shadow
-const getBranch = ({ accessToken, owner, repo, branch, expected }) => {
+const getBranch = ({
+  // eslint-disable-next-line no-shadow
+  accessToken, owner, repo, branch, expected,
+}) => {
   let branchNock = nock('https://api.github.com');
   const path = `/repos/${owner}/${repo}/branches/${branch}`;
 
@@ -278,7 +329,9 @@ const getBranch = ({ accessToken, owner, repo, branch, expected }) => {
 };
 
 /* eslint-disable camelcase */
-const getOrganizationMembers = ({ accessToken, organization, role, per_page, page, response, responseCode }) => {
+const getOrganizationMembers = ({
+  accessToken, organization, role, per_page, page, response, responseCode,
+}) => {
   /* eslint-disable no-param-reassign */
   accessToken = accessToken || 'access-token-123abc';
   organization = organization || 'test-org';
@@ -300,28 +353,35 @@ const getOrganizationMembers = ({ accessToken, organization, role, per_page, pag
 
   return withAuth(nock('https://api.github.com'), accessToken)
     .get(`/orgs/${organization}/members?per_page=${per_page}&page=${page}&role=${role}`)
-    .reply(responseCode || 200, response || orgMembers.slice(((page - 1) * per_page), (page * per_page)));
+    .reply(
+      responseCode || 200,
+      response || orgMembers.slice(((page - 1) * per_page), (page * per_page))
+    );
 };
 
-const getTeamMembers = ({ accessToken, org, team_slug, per_page, page, response } = {}) => {
+const getTeamMembers = ({
+  accessToken, team_id, per_page, page, response,
+} = {}) => {
   /* eslint-disable no-param-reassign */
   accessToken = accessToken || 'access-token-123abc';
-  team_slug = team_slug || 'test-team';
+  team_id = team_id || 'test-team';
   per_page = per_page || 100;
   page = page || 1;
   /* eslint-enable no-param-reassign */
 
   const teamMembers = [];
   for (let i = 0; i < (per_page + 2); i += 1) {
-    teamMembers.push({ login: `user-${team_slug}-${i}` });
+    teamMembers.push({ login: `user-${team_id}-${i}` });
   }
 
   return withAuth(nock('https://api.github.com'), accessToken)
-    .get(`/orgs/${org}/teams/${team_slug}/members?per_page=${per_page}&page=${page}`)
+    .get(`/teams/${team_id}/members?per_page=${per_page}&page=${page}`)
     .reply(response || 200, teamMembers.slice(((page - 1) * per_page), page * per_page));
 };
 
-const getRepositories = ({ accessToken, per_page, page, response }) => {
+const getRepositories = ({
+  accessToken, per_page, page, response,
+}) => {
   /* eslint-disable no-param-reassign */
   accessToken = accessToken || 'access-token-123abc';
   per_page = per_page || 100;
@@ -338,7 +398,9 @@ const getRepositories = ({ accessToken, per_page, page, response }) => {
     .reply(response || 200, repos.slice(((page - 1) * per_page), (page * per_page)));
 };
 
-const getCollaborators = ({ accessToken, owner, repository, per_page, page, response }) => {
+const getCollaborators = ({
+  accessToken, owner, repository, per_page, page, response,
+}) => {
   /* eslint-disable no-param-reassign */
   accessToken = accessToken || 'access-token-123abc';
   per_page = per_page || 100;
@@ -362,6 +424,7 @@ module.exports = {
   getAccessToken,
   createRepoForOrg,
   createRepoForUser,
+  createRepoUsingTemplate,
   githubAuth,
   repo,
   status,

--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -360,22 +360,22 @@ const getOrganizationMembers = ({
 };
 
 const getTeamMembers = ({
-  accessToken, team_id, per_page, page, response,
+  accessToken, org, team_slug, per_page, page, response,
 } = {}) => {
   /* eslint-disable no-param-reassign */
   accessToken = accessToken || 'access-token-123abc';
-  team_id = team_id || 'test-team';
+  team_slug = team_slug || 'test-team';
   per_page = per_page || 100;
   page = page || 1;
   /* eslint-enable no-param-reassign */
 
   const teamMembers = [];
   for (let i = 0; i < (per_page + 2); i += 1) {
-    teamMembers.push({ login: `user-${team_id}-${i}` });
+    teamMembers.push({ login: `user-${team_slug}-${i}` });
   }
 
   return withAuth(nock('https://api.github.com'), accessToken)
-    .get(`/teams/${team_id}/members?per_page=${per_page}&page=${page}`)
+    .get(`/orgs/${org}/teams/${team_slug}/members?per_page=${per_page}&page=${page}`)
     .reply(response || 200, teamMembers.slice(((page - 1) * per_page), page * per_page));
 };
 

--- a/test/api/unit/services/GitHub.test.js
+++ b/test/api/unit/services/GitHub.test.js
@@ -545,7 +545,7 @@ describe('GitHub', () => {
     it('returns a branch based on the supplied parameters', (done) => {
       const accessToken = 'token';
       const org = 'federalist-users';
-      const team_slug = 12345;
+      const team_slug = '12345';
 
       githubAPINocks.getTeamMembers({ accessToken, org, team_slug });
       githubAPINocks.getTeamMembers({

--- a/test/api/unit/services/GitHub.test.js
+++ b/test/api/unit/services/GitHub.test.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const config = require('../../../../config');
 const factory = require('../../support/factory');
 const GitHub = require('../../../../api/services/GitHub');
@@ -140,6 +140,91 @@ describe('GitHub', () => {
         expect(err.message).to.equal('A repo with that name already exists.');
         done();
       }).catch(done);
+    });
+  });
+
+  describe('.createRepoFromTemplate(user, owner, name, template)', () => {
+    const repo = 'repo-name';
+    const org = 'org-name';
+    const template = {
+      owner: '18f',
+      repo: 'cool-starter-repo',
+    };
+
+    it('should create a repository for the user if the user is the owner', async () => {
+      const user = await factory.user();
+      const createRepoNock = githubAPINocks.createRepoUsingTemplate({
+        accessToken: user.githubAccessToken,
+        repo,
+        template,
+      });
+
+      await GitHub.createRepoFromTemplate(user, user.username, repo, template);
+
+      expect(createRepoNock.isDone()).to.equal(true);
+    });
+
+    it('should create a repository for an org if the user is not the owner', async () => {
+      const user = await factory.user();
+      const createRepoNock = githubAPINocks.createRepoUsingTemplate({
+        accessToken: user.githubAccessToken,
+        owner: org,
+        repo,
+        template,
+      });
+
+      await GitHub.createRepoFromTemplate(user, org, repo, template);
+
+      expect(createRepoNock.isDone()).to.equal(true);
+    });
+
+    it('should create a user repository even if the case for the owner and username don\'t match', async () => {
+      const user = await factory.user();
+      const createRepoNock = githubAPINocks.createRepoUsingTemplate({
+        accessToken: user.githubAccessToken,
+        repo,
+        template,
+      });
+
+      await GitHub.createRepoFromTemplate(user, user.username.toUpperCase(), repo, template);
+
+      expect(createRepoNock.isDone()).to.equal(true);
+    });
+
+    it('should reject if the user is not authorized to create a repository', async () => {
+      const user = await factory.user();
+      githubAPINocks.createRepoUsingTemplate({
+        accessToken: user.githubAccessToken,
+        owner: org,
+        repo,
+        template,
+        response: [403, {
+          message: 'You need admin access to the organization before adding a repository to it.',
+        }],
+      });
+
+      const err = await GitHub.createRepoFromTemplate(user, org, repo, template).catch(e => e);
+
+      expect(err.status).to.equal(400);
+      expect(err.message).to.equal('You need admin access to the organization before adding a repository to it.');
+    });
+
+    it('should reject if the repo already exists', async () => {
+      const user = await factory.user();
+      githubAPINocks.createRepoUsingTemplate({
+        accessToken: user.githubAccessToken,
+        owner: org,
+        repo,
+        template,
+        response: [422, {
+          errors: [{ message: 'name already exists on this account' }],
+        }],
+      });
+
+      const err = await GitHub.createRepoFromTemplate(user, org, repo, template).catch(e => e);
+
+      expect(err.status).to.equal(400);
+      expect(err.message).to.equal('A repo with that name already exists.');
     });
   });
 
@@ -293,14 +378,14 @@ describe('GitHub', () => {
 
         return GitHub.getBranch(values.user, owner, repository, branch);
       })
-      .then((branchInfo) => {
-        expect(branchInfo).to.exist;
-        expect(branchInfo.name).to.exist;
-        expect(branchInfo.commit).to.exist;
-        expect(mockGHRequest.isDone()).to.be.true;
-        done();
-      })
-      .catch(done);
+        .then((branchInfo) => {
+          expect(branchInfo).to.exist;
+          expect(branchInfo.name).to.exist;
+          expect(branchInfo.commit).to.exist;
+          expect(mockGHRequest.isDone()).to.be.true;
+          done();
+        })
+        .catch(done);
     });
 
     it('returns an error if branch is not defined', (done) => {
@@ -325,7 +410,7 @@ describe('GitHub', () => {
             done();
           });
       })
-      .catch(done);
+        .catch(done);
     });
   });
 
@@ -362,8 +447,12 @@ describe('GitHub', () => {
       const repository = 'repo';
 
       githubAPINocks.getCollaborators({ accessToken, owner, repository });
-      githubAPINocks.getCollaborators({ accessToken, owner, repository, page: 2 });
-      githubAPINocks.getCollaborators({ accessToken, owner, repository, page: 3 });
+      githubAPINocks.getCollaborators({
+        accessToken, owner, repository, page: 2,
+      });
+      githubAPINocks.getCollaborators({
+        accessToken, owner, repository, page: 3,
+      });
 
       GitHub.getCollaborators(accessToken, owner, repository)
         .then((collabs) => {
@@ -417,8 +506,12 @@ describe('GitHub', () => {
       const organization = 'testOrg';
 
       githubAPINocks.getOrganizationMembers({ accessToken, organization, role: 'admin' });
-      githubAPINocks.getOrganizationMembers({ accessToken, organization, role: 'admin', page: 2 });
-      githubAPINocks.getOrganizationMembers({ accessToken, organization, role: 'admin', page: 3 });
+      githubAPINocks.getOrganizationMembers({
+        accessToken, organization, role: 'admin', page: 2,
+      });
+      githubAPINocks.getOrganizationMembers({
+        accessToken, organization, role: 'admin', page: 3,
+      });
       GitHub.getOrganizationMembers(accessToken, organization, 'admin')
         .then((members) => {
           expect(members.length).to.equal(3);
@@ -432,8 +525,12 @@ describe('GitHub', () => {
       const organization = 'testOrg';
 
       githubAPINocks.getOrganizationMembers({ accessToken, organization, role: 'member' });
-      githubAPINocks.getOrganizationMembers({ accessToken, organization, role: 'member', page: 2 });
-      githubAPINocks.getOrganizationMembers({ accessToken, organization, role: 'member', page: 3 });
+      githubAPINocks.getOrganizationMembers({
+        accessToken, organization, role: 'member', page: 2,
+      });
+      githubAPINocks.getOrganizationMembers({
+        accessToken, organization, role: 'member', page: 3,
+      });
       GitHub.getOrganizationMembers(accessToken, organization, 'member')
         .then((members) => {
           expect(members.length).to.equal(98);
@@ -451,8 +548,12 @@ describe('GitHub', () => {
       const team_slug = 12345;
 
       githubAPINocks.getTeamMembers({ accessToken, org, team_slug });
-      githubAPINocks.getTeamMembers({ accessToken, org, team_slug, page: 2 });
-      githubAPINocks.getTeamMembers({ accessToken, org, team_slug, page: 3 });
+      githubAPINocks.getTeamMembers({
+        accessToken, org, team_slug, page: 2,
+      });
+      githubAPINocks.getTeamMembers({
+        accessToken, org, team_slug, page: 3,
+      });
       GitHub.getTeamMembers(accessToken, org, team_slug)
         .then((members) => {
           expect(members.length).to.equal(102);

--- a/test/api/unit/services/SQS.test.js
+++ b/test/api/unit/services/SQS.test.js
@@ -543,25 +543,6 @@ describe('SQS', () => {
         .catch(done);
     });
 
-    it('sets SOURCE_REPO, SOURCE_OWNER, and BRANCH in the repository if the build has a source owner / repo', (done) => {
-      const buildParams = {
-        repository: 'template',
-        owner: '18f',
-        branch: 'my-branch',
-      };
-      factory.site({ engine: 'hugo' })
-        .then(() => factory.build({ source: buildParams }))
-        .then(build => Build.findByPk(build.id, { include: [Site, User] }))
-        .then(build => SQS.messageBodyForBuild(build))
-        .then((message) => {
-          expect(messageEnv(message, 'SOURCE_REPO')).to.equal(buildParams.repository);
-          expect(messageEnv(message, 'SOURCE_OWNER')).to.equal(buildParams.owner);
-          expect(messageEnv(message, 'BRANCH')).to.equal(buildParams.branch);
-          done();
-        })
-        .catch(done);
-    });
-
     describe('SKIP_LOGGING', () => {
       const origAppEnv = config.app.app_env;
 

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -321,8 +321,6 @@ describe('SiteCreator', () => {
           expect(site.Builds).to.have.length(1);
           expect(site.Builds[0].user).to.equal(user.id);
           expect(site.Builds[0].branch).to.equal(site.defaultBranch);
-          expect(site.Builds[0].source.repository).to.equal(fakeTemplate.repo);
-          expect(site.Builds[0].source.owner).to.equal(fakeTemplate.owner);
 
           templateResolverStub.restore();
 

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -253,17 +253,18 @@ describe('SiteCreator', () => {
     });
 
     context('when the site is created from a template', () => {
+      const template = 'uswds2';
       const siteParams = {
         owner: crypto.randomBytes(3).toString('hex'),
         repository: crypto.randomBytes(3).toString('hex'),
-        template: 'uswds2',
+        template,
       };
       let user;
 
       it('should create a new site record for the given repository and add the user', (done) => {
         factory.user().then((model) => {
           user = model;
-          githubAPINocks.createRepoForOrg();
+          githubAPINocks.createRepoUsingTemplate();
           githubAPINocks.webhook();
           return SiteCreator.createSite({ user, siteParams });
         }).then((site) => {
@@ -292,7 +293,7 @@ describe('SiteCreator', () => {
         factory.user()
           .then((model) => {
             user = model;
-            githubAPINocks.createRepoForOrg();
+            githubAPINocks.createRepoUsingTemplate();
             githubAPINocks.webhook();
             return SiteCreator.createSite({ siteParams, user });
           }).then((site) => {
@@ -313,7 +314,7 @@ describe('SiteCreator', () => {
 
         factory.user().then((model) => {
           user = model;
-          githubAPINocks.createRepoForOrg();
+          githubAPINocks.createRepoUsingTemplate();
           githubAPINocks.webhook();
           return SiteCreator.createSite({ siteParams, user });
         }).then(site => Site.findByPk(site.id, { include: [Build] })).then((site) => {
@@ -336,7 +337,7 @@ describe('SiteCreator', () => {
         factory.user()
           .then((model) => {
             user = model;
-            githubAPINocks.createRepoForOrg();
+            githubAPINocks.createRepoUsingTemplate();
             webhookNock = githubAPINocks.webhook({
               accessToken: user.githubAccessToken,
               owner: siteParams.owner,
@@ -356,10 +357,11 @@ describe('SiteCreator', () => {
           .then((model) => {
             user = model;
 
-            githubAPINocks.createRepoForOrg({
+            githubAPINocks.createRepoUsingTemplate({
               accessToken: user.accessToken,
-              org: siteParams.owner,
+              owner: siteParams.owner,
               repo: siteParams.repository,
+              template: TemplateResolver.getTemplate(template),
               response: [422, {
                 errors: [{ message: 'name already exists on this account' }],
               }],


### PR DESCRIPTION
Simpler than I thought!

- Requires that the source template be configured as a "template" in Github (just a checkbox)
- Removes usage of the `source` column of the build, can be removed completely in a follow up PR.
I really, really tried to limit the blast radius of auto-linting changes, but still failed a bit :(