### PR TITLE
Migrate to reach-router

### DIFF
--- a/frontend/actions/actionCreators/navigationActions.js
+++ b/frontend/actions/actionCreators/navigationActions.js
@@ -1,12 +1,6 @@
-const updateRouterType = 'UPDATE_ROUTER';
+import { navigate } from '@reach/router';
 
-const updateRouter = (path, method) => ({
-  type: updateRouterType,
-  method,
-  arguments: [path],
-});
+const pushRouterHistory = path => navigate(path);
+const replaceRouterHistory = path => navigate(path, { replace: true });
 
-const pushRouterHistory = path => updateRouter(path, 'push');
-const replaceRouterHistory = path => updateRouter(path, 'replace');
-
-export { updateRouterType, pushRouterHistory, replaceRouterHistory };
+export { pushRouterHistory, replaceRouterHistory };

--- a/frontend/components/NotFound.js
+++ b/frontend/components/NotFound.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from '@reach/router';
 
 const NotFound = () => (
   <div className="usa-grid">

--- a/frontend/components/app.js
+++ b/frontend/components/app.js
@@ -9,7 +9,9 @@ import LoadingIndicator from './LoadingIndicator';
 import BuildStatusNotifier from '../util/buildStatusNotifier';
 
 export class App extends React.Component {
-  componentWillMount() {
+  componentDidMount() {
+    const { onEnter } = this.props;
+    onEnter();
     BuildStatusNotifier.listen();
   }
 
@@ -75,6 +77,7 @@ App.propTypes = {
   location: PropTypes.shape({
     key: PropTypes.string,
   }),
+  onEnter: PropTypes.func.isRequired,
   user: PropTypes.oneOfType([
     // When the user is not auth'd, this prop is false, which is a little weird
     PropTypes.bool,

--- a/frontend/components/site/NotificationSettings.jsx
+++ b/frontend/components/site/NotificationSettings.jsx
@@ -66,7 +66,7 @@ NotificationSettings.defaultProps = {
   user: null,
 };
 
-const mapStateToProps = ({ user, sites }, { params: { id } }) => ({
+const mapStateToProps = ({ user, sites }, { id }) => ({
   user: user.data,
   site: currentSite(sites, id),
 });

--- a/frontend/components/site/PagesHeader.jsx
+++ b/frontend/components/site/PagesHeader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import { Link } from '@reach/router';
 
 import { IconView } from '../icons';
 import GitHubLink from '../GitHubLink';

--- a/frontend/components/site/SideNav.jsx
+++ b/frontend/components/site/SideNav.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import { Link } from '@reach/router';
 
 import * as icons from '../icons';
 

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -22,10 +22,10 @@ class SitePublishedFilesTable extends React.Component {
   }
 
   componentDidMount() {
-    const { params } = this.props;
+    const { id, name } = this.props;
 
-    const site = { id: params.id };
-    const branch = params.name;
+    const site = { id };
+    const branch = name;
 
     const startAtKey = null; // start without a startAtKey
     publishedFileActions.fetchPublishedFiles(site, branch, startAtKey);
@@ -67,7 +67,7 @@ class SitePublishedFilesTable extends React.Component {
   }
 
   nextPage() {
-    const { params } = this.props;
+    const { id, name } = this.props;
     const { currentPage, filesByPage } = this.state;
 
     const nextPage = currentPage + 1;
@@ -85,8 +85,8 @@ class SitePublishedFilesTable extends React.Component {
     }
 
     // else dispatch action to fetch next page of files
-    const site = { id: params.id };
-    const branch = params.name;
+    const site = { id };
+    const branch = name;
     const files = filesByPage[currentPage];
     const startAtKey = files[files.length - 1].key;
 
@@ -135,11 +135,11 @@ class SitePublishedFilesTable extends React.Component {
   }
 
   renderPublishedFilesTable(files) {
-    const { params } = this.props;
+    const { name } = this.props;
 
     return (
       <div>
-        <h3>{params.name}</h3>
+        <h3>{name}</h3>
         <p>
           Use this page to audit the files that Federalist has publicly published.
           Up to 200 files are shown per page.
@@ -210,10 +210,8 @@ class SitePublishedFilesTable extends React.Component {
 }
 
 SitePublishedFilesTable.propTypes = {
-  params: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-  }).isRequired,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   publishedFiles: PropTypes.shape({
     isLoading: PropTypes.bool.isRequired,
     data: PropTypes.shape({
@@ -236,7 +234,7 @@ SitePublishedFilesTable.defaultProps = {
   publishedFiles: null,
 };
 
-const mapStateToProps = ({ publishedFiles, sites }, { params: { id } }) => ({
+const mapStateToProps = ({ publishedFiles, sites }, { id }) => ({
   publishedFiles,
   site: currentSite(sites, id),
 });

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -14,7 +14,7 @@ import { currentSite } from '../../../selectors/site';
 class SiteSettings extends React.Component {
   constructor(props) {
     super(props);
-    autoBind(this, 'handleUpdate', 'handleDelete', 'handleCopySite');
+    autoBind(this, 'handleUpdate', 'handleDelete');
   }
 
   handleDelete() {
@@ -109,7 +109,7 @@ SiteSettings.defaultProps = {
   site: null,
 };
 
-const mapStateToProps = ({ sites }, { params: { id } }) => ({
+const mapStateToProps = ({ sites }, { id }) => ({
   site: currentSite(sites, id),
 });
 

--- a/frontend/components/site/SiteUsers.jsx
+++ b/frontend/components/site/SiteUsers.jsx
@@ -92,7 +92,7 @@ SiteUsers.defaultProps = {
   user: null,
 };
 
-const mapStateToProps = ({ user, sites }, { params: { id } }) => ({
+const mapStateToProps = ({ user, sites }, { id }) => ({
   user: user.data,
   site: currentSite(sites, id),
 });

--- a/frontend/components/site/siteBuildLogTable.jsx
+++ b/frontend/components/site/siteBuildLogTable.jsx
@@ -10,7 +10,7 @@ function SiteBuildLogTable({ buildLogs }) {
   return (
     <pre className="build-log">
       {Object.keys(groupedLogs).map(source => (
-        <React.Fragment>
+        <React.Fragment key={source}>
           {source !== 'ALL' && (
             <span className="log-source-header">{source}</span>
           )}

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -58,6 +58,7 @@ class SiteBuildLogs extends React.Component {
             <li><DownloadBuildLogsButton buildId={buildId} buildLogsData={buildLogs.data} /></li>
             <li>
               <div>
+                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                 <a
                   href="#"
                   role="button"

--- a/frontend/components/site/siteBuildLogs.js
+++ b/frontend/components/site/siteBuildLogs.js
@@ -20,13 +20,13 @@ class SiteBuildLogs extends React.Component {
 
   /* eslint-disable scanjs-rules/call_setInterval */
   componentDidMount() {
-    const { actions: { fetchBuildLogs }, params } = this.props;
+    const { actions: { fetchBuildLogs }, buildId } = this.props;
 
-    fetchBuildLogs({ id: params.buildId });
+    fetchBuildLogs({ id: buildId });
     this.intervalHandle = setInterval(() => {
       const { autoRefresh } = this.state;
       if (autoRefresh) {
-        fetchBuildLogs({ id: params.buildId });
+        fetchBuildLogs({ id: buildId });
       }
     }, REFRESH_INTERVAL);
   }
@@ -38,9 +38,9 @@ class SiteBuildLogs extends React.Component {
 
   /* eslint-disable jsx-a11y/href-no-hash */
   render() {
-    const { buildLogs, params } = this.props;
+    const { buildLogs, buildId: buildIdStr } = this.props;
     const { autoRefresh } = this.state;
-    const buildId = parseInt(params.buildId, 10);
+    const buildId = parseInt(buildIdStr, 10);
 
     if (!buildLogs.isLoading && (!buildLogs || !buildLogs.data || !buildLogs.data.length)) {
       return (
@@ -84,9 +84,7 @@ class SiteBuildLogs extends React.Component {
 /* eslint-enable jsx-a11y/href-no-hash */
 
 SiteBuildLogs.propTypes = {
-  params: PropTypes.shape({
-    buildId: PropTypes.string.isRequired,
-  }).isRequired,
+  buildId: PropTypes.string.isRequired,
   buildLogs: PropTypes.shape({
     isLoading: PropTypes.bool,
     data: PropTypes.array,

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import autoBind from 'react-autobind';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
+import { Link } from '@reach/router';
 
 import GitHubLink from '../GitHubLink';
 import { BUILD } from '../../propTypes';
@@ -75,14 +75,14 @@ class SiteBuilds extends React.Component {
 
   /* eslint-disable scanjs-rules/call_setInterval */
   componentDidMount() {
-    const { actions, params } = this.props;
+    const { actions, id } = this.props;
 
     const { fetchBuilds } = actions;
-    fetchBuilds({ id: params.id });
+    fetchBuilds({ id });
     this.intervalHandle = setInterval(() => {
       const { autoRefresh } = this.state;
       if (autoRefresh) {
-        fetchBuilds({ id: params.id });
+        fetchBuilds({ id });
       }
     }, REFRESH_INTERVAL);
   }
@@ -240,6 +240,7 @@ class SiteBuilds extends React.Component {
 }
 
 SiteBuilds.propTypes = {
+  id: PropTypes.string.isRequired,
   builds: PropTypes.shape({
     isLoading: PropTypes.bool,
     data: PropTypes.arrayOf(BUILD),
@@ -247,9 +248,6 @@ SiteBuilds.propTypes = {
   site: PropTypes.shape({
     id: PropTypes.number,
   }),
-  params: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-  }).isRequired,
   actions: PropTypes.shape({
     fetchBuilds: PropTypes.func.isRequired,
     restartBuild: PropTypes.func.isRequired,
@@ -265,7 +263,7 @@ SiteBuilds.defaultProps = {
   },
 };
 
-const mapStateToProps = ({ builds, sites }, { params: { id } }) => ({
+const mapStateToProps = ({ builds, sites }, { id }) => ({
   builds,
   site: currentSite(sites, id),
 });

--- a/frontend/components/site/siteBuilds.js
+++ b/frontend/components/site/siteBuilds.js
@@ -129,6 +129,7 @@ class SiteBuilds extends React.Component {
       <div>
         <div className="log-tools">
           <div>
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <a
               href="#"
               role="button"

--- a/frontend/components/site/sitePublishedBranchesTable.js
+++ b/frontend/components/site/sitePublishedBranchesTable.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
+import { Link } from '@reach/router';
 import publishedBranchActions from '../../actions/publishedBranchActions';
 import { currentSite } from '../../selectors/site';
 import LoadingIndicator from '../LoadingIndicator';
@@ -108,7 +108,7 @@ SitePublishedBranchesTable.defaultProps = {
   site: null,
 };
 
-const mapStateToProps = ({ publishedBranches, sites }, { params: { id } }) => ({
+const mapStateToProps = ({ publishedBranches, sites }, { id }) => ({
   publishedBranches,
   site: currentSite(sites, id),
 });

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -49,14 +49,14 @@ export class SiteContainer extends React.Component {
 
   render() {
     const {
-      sites, children, params, location, alert,
+      id, sites, children, params, location, alert,
     } = this.props;
 
     if (sites.isLoading || !sites.data) {
       return <LoadingIndicator />;
     }
 
-    const site = currentSite(sites, params.id);
+    const site = currentSite(sites, id);
 
     if (!site) {
       const errorMessage = (
@@ -105,8 +105,8 @@ export class SiteContainer extends React.Component {
 }
 
 SiteContainer.propTypes = {
+  id: PropTypes.string,
   params: PropTypes.shape({
-    id: PropTypes.string,
     branch: PropTypes.string,
     fileName: PropTypes.string,
   }).isRequired,
@@ -131,6 +131,10 @@ SiteContainer.defaultProps = {
     data: [],
   },
   alert: {},
+  params: {
+    branch: undefined,
+    fileName: undefined,
+  },
 };
 
 export default connect(state => state)(SiteContainer);

--- a/frontend/components/siteContainer.js
+++ b/frontend/components/siteContainer.js
@@ -105,11 +105,11 @@ export class SiteContainer extends React.Component {
 }
 
 SiteContainer.propTypes = {
-  id: PropTypes.string,
+  id: PropTypes.string.isRequired,
   params: PropTypes.shape({
     branch: PropTypes.string,
     fileName: PropTypes.string,
-  }).isRequired,
+  }),
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }).isRequired,
@@ -131,10 +131,7 @@ SiteContainer.defaultProps = {
     data: [],
   },
   alert: {},
-  params: {
-    branch: undefined,
-    fileName: undefined,
-  },
+  params: {},
 };
 
 export default connect(state => state)(SiteContainer);

--- a/frontend/components/siteList/siteList.js
+++ b/frontend/components/siteList/siteList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import { Link } from '@reach/router';
 import { connect } from 'react-redux';
 
 import { SITE, ALERT, USER } from '../../propTypes';

--- a/frontend/components/siteList/siteListItem.js
+++ b/frontend/components/siteList/siteListItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import { Link } from '@reach/router';
 
 import { IconView } from '../icons';
 import PublishedState from './publishedState';

--- a/frontend/main.jsx
+++ b/frontend/main.jsx
@@ -4,21 +4,19 @@ import 'babel-polyfill';
 import { render } from 'react-dom';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { Router, browserHistory } from 'react-router';
-import { syncHistoryWithStore } from 'react-router-redux';
+import { Router } from '@reach/router';
+
 
 import routes from './routes';
 import store from './store';
 
 import './sass/styles.scss';
 
-const history = syncHistoryWithStore(browserHistory, store);
-
 const mainEl = document.querySelector('#js-app');
 
 render((
   <Provider store={store}>
-    <Router history={history}>
+    <Router>
       { routes }
     </Router>
   </Provider>

--- a/frontend/middleware.js
+++ b/frontend/middleware.js
@@ -1,18 +1,6 @@
-import { browserHistory } from 'react-router';
 import Notifications from 'react-notification-system-redux';
 
-import { updateRouterType as UPDATE_ROUTER } from './actions/actionCreators/navigationActions';
-
-export const reroute = () => next => (action) => {
-  if (action.type !== UPDATE_ROUTER) {
-    return next(action);
-  }
-
-  browserHistory[action.method](...action.arguments);
-  return next(action);
-};
-
-
+// eslint-disable-next-line import/prefer-default-export
 export const createNotifier = notificationSettings => store => next => (action) => {
   // This middleware creation function takes a notificationSettings object and
   // returns a Redux middleware. See notificationSettings.js for example settings.

--- a/frontend/propTypes.js
+++ b/frontend/propTypes.js
@@ -49,7 +49,6 @@ export const BUILD = PropTypes.shape({
 });
 
 export const BUILD_LOG = PropTypes.shape({
-  id: PropTypes.number.isRequired,
   source: PropTypes.string.isRequired,
   output: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,

--- a/frontend/routes.js
+++ b/frontend/routes.js
@@ -22,33 +22,6 @@ const fetchInitialData = () => {
   siteActions.fetchSites();
 };
 
-// export default (
-//   <Route path="/" component={App} onEnter={fetchInitialData}>
-//     <Route path="sites">
-//       <IndexRoute component={SiteList} />
-//       <Route path="new" component={AddSite} />
-//       <Route path=":id" component={SiteContainer}>
-//         <IndexRedirect to="builds" />
-//         <Route path="settings" component={SiteSettings} />
-//         <Route path="published">
-//           <IndexRoute component={SitePublishedBranchesTable} />
-//           <Route path=":name" component={SitePublishedFilesTable} />
-//         </Route>
-//         <Route path="builds">
-//           <IndexRoute component={SiteBuilds} />
-//           <Route path=":buildId/logs" component={SiteBuildLogs} />
-//         </Route>
-//         <Route path="users" component={SiteUsers} />
-//         <Route path="notifications" component={NotificationSettings} />
-//       </Route>
-//       <Redirect from="*" to="/not-found" />
-//     </Route>
-//     <Route path="/not-found" component={NotFound} />
-//     <Redirect from="*" to="/sites" />
-//   </Route>
-// );
-
-
 export default (
   <App path="/" onEnter={fetchInitialData}>
     <SiteList path="sites" />

--- a/frontend/routes.js
+++ b/frontend/routes.js
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  Route, IndexRedirect, IndexRoute, Redirect,
-} from 'react-router';
+import { Redirect } from '@reach/router';
 
 import App from './components/app';
 import SiteList from './components/siteList/siteList';
@@ -24,28 +22,49 @@ const fetchInitialData = () => {
   siteActions.fetchSites();
 };
 
+// export default (
+//   <Route path="/" component={App} onEnter={fetchInitialData}>
+//     <Route path="sites">
+//       <IndexRoute component={SiteList} />
+//       <Route path="new" component={AddSite} />
+//       <Route path=":id" component={SiteContainer}>
+//         <IndexRedirect to="builds" />
+//         <Route path="settings" component={SiteSettings} />
+//         <Route path="published">
+//           <IndexRoute component={SitePublishedBranchesTable} />
+//           <Route path=":name" component={SitePublishedFilesTable} />
+//         </Route>
+//         <Route path="builds">
+//           <IndexRoute component={SiteBuilds} />
+//           <Route path=":buildId/logs" component={SiteBuildLogs} />
+//         </Route>
+//         <Route path="users" component={SiteUsers} />
+//         <Route path="notifications" component={NotificationSettings} />
+//       </Route>
+//       <Redirect from="*" to="/not-found" />
+//     </Route>
+//     <Route path="/not-found" component={NotFound} />
+//     <Redirect from="*" to="/sites" />
+//   </Route>
+// );
+
+
 export default (
-  <Route path="/" component={App} onEnter={fetchInitialData}>
-    <Route path="sites">
-      <IndexRoute component={SiteList} />
-      <Route path="new" component={AddSite} />
-      <Route path=":id" component={SiteContainer}>
-        <IndexRedirect to="builds" />
-        <Route path="settings" component={SiteSettings} />
-        <Route path="published">
-          <IndexRoute component={SitePublishedBranchesTable} />
-          <Route path=":name" component={SitePublishedFilesTable} />
-        </Route>
-        <Route path="builds">
-          <IndexRoute component={SiteBuilds} />
-          <Route path=":buildId/logs" component={SiteBuildLogs} />
-        </Route>
-        <Route path="users" component={SiteUsers} />
-        <Route path="notifications" component={NotificationSettings} />
-      </Route>
-      <Redirect from="*" to="/not-found" />
-    </Route>
-    <Route path="/not-found" component={NotFound} />
-    <Redirect from="*" to="/sites" />
-  </Route>
+  <App path="/" onEnter={fetchInitialData}>
+    <SiteList path="sites" />
+    <AddSite path="sites/new" />
+    <SiteContainer path="sites/:id">
+      <Redirect noThrow from="/" to="builds" />
+      <SiteSettings path="settings" />
+      <SitePublishedBranchesTable path="published" />
+      <SitePublishedFilesTable path="published/:name" />
+      <SiteBuilds path="builds" />
+      <SiteBuildLogs path="builds/:buildId/logs" />
+      <SiteUsers path="users" />
+      <NotificationSettings path="notifications" />
+    </SiteContainer>
+    <Redirect noThrow from="*" to="/not-found" />
+    <NotFound path="/not-found" />
+    <Redirect noThrow from="*" to="/sites" />
+  </App>
 );

--- a/frontend/store.js
+++ b/frontend/store.js
@@ -4,17 +4,13 @@ import {
 } from 'redux';
 import logger from 'redux-logger';
 import { composeWithDevTools } from 'redux-devtools-extension';
-import { routerReducer } from 'react-router-redux';
 import thunk from 'redux-thunk';
 
 import reducers from './reducers';
-import { reroute, createNotifier } from './middleware';
+import { createNotifier } from './middleware';
 import { notificationSettings } from './util/notificationSettings';
 
-const reducer = combineReducers({
-  ...reducers,
-  routing: routerReducer,
-});
+const reducer = combineReducers(reducers);
 
 // FRONTEND_CONFIG is a global variable rendered into the index
 // template by the Main controller. We use it to initialize our
@@ -24,7 +20,6 @@ const FRONTEND_CONFIG = typeof window !== 'undefined'
   : global.FRONTEND_CONFIG;
 
 const middlewares = [
-  reroute,
   createNotifier(notificationSettings),
   thunk,
 ];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "keywords": [],
   "dependencies": {
     "@octokit/rest": "^17.9.2",
-    "@reach/router": "^1.3.3",
     "aws-sdk": "^2.683.0",
     "body-parser": "^1.18.3",
     "cfenv": "^1.0.0",
@@ -84,6 +83,7 @@
   "author": "dhcole",
   "license": "CC0-1.0",
   "devDependencies": {
+    "@reach/router": "^1.3.3",
     "autoprefixer": "^9.8.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "keywords": [],
   "dependencies": {
     "@octokit/rest": "^17.9.2",
+    "@reach/router": "^1.3.3",
     "aws-sdk": "^2.683.0",
     "body-parser": "^1.18.3",
     "cfenv": "^1.0.0",
@@ -131,8 +132,6 @@
     "react-notification-system": "^0.4.0",
     "react-notification-system-redux": "^2.0.1",
     "react-redux": "^7.2.0",
-    "react-router": "^3.0.5",
-    "react-router-redux": "^4.0.8",
     "react-svg-loader": "^3.0.3",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.2",

--- a/test/frontend/actions/actionCreators/navigationActionsTest.js
+++ b/test/frontend/actions/actionCreators/navigationActionsTest.js
@@ -1,34 +1,30 @@
-import { expect } from "chai";
+import sinon from 'sinon';
+import * as reachRouter from '@reach/router';
 import {
-  updateRouterType,
   pushRouterHistory,
-  replaceRouterHistory
-} from "../../../../frontend/actions/actionCreators/navigationActions";
+  replaceRouterHistory,
+} from '../../../../frontend/actions/actionCreators/navigationActions';
 
-describe("updateRouter actionCreator", () => {
-  const path = "/what/is/this/path/of/which/you/speak";
+describe('navigationActions', () => {
+  let navigateStub;
 
-  it("constructs a browser history push properly", () => {
-    const actual = pushRouterHistory(path);
-
-    expect(actual).to.deep.equal({
-      type: updateRouterType,
-      method: "push",
-      arguments: [ path ]
-    });
+  beforeEach(() => {
+    navigateStub = sinon.stub(reachRouter, 'navigate').resolves();
   });
 
-  it("constructs a browser history replace properly", () => {
-    const actual = replaceRouterHistory(path);
-
-    expect(actual).to.deep.equal({
-      type: updateRouterType,
-      method: "replace",
-      arguments: [ path ]
-    });
+  afterEach(() => {
+    sinon.restore();
   });
 
-  it("exports its type", () => {
-    expect(updateRouterType).to.equal("UPDATE_ROUTER");
+  const path = '/what/is/this/path/of/which/you/speak';
+
+  describe('.pushRouterHistory', () => {
+    it('navigates', () => pushRouterHistory(path)
+      .then(() => sinon.assert.calledWithExactly(navigateStub, path)));
+  });
+
+  describe('.replaceRouterHistory', () => {
+    it('navigates and replaces history', () => replaceRouterHistory(path)
+      .then(() => sinon.assert.calledWithExactly(navigateStub, path, { replace: true })));
   });
 });

--- a/test/frontend/components/app.test.js
+++ b/test/frontend/components/app.test.js
@@ -8,6 +8,7 @@ proxyquire.noCallThru();
 
 const alertActionUpdate = stub();
 const buildStatusNotifierListen = stub();
+const onEnter = stub();
 const Header = () => <div />;
 
 const username = 'jenny mcuser';
@@ -27,6 +28,7 @@ const props = {
   location: {
     key: 'a-route',
   },
+  onEnter,
 };
 
 const AppFixture = proxyquire('../../../frontend/components/app', {
@@ -100,6 +102,18 @@ describe('<App/>', () => {
 
     wrapper = shallow(<AppFixture {...newProps} />);
     expect(wrapper.find('LoadingIndicator')).to.have.length(1);
+    expect(buildStatusNotifierListen.called).to.be.true;
+  });
+
+  it('calls onEnter on mount', () => {
+    shallow(<AppFixture {...props} />);
+
+    expect(onEnter.called).to.be.true;
+  });
+
+  it('subscribes to build status events on mount', () => {
+    shallow(<AppFixture {...props} />);
+
     expect(buildStatusNotifierListen.called).to.be.true;
   });
 });

--- a/test/frontend/components/site/siteBuildLogs.test.js
+++ b/test/frontend/components/site/siteBuildLogs.test.js
@@ -11,12 +11,12 @@ let props;
 describe('<SiteBuildLogs/>', () => {
   beforeEach(() => {
     props = {
-      params: {
-        buildId: '123',
-      },
+      buildId: '123',
       buildLogs: {
         isLoading: false,
-        data: [{ id: 1, source: 'theSource', createdAt: '2018-11-05T13:15:30Z', output: 'blahblah' }],
+        data: [{
+          id: 1, source: 'theSource', createdAt: '2018-11-05T13:15:30Z', output: 'blahblah',
+        }],
       },
       actions: { fetchBuildLogs: sinon.spy() },
     };

--- a/test/frontend/components/site/siteBuilds.test.js
+++ b/test/frontend/components/site/siteBuilds.test.js
@@ -39,9 +39,7 @@ describe('<SiteBuilds/>', () => {
         isLoading: false,
       },
       site,
-      params: {
-        id: '5',
-      },
+      id: '5',
       actions: {
         fetchBuilds: sinon.spy(),
         restartBuild: sinon.spy(),
@@ -146,9 +144,7 @@ describe('<SiteBuilds/>', () => {
   });
 
   it('should render a paragraph about truncation if 100 or more builds are present', () => {
-    props.builds.data = Array(100).fill(1).map((val, index) =>
-      Object.assign(build, { id: index })
-    );
+    props.builds.data = Array(100).fill(1).map((val, index) => Object.assign(build, { id: index }));
 
     const wrapper = shallow(<SiteBuilds {...props} />);
     expect(wrapper.find('table + p')).to.have.length(1);

--- a/test/frontend/components/siteContainer.test.js
+++ b/test/frontend/components/siteContainer.test.js
@@ -34,8 +34,8 @@ describe('<SiteContainer/>', () => {
       location: {
         pathname: '',
       },
+      id: '1',
       params: {
-        id: '1',
         branch: 'branch',
         fileName: 'boop.txt',
       },
@@ -60,7 +60,7 @@ describe('<SiteContainer/>', () => {
   });
 
   it('renders an error after sites have loaded but no matching site', () => {
-    props.params.id = '2';
+    props.id = '2';
     const wrapper = shallow(<SiteContainer {...props} />);
     const alert = wrapper.find('AlertBanner');
 

--- a/test/frontend/components/siteList/siteListItem.test.js
+++ b/test/frontend/components/siteList/siteListItem.test.js
@@ -31,7 +31,7 @@ describe('<SiteListItem />', () => {
 
   beforeEach(() => {
     Fixture = proxyquire('../../../../frontend/components/siteList/siteListItem', {
-      'react-router': { Link },
+      '@reach/router': { Link },
       './publishedState': PublishedState,
       './repoLastVerified': RepoLastVerified,
       '../icons': { IconView: 'IconView' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,6 +577,16 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@reach/router@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.3.tgz#58162860dce6c9449d49be86b0561b5ef46d80db"
+  integrity sha512-gOIAiFhWdiVGSVjukKeNKkCRBLmnORoTPyBihI/jLunICPgxdP30DroAvPQuf1eVfQbfGJQDJkwhJXsNPMnVWw==
+  dependencies:
+    create-react-context "0.3.0"
+    invariant "^2.2.3"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -3387,6 +3397,14 @@ create-react-class@^15.5.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
+  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
+
 cron-parser@^2.7.3:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.13.0.tgz#6f930bb6f2931790d2a9eec83b3ec276e27a6725"
@@ -5544,6 +5562,11 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -5674,16 +5697,6 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-history@^3.0.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"
-  integrity sha1-/O3M6PEpdTcVRdc1RhAzV5ptrpw=
-  dependencies:
-    invariant "^2.2.1"
-    loose-envify "^1.2.0"
-    query-string "^4.2.2"
-    warning "^3.0.0"
-
 history@^4.10.1:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -5704,11 +5717,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -6109,7 +6117,7 @@ interpret@1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -9104,7 +9112,7 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@^4.1.0, query-string@^4.2.2:
+query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   integrity sha1-u7aTucqRXCMlFbIosaArYJBD2+s=
@@ -9222,6 +9230,11 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
 react-notification-system-redux@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-notification-system-redux/-/react-notification-system-redux-2.0.1.tgz#e1f47e788d344fac9b5183402bb96c73033e5854"
@@ -9257,25 +9270,6 @@ react-redux@^7.2.0:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
-
-react-router-redux@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
-  integrity sha1-InQDWWtRUeGCN32rg1tdRfD4BU4=
-
-react-router@^3.0.5:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.3.tgz#340146a2d6ee5618539c1bf96332ac97f58d6a58"
-  integrity sha512-dOBEo8985n6xyJmorgHtLxb/k30ua/JdfUhATGTTVQJsnlb/u/rx7X7p//qHyLWEfUcM0CLMTXWS+hp+THCsxA==
-  dependencies:
-    create-react-class "^15.5.1"
-    history "^3.0.0"
-    hoist-non-react-statics "^2.3.1"
-    invariant "^2.2.1"
-    loose-envify "^1.2.0"
-    prop-types "^15.7.2"
-    react-is "^16.8.6"
-    warning "^3.0.0"
 
 react-svg-core@^3.0.3:
   version "3.0.3"
@@ -11634,10 +11628,10 @@ vm-browserify@~0.0.1:
   dependencies:
     indexof "0.0.1"
 
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
Resolves the outdated React Router & friends deps by replacing with the simpler, accessibility-oriented Reach Router. This also removes the history sync with with the Redux store, which isn't necessary and we weren't actually using for anything.

The big changes are:
- removing the redux/history sync
- `@reach/router` provides url params directory in the component props instead of under a `params` key
- Routes are specified with the actual component and a `path` prop, instead of using a `route` component
- Route nesting is used only when the components themselves are meant to be nested with `children`