### PR TITLE
Actually cancel build tasks, refactor

### DIFF
--- a/api/models/build.js
+++ b/api/models/build.js
@@ -6,6 +6,25 @@ const { logger } = require('../../winston');
 const { branchRegex, shaRegex, isEmptyOrUrl } = require('../utils/validators');
 const { buildUrl } = require('../utils/build');
 
+const States = (function createStates() {
+  const values = {
+    Created: 'created',
+    Queued: 'queued',
+    Tasked: 'tasked',
+    Error: 'error',
+    Processing: 'processing',
+    Skipped: 'skipped', // remove?
+    Success: 'success',
+  };
+
+  return {
+    ...values,
+    values() {
+      return Object.values(values);
+    },
+  };
+}());
+
 const associate = ({
   Build,
   BuildLog,
@@ -40,19 +59,19 @@ const jobStateUpdate = (buildStatus, build, site, timestamp) => {
     state: buildStatus.status,
   };
 
-  if (buildStatus.status === 'error') {
+  if (buildStatus.status === States.Error) {
     atts.error = jobErrorMessage(buildStatus.message);
   }
 
-  if (['error', 'success'].includes(buildStatus.status)) {
+  if (build.canComplete(buildStatus.status)) {
     atts.completedAt = timestamp;
   }
 
-  if (buildStatus.status === 'success') {
+  if (buildStatus.status === States.Success) {
     atts.url = buildUrl(build, site);
   }
 
-  if (['created', 'queued', 'tasked'].includes(build.state) && buildStatus.status === 'processing') {
+  if (build.canStart(buildStatus.status)) {
     atts.startedAt = timestamp;
   }
 
@@ -81,12 +100,12 @@ async function enqueue() {
 
   try {
     await SQS.sendBuildMessage(foundBuild, count);
-    await build.updateJobStatus({ status: 'queued' });
+    await build.updateJobStatus({ status: States.Queued });
   } catch (err) {
     const errMsg = `There was an error, adding the job to SQS: ${err}`;
     logger.error(errMsg);
     await build.updateJobStatus({
-      status: 'error',
+      status: States.Error,
       message: errMsg,
     });
   }
@@ -98,10 +117,19 @@ async function updateJobStatus(buildStatus) {
   const timestamp = new Date();
   const site = await this.getSite();
   const build = await jobStateUpdate(buildStatus, this, site, timestamp);
-  if (build.state === 'success') {
+  if (build.state === States.Success) {
     await site.update({ publishedAt: timestamp });
   }
   return build;
+}
+
+function canComplete(state) {
+  return [States.Error, States.Success].includes(state);
+}
+
+function canStart(state) {
+  return [States.Created, States.Queued, States.Tasked].includes(this.state)
+    && state === States.Processing;
 }
 
 module.exports = (sequelize, DataTypes) => {
@@ -129,8 +157,8 @@ module.exports = (sequelize, DataTypes) => {
     },
     state: {
       type: DataTypes.ENUM,
-      values: ['created', 'queued', 'tasked', 'error', 'processing', 'skipped', 'success'],
-      defaultValue: 'created',
+      values: States.values(),
+      defaultValue: States.Created,
       allowNull: false,
     },
     token: {
@@ -177,5 +205,8 @@ module.exports = (sequelize, DataTypes) => {
   Build.associate = associate;
   Build.prototype.enqueue = enqueue;
   Build.prototype.updateJobStatus = updateJobStatus;
+  Build.prototype.canComplete = canComplete;
+  Build.prototype.canStart = canStart;
+  Build.States = States;
   return Build;
 };

--- a/api/services/TimeoutBuilds.js
+++ b/api/services/TimeoutBuilds.js
@@ -1,31 +1,58 @@
 const moment = require('moment');
 const { Op } = require('sequelize');
+const { zip } = require('underscore');
 
 const { Build } = require('../models');
+const CFApi = require('../utils/cfApiClient');
 
 const TIMEOUT = process.env.BUILD_TIMEOUT || 45;
 
-const timeoutBuilds = (date = new Date()) => {
+const timeoutBuilds = async (date = new Date()) => {
+  const cfApi = new CFApi();
+
   const now = moment(date);
-  const cutoff = now.clone().subtract(TIMEOUT, 'minutes');
+  const buildTimout = now.clone().subtract(TIMEOUT, 'minutes');
+  const taskTimeout = now.clone().subtract(5, 'minutes');
 
   const atts = {
     error: 'The build timed out',
-    state: 'error',
+    state: Build.States.Error,
     completedAt: now.toDate(),
   };
 
   const options = {
     where: {
-      state: 'processing',
-      startedAt: {
-        [Op.lt]: cutoff.toDate(),
-      },
+      [Op.or]: [
+
+        /*
+          The garden build itself should timout builds once they start, but just in case
+        */
+        {
+          state: Build.States.Processing,
+          startedAt: {
+            [Op.lt]: buildTimout.toDate(),
+          },
+        },
+
+        /*
+          The builder created the cloud foundry task but the garden build failed
+          before starting the build
+        */
+        {
+          state: Build.States.Tasked,
+          updatedAt: {
+            [Op.lt]: taskTimeout.toDate(),
+          },
+        },
+      ],
     },
     returning: ['id'],
   };
 
-  return Build.update(atts, options);
+  const [, builds] = await Build.update(atts, options);
+  const buildIds = builds.map(b => b.id);
+  const cancels = await Promise.allSettled(buildIds.map(buildId => cfApi.cancelBuildTask(buildId)));
+  return zip(buildIds, cancels);
 };
 
 module.exports = timeoutBuilds;

--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -1,12 +1,40 @@
 const request = require('request');
 const url = require('url');
-const { filterEntity, firstEntity } = require('.');
-const CloudFoundryAuthClient = require('./cfAuthClient');
 const config = require('../../config');
+const CloudFoundryAuthClient = require('./cfAuthClient');
+const { filterEntity, firstEntity, objToQueryParams } = require('.');
 
 class CloudFoundryAPIClient {
   constructor() {
     this.authClient = new CloudFoundryAuthClient();
+  }
+
+  cancelTask(taskGuid) {
+    return this.authRequest('POST', `/v3/tasks/${taskGuid}/actions/cancel`);
+  }
+
+  async cancelBuildTask(buildId) {
+    const buildTask = await this.fetchBuildTask(buildId);
+    if (!buildTask) {
+      throw new Error(`There are no tasks for build id: ${buildId}`);
+    }
+    return this.cancelTask(buildTask.guid);
+  }
+
+  fetchBuildTask(buildId) {
+    return this.fetchTaskByName(`build-${buildId}`);
+  }
+
+  fetchTaskByName(name) {
+    return this.fetchTasks({ names: name })
+      .then(tasks => tasks.filter(task => task.name === name));
+  }
+
+  fetchTasks(params) {
+    const qs = objToQueryParams(params);
+
+    return this.authRequest('GET', `/v3/tasks?${qs.toString()}`)
+      .then(body => body.resources);
   }
 
   createRoute(name) {
@@ -199,6 +227,10 @@ class CloudFoundryAPIClient {
         }
       });
     });
+  }
+
+  authRequest(method, path, json) {
+    return this.accessToken().then(token => this.request(method, path, token, json));
   }
 }
 

--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -27,7 +27,7 @@ class CloudFoundryAPIClient {
 
   fetchTaskByName(name) {
     return this.fetchTasks({ names: name })
-      .then(tasks => tasks.filter(task => task.name === name));
+      .then(tasks => tasks.find(task => task.name === name));
   }
 
   fetchTasks(params) {

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -195,6 +195,16 @@ function omitBy(fn, obj) {
   return pick(pickedKeys, obj);
 }
 
+function objToQueryParams(obj) {
+  const qs = new URLSearchParams();
+  Object
+    .entries(obj)
+    .forEach(([key, value]) => {
+      qs.append(key, value);
+    });
+  return qs;
+}
+
 module.exports = {
   filterEntity,
   firstEntity,
@@ -207,6 +217,7 @@ module.exports = {
   loadDevelopmentManifest,
   loadProductionManifest,
   mapValues,
+  objToQueryParams,
   omitBy,
   omit,
   pick,

--- a/scripts/timeout-builds.js
+++ b/scripts/timeout-builds.js
@@ -3,9 +3,17 @@ const timeoutBuilds = require('../api/services/TimeoutBuilds');
 
 async function runTimeoutBuilds() {
   try {
-    const [count, timedoutBuilds] = await timeoutBuilds();
-    console.log(`Timed out ${count} total builds: [${timedoutBuilds.map(b => b.id).join(', ')}]`);
-    process.exit(0);
+    const results = await timeoutBuilds();
+    const allBuildIds = results.map(r => r[0]);
+    console.log(`${results.length} total builds timed out: [${allBuildIds.join(', ')}]`);
+
+    const failedCancels = results.filter(([, result]) => result.status === 'rejected');
+    if (failedCancels.length === 0) {
+      process.exit(0);
+    }
+
+    const details = failedCancels.map(([buildId, { reason }]) => `${buildId}: ${reason}`).join('\n');
+    throw new Error(`${failedCancels.length} build tasks could not be canceled:\n${details}`);
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/test/api/unit/services/TimeoutBuilds.test.js
+++ b/test/api/unit/services/TimeoutBuilds.test.js
@@ -4,42 +4,81 @@ const sinon = require('sinon');
 
 const factory = require('../../support/factory');
 const timeoutBuilds = require('../../../../api/services/TimeoutBuilds');
-const { Build } = require('../../../../api/models');
+const { Build, sequelize } = require('../../../../api/models');
+const CFApi = require('../../../../api/utils/cfApiClient');
+
+const { Processing, Queued, Tasked } = Build.States;
+
+function setBuildUpdatedAt(build, date) {
+  return sequelize.query(
+    'UPDATE build set "updatedAt" = ? WHERE id = ?',
+    { replacements: [date, build.id] }
+  ).then(() => build.reload());
+}
 
 describe('TimeoutBuilds', () => {
+  let cancelBuildTaskStub;
+
+  beforeEach(() => {
+    cancelBuildTaskStub = sinon.stub(CFApi.prototype, 'cancelBuildTask');
+  });
+
   afterEach(() => {
     sinon.restore();
     Build.truncate();
   });
 
-  it('times out builds', async () => {
+  it('times out the correct builds', async () => {
+    const error = new Error('foo');
+    cancelBuildTaskStub
+      .onFirstCall()
+      .resolves()
+      .onSecondCall()
+      .rejects(error)
+      .onThirdCall()
+      .resolves();
+
     const now = moment();
     const timeout = 45;
 
-    const [b1, b2] = await Promise.all([
+    const [b1, b2, b3] = await Promise.all([
       // should be timed out
-      factory.build({ state: 'processing', startedAt: now.clone().subtract(timeout + 22, 'minutes').toDate() }),
-      factory.build({ state: 'processing', startedAt: now.clone().subtract(timeout + 20, 'minutes').toDate() }),
+      factory.build({ state: Processing, startedAt: now.clone().subtract(timeout + 22, 'minutes').toDate() }),
+      factory.build({ state: Processing, startedAt: now.clone().subtract(timeout + 20, 'minutes').toDate() }),
+      factory.build({ state: Tasked })
+        .then(build => setBuildUpdatedAt(build, now.clone().subtract(6, 'minutes').toDate())),
+
       // other
       factory.build(),
-      factory.build({ state: 'processing', startedAt: now.toDate() }),
-      factory.build({ state: 'processing', startedAt: now.clone().subtract(timeout - 1, 'minutes').toDate() }),
+      factory.build({ state: Processing, startedAt: now.toDate() }),
+      factory.build({ state: Processing, startedAt: now.clone().subtract(timeout - 1, 'minutes').toDate() }),
+      factory.build({ state: Tasked })
+        .then(build => setBuildUpdatedAt(build, now.clone().subtract(3, 'minutes').toDate())),
+
       // invalid states
-      factory.build({ state: 'queued', startedAt: now.clone().subtract(timeout + 20, 'minutes').toDate() }),
-      factory.build({ state: 'processing' }),
+      factory.build({ state: Queued, startedAt: now.clone().subtract(timeout + 20, 'minutes').toDate() }),
+      factory.build({ state: Processing }),
     ]);
 
-    const result = await timeoutBuilds(now);
+    const results = await timeoutBuilds(now);
 
-    expect(result[0]).to.equal(2);
-    expect(result[1].map(b => b.id)).to.have.members([b1.id, b2.id]);
+    expect(results.length).to.equal(3);
+    expect(results.map(r => r[0])).to.have.members([b1.id, b2.id, b3.id]);
+    expect(results.map(r => r[1])).to.have.deep.members([
+      { status: 'fulfilled', value: undefined },
+      { status: 'rejected', reason: error },
+      { status: 'fulfilled', value: undefined },
+    ]);
 
-    await Promise.all([b1.reload(), b2.reload()]);
+    await Promise.all([b1.reload(), b2.reload(), b3.reload()]);
 
-    [b1, b2].forEach((b) => {
+    sinon.assert.calledThrice(cancelBuildTaskStub);
+
+    [b1, b2, b3].forEach((b) => {
       expect(b.state).to.equal('error');
       expect(b.error).to.equal('The build timed out');
       expect(b.completedAt.toString()).to.equal(now.toDate().toString());
+      sinon.assert.calledWithExactly(cancelBuildTaskStub, b.id);
     });
   });
 });

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -413,4 +413,17 @@ describe('utils', () => {
       });
     });
   });
+
+  describe('.objToQueryParams', () => {
+    it('returns an instance of URLSearchParams with the correct values', () => {
+      const obj = { foo: 'bar', baz: 'foo' };
+
+      const result = utils.objToQueryParams(obj);
+
+      expect(result).to.be.an.instanceOf(URLSearchParams);
+      Object.entries(obj).forEach(([key, value]) => {
+        expect(result.get(key)).to.equal(value);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Looks good locally, looking forward to testing in staging.

Currently looking for builds that have been `processing` for more than 45 mins or `tasked` for more than 3 minutes, but not looking at `queued` state. Thoughts on if and how to handle this? I don't necessarily want to cancel builds when there is a backup...