### PR TITLE
Add ability to archive build logs to S3

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -23,6 +23,7 @@ applications:
       - federalist-deploy-user
       - federalist-site-wide-error
       - federalist-((env))-dynamodb-creds
+      - federalist-((env))-s3-build-logs
     env:
       NODE_ENV: production
       APP_ENV: ((env))

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -180,6 +180,9 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       validate: isEmptyOrUrl,
     },
+    logsS3Key: {
+      type: DataTypes.STRING,
+    },
   }, {
     tableName: 'build',
     hooks: {

--- a/api/serializers/build.js
+++ b/api/serializers/build.js
@@ -26,6 +26,7 @@ const toJSON = (build) => {
   });
   delete object.token;
   delete object.url;
+  delete object.logsS3Key;
   // only return first 80 chars in case it's long
   if (object.error) {
     object.error = object.error.slice(0, 80);

--- a/api/services/S3Helper.js
+++ b/api/services/S3Helper.js
@@ -128,6 +128,16 @@ class S3Client {
     return client.putObject(params).promise();
   }
 
+  getObject(key, extras = {}) {
+    const { bucket, client } = this;
+    const params = {
+      Bucket: bucket,
+      Key: key,
+      ...extras,
+    };
+    return client.getObject(params).promise();
+  }
+
   // Private Methods
   listObjectsHelper(currObjects, extraS3Params = {}, opts = {}, callback) {
     const listObjectArgs = { Bucket: this.bucket, ...extraS3Params };

--- a/api/services/build-logs/build-logs.js
+++ b/api/services/build-logs/build-logs.js
@@ -1,0 +1,64 @@
+const { QueryTypes } = require('sequelize');
+const config = require('../../../config');
+const { BuildLog, sequelize } = require('../../models');
+const S3Helper = require('../S3Helper');
+
+const BuildLogs = {
+  s3() {
+    return new S3Helper.S3Client(config.s3BuildLogs);
+  },
+
+  buildKey(site, build) {
+    return `${site.owner}/${site.repository}/${build.id}`;
+  },
+
+  async fetchBuildLogs(build) {
+    const query = `
+      SELECT STRING_AGG(bl.output, '\n') as output
+        FROM (
+          SELECT output
+            FROM buildlog
+          WHERE build = :buildid
+        ORDER BY id
+        ) AS bl
+    `;
+
+    const { output } = await sequelize.query(query, {
+      replacements: {
+        buildid: build.id,
+      },
+      plain: true,
+      raw: true,
+      type: QueryTypes.SELECT,
+    });
+
+    return output;
+  },
+
+  async archiveBuildLogs(site, build) {
+    const key = this.buildKey(site, build);
+    const logs = await this.fetchBuildLogs(build);
+    if (!logs) {
+      return;
+    }
+
+    await this.s3().putObject(logs, key);
+    await build.update({ logsS3Key: key });
+    await BuildLog.destroy({ where: { build: build.id } });
+  },
+
+  async getBuildLogs(build, startBytes, endBytes) {
+    try {
+      const params = { Range: `bytes=${startBytes}-${endBytes}` };
+      const response = await this.s3().getObject(build.logsS3Key, params);
+      return response.Body.toString();
+    } catch (error) {
+      if (error.code === 'InvalidRange') {
+        return null;
+      }
+      throw error;
+    }
+  },
+};
+
+module.exports = BuildLogs;

--- a/api/services/build-logs/index.js
+++ b/api/services/build-logs/index.js
@@ -1,0 +1,6 @@
+const BuildLogs = require('./build-logs');
+
+module.exports = {
+  archiveBuildLogs: BuildLogs.archiveBuildLogs.bind(BuildLogs),
+  getBuildLogs: BuildLogs.getBuildLogs.bind(BuildLogs),
+};

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -31,6 +31,18 @@ if (s3Creds) {
   throw new Error('No S3 credentials found');
 }
 
+const s3BuildLogsCreds = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-s3-build-logs`);
+if (s3BuildLogsCreds) {
+  module.exports.s3BuildLogs = {
+    accessKeyId: s3BuildLogsCreds.access_key_id,
+    secretAccessKey: s3BuildLogsCreds.secret_access_key,
+    region: s3BuildLogsCreds.region,
+    bucket: s3BuildLogsCreds.bucket,
+  };
+} else {
+  throw new Error('No S3 Build Logs credentials found');
+}
+
 // SQS Configs
 const sqsCreds = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-sqs-creds`);
 if (sqsCreds) {

--- a/frontend/propTypes.js
+++ b/frontend/propTypes.js
@@ -45,7 +45,6 @@ export const BUILD = PropTypes.shape({
 export const BUILD_LOG = PropTypes.shape({
   source: PropTypes.string.isRequired,
   output: PropTypes.string.isRequired,
-  createdAt: PropTypes.string.isRequired,
 });
 
 export const USER_ACTION = PropTypes.shape({

--- a/migrations/20201005190802-add-logsS3Key-to-build.js
+++ b/migrations/20201005190802-add-logsS3Key-to-build.js
@@ -1,0 +1,3 @@
+exports.up = (db, callback) => db.addColumn('build', "logsS3Key", { type: 'string' }, callback);
+
+exports.down = (db, callback) => db.removeColumn('build', "logsS3Key", callback);

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "analyze-webpack": "webpack-bundle-analyzer -h 0.0.0.0 public/stats.json",
     "serve-coverage": "serve -l 8080 ./coverage",
     "update-local-config": "node ./scripts/update-local-config.js",
-    "create-dev-data": "node ./scripts/create-dev-data.js",
+    "create-dev-data": "NODE_ENV=development node ./scripts/create-dev-data.js",
     "update-proxy-db": "node ./scripts/proxy-edge.js",
     "timeout-builds": "node ./scripts/timeout-builds.js"
   },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "update-local-config": "node ./scripts/update-local-config.js",
     "create-dev-data": "NODE_ENV=development node ./scripts/create-dev-data.js",
     "update-proxy-db": "node ./scripts/proxy-edge.js",
-    "timeout-builds": "node ./scripts/timeout-builds.js"
+    "timeout-builds": "node ./scripts/timeout-builds.js",
+    "archive-build-logs": "node ./scripts/archive-build-logs.js"
   },
   "main": "index.js",
   "repository": {

--- a/scripts/archive-build-logs.js
+++ b/scripts/archive-build-logs.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-console */
+const { Build, Site } = require('../api/models');
+const BuildLogs = require('../api/services/build-logs');
+
+async function runArchiveBuildLogs(buildId) {
+  try {
+    const build = await Build.findOne({
+      where: { id: buildId },
+      include: [{
+        model: Site,
+        required: true,
+      }],
+    });
+    await BuildLogs.archiveBuildLogs(build.Site, build);
+    console.log('Success!');
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+const buildId = parseInt(process.argv[2], 10);
+runArchiveBuildLogs(buildId);

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const inquirer = require('inquirer');
 Promise.props = require('promise-props');
-
+const BuildLogs = require('../api/services/build-logs');
 const cleanDatabase = require('../api/utils/cleanDatabase');
 const {
   ActionType,
@@ -200,7 +200,13 @@ async function createData({ githubUsername }) {
     actionId: removeAction.id,
     siteId: site1.id,
   });
-}
+
+  console.log('Uploading logs to S3');
+  try {
+    await BuildLogs.archiveBuildLogs(nodeSite, nodeSiteBuilds[0]);
+  } catch(error) {
+    console.error('Failed to upload logs to S3, probably because the credentials are not configured locally. This can be ignored.')
+  }
 
 const confirm = {
   type: 'confirm',

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -204,9 +204,10 @@ async function createData({ githubUsername }) {
   console.log('Uploading logs to S3');
   try {
     await BuildLogs.archiveBuildLogs(nodeSite, nodeSiteBuilds[0]);
-  } catch(error) {
-    console.error('Failed to upload logs to S3, probably because the credentials are not configured locally. This can be ignored.')
+  } catch (error) {
+    console.error('Failed to upload logs to S3, probably because the credentials are not configured locally. This can be ignored.');
   }
+}
 
 const confirm = {
   type: 'confirm',

--- a/test/api/unit/services/BuildLogs.test.js
+++ b/test/api/unit/services/BuildLogs.test.js
@@ -1,0 +1,163 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const factory = require('../../support/factory');
+
+const { BuildLog } = require('../../../../api/models');
+const BuildLogs = require('../../../../api/services/build-logs/build-logs');
+
+describe('BuildLogs Service', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('.buildKey', () => {
+    const site1 = { owner: 'owner1', repository: 'repo1' };
+    const site2 = { owner: 'owner2', repository: 'repo2' };
+    const build1 = { id: 111 };
+    const build2 = { id: 222 };
+
+    it('is a string', () => {
+      const result = BuildLogs.buildKey(site1, build1);
+      expect(result).to.be.a('string');
+    });
+
+    it('is unique per site and build', () => {
+      const [a, b, c, d] = [
+        BuildLogs.buildKey(site1, build1),
+        BuildLogs.buildKey(site1, build2),
+        BuildLogs.buildKey(site2, build1),
+        BuildLogs.buildKey(site1, build1),
+      ];
+
+      expect(a).to.not.equal(b);
+      expect(b).to.not.equal(c);
+      expect(a).to.not.equal(c);
+      expect(a).to.equal(d);
+    });
+  });
+
+  describe('.fetchBuildLogs', () => {
+    it('returns the logs as one string', async () => {
+      const numLogs = 100;
+      const build = await factory.build();
+      await factory.bulkBuildLogs(numLogs, { buildId: build.id, output: 'Foobarbaz' });
+
+      const logStr = await BuildLogs.fetchBuildLogs(build);
+
+      expect(logStr).to.be.a('string');
+      expect(logStr.split('\n').length).to.equal(numLogs);
+
+      const matches = [...logStr.matchAll(/Foobarbaz/g)];
+      expect(matches.length).to.equal(numLogs);
+    });
+
+    describe('when there are no logs', () => {
+      it('returns null', async () => {
+        const build = await factory.build();
+
+        const logStr = await BuildLogs.fetchBuildLogs(build);
+
+        expect(logStr).to.be.null;
+      });
+    });
+  });
+
+  describe('.archiveBuildLogs', () => {
+    let putObjectStub;
+
+    beforeEach(() => {
+      putObjectStub = sinon.stub();
+      putObjectStub.resolves();
+      sinon.stub(BuildLogs, 's3').returns({
+        putObject: putObjectStub,
+      });
+    });
+
+    it('does all the things', async () => {
+      const site = await factory.site();
+      const build = await factory.build({ site });
+      await factory.buildLog({ build: build.id, output: 'Foobarbaz' });
+      const destroySpy = sinon.spy(BuildLog, 'destroy');
+
+      // there should be 1 build log
+      const numLogsBefore = await BuildLog.count({ where: { build: build.id } });
+      expect(numLogsBefore).to.equal(1);
+
+      const expectedKey = BuildLogs.buildKey(site, build);
+      const expectedLogs = 'Foobarbaz';
+
+      await BuildLogs.archiveBuildLogs(site, build);
+
+      // sends logs to S3
+      sinon.assert.calledOnceWithExactly(putObjectStub, expectedLogs, expectedKey);
+
+      // updates the build
+      await build.reload();
+      expect(build.logsS3Key).to.equal(expectedKey);
+
+      // deletes the logs
+      sinon.assert.calledOnceWithExactly(destroySpy, { where: { build: build.id } });
+      const numLogsAfter = await BuildLog.count({ where: { build: build.id } });
+      expect(numLogsAfter).to.equal(0);
+    });
+
+    describe('when there are no logs', () => {
+      it('does not do anything', async () => {
+        const site = await factory.site();
+        const build = await factory.build({ site });
+        const destroySpy = sinon.spy(BuildLog, 'destroy');
+
+        await BuildLogs.archiveBuildLogs(site, build);
+
+        // does not send logs to S3
+        sinon.assert.notCalled(putObjectStub);
+
+        // does not update build
+        await build.reload();
+        expect(build.logsS3Key).to.be.null;
+
+        // does not delete the logs
+        sinon.assert.notCalled(destroySpy);
+      });
+    });
+  });
+
+  describe('.getBuildLogs', () => {
+    let getObjectStub;
+
+    beforeEach(() => {
+      getObjectStub = sinon.stub();
+      sinon.stub(BuildLogs, 's3').returns({
+        getObject: getObjectStub,
+      });
+    });
+
+    it('returns the byte range of the logs', async () => {
+      const key = 'owner/repo/1';
+
+      const build = { logsS3Key: key };
+      getObjectStub.resolves(
+        { Body: Buffer.from('hel') }
+      );
+
+      const result = await BuildLogs.getBuildLogs(build, 0, 2);
+
+      sinon.assert.calledOnceWithExactly(getObjectStub, key, { Range: 'bytes=0-2' });
+      expect(result).to.equal('hel');
+    });
+
+    it('returns null if range cannott be satisified', async () => {
+      const key = 'owner/repo/1';
+
+      const build = { logsS3Key: key };
+      const error = new Error('foo');
+      error.code = 'InvalidRange';
+      getObjectStub.rejects(error);
+
+      const result = await BuildLogs.getBuildLogs(build, 100, 199);
+
+      sinon.assert.calledOnceWithExactly(getObjectStub, key, { Range: 'bytes=100-199' });
+      expect(result).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
- build logs can be archived to S3
- logs are fetched from the database OR S3 depending on IF they have been archived
- fetches for logs from S3 are paginated in a similar way as from the database
- private S3 buckets have been created in staging and production (`federalist-((env))-s3-build-logs`)
- removed handling of legacy build logs in controller since they are no longer present (maybe have to clean up history in staging...)
- currently, logs are not automatically archived, but a script exists to archive a single build for testing: 
```
cf run-task <app-name> --name archive-build-logs-<buildid> --command "yarn archive-build-logs <buildid>"
```
Example for build id `49` in `staging`:
```
cf run-task federalistapp-staging --name archive-build-logs-49 --command "yarn archive-build-logs 49"
```