### PR TITLE
Only display empty hint

### DIFF
--- a/api/models/user-environment-variable.js
+++ b/api/models/user-environment-variable.js
@@ -22,6 +22,9 @@ module.exports = (sequelize, DataTypes) => {
     hint: {
       type: DataTypes.STRING,
       allowNull: false,
+      get() {
+        return '';
+      },
     },
   }, {
     tableName: 'user_environment_variable',

--- a/api/services/Encryptor.js
+++ b/api/services/Encryptor.js
@@ -27,7 +27,7 @@ function encrypt(value, key, { hintSize = 4 } = {}) {
     .join(':'); // Return a `:` delimited hex string
 
   // Create the hint
-  const hint = value.slice(-1 * hintSize);
+  const hint = hintSize ? value.slice(-1 * hintSize) : '';
 
   return { ciphertext, hint };
 }

--- a/test/api/requests/user-environment-variable.test.js
+++ b/test/api/requests/user-environment-variable.test.js
@@ -342,7 +342,7 @@ describe('User Environment Variable API', () => {
 
         validateAgainstJSONSchema('POST', '/site/{site_id}/user-environment-variable', 200, body);
         expect(body.name).to.eq(name);
-        expect(body.hint).to.eq(value.slice(-4));
+        expect(body.hint).to.eq('');
         expect(afterNumUEVs).to.eq(beforeNumUEVs + 1);
       });
     });

--- a/test/api/unit/models/user-environment-variable.test.js
+++ b/test/api/unit/models/user-environment-variable.test.js
@@ -26,5 +26,10 @@ describe('UserEnvironmentVariable model', () => {
 
       expect(uevs).to.be.empty;
     });
+
+    it('always returns an empty string for the hint', async () => {
+      const uev = await factories.userEnvironmentVariable.create({ value: 'abc123' });
+      expect(uev.hint).to.equal('');
+    });
   });
 });

--- a/test/api/unit/services/Encryptor.test.js
+++ b/test/api/unit/services/Encryptor.test.js
@@ -38,5 +38,13 @@ describe('Encryptor', () => {
 
       expect(hint.length).to.eq(hintSize);
     });
+
+    it('returns an empty string when specified size is 0', () => {
+      const hintSize = 0;
+
+      const { hint } = Encryptor.encrypt(value, key, { hintSize });
+
+      expect(hint).to.eq('');
+    });
   });
 });


### PR DESCRIPTION
The 4 char hint is still being generated and saved, but only empty strings will be returned from the API. Unsure if we should change this as well since we can easily see it. We could try to enforce a larger minimum size for the values going forward, but I don't think we can tell the actual length of existing ones since they are encrypted.

Thoughts?