### PR TITLE
Make sure remove S3 is run after bucket contents completely removed

### DIFF
--- a/api/services/SiteDestroyer.js
+++ b/api/services/SiteDestroyer.js
@@ -4,8 +4,8 @@ const S3SiteRemover = require('./S3SiteRemover');
 
 async function destroySite(site) {
   const destroyComponents = [
-    S3SiteRemover.removeSite(site),
-    S3SiteRemover.removeInfrastructure(site),
+    S3SiteRemover.removeSite(site)
+      .then(() => S3SiteRemover.removeInfrastructure(site)),
     site.destroy(),
   ];
 


### PR DESCRIPTION
When deleting a site an error gets thrown because the cf service for the S3 bucket cannot be deleted because all of the contents are not removed yet.  Change the promises to make sure remove s3 content is finished before deleting bucket.