### PR TITLE
Remove eslint from codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,30 +3,6 @@ version: "2"
 plugins:
   duplication:
     enabled: false
-  eslint:
-    enabled: true
-    channel: "eslint-6"
-    checks:
-      import/no-unresolved:
-        enabled: false
-      import/extensions:
-        enabled: false
-      implicit-arrow-linebreak:
-        enabled: false
-      no-use-before-define:
-        enabled: false
-      object-curly-newline:
-        enabled: false
-      no-unsanitized/method:
-        enabled: false
-      no-unsanitized/property:
-        enabled: false
-      prefer-destructuring:
-        enabled: false
-    config:
-      extensions:
-      - .js
-      - .jsx
 exclude_patterns:
   - "node_modules/"
   - "migrations/"
@@ -34,4 +10,3 @@ exclude_patterns:
   - "scripts/"
   - "coverage/"
   - "migrate.js"
-  - "admin-client/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,3 +34,4 @@ exclude_patterns:
   - "scripts/"
   - "coverage/"
   - "migrate.js"
+  - "admin-client/"


### PR DESCRIPTION
We already run eslint as a build step from circle ci, not sure why we need to run it in code climate as well. Hopefully, this will fix the noise...