### PR TITLE
Update uaa to use new admin and app client creds

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -9,6 +9,8 @@ applications:
     memory: ((memory))
     instances: ((instances))
     services:
+      - admin-((env))-uaa-client
+      - app-((env))-uaa-client
       - federalist-((env))-rds
       - federalist-((env))-s3
       - federalist-((env))-env
@@ -22,7 +24,6 @@ applications:
       - federalist-site-wide-error
       - federalist-((env))-dynamodb-creds
       - federalist-((env))-s3-build-logs
-      - uaa-client
     env:
       NODE_ENV: production
       APP_ENV: ((env))

--- a/README.md
+++ b/README.md
@@ -159,11 +159,20 @@ The app expects the following user provided services to be provided:
   - `secret_key`: The AWS secret key for SQS queue
   - `region`: The AWS region
   - `sqs_url`: The AWS SQS queue URL
-- `uaa-client`: An instance of cloud.gov's UAA broker to support authentication via SecureAuth. The service binding must include redirect_uris:
-  - `<host>/auth/uaa/callback`
-  - `<host>/auth/uaa/logout`
-  - `<host>/admin/auth/uaa/callback`
-  - `<host>/admin/auth/uaa/logout`
+- `admin-<environment>-uaa-client`: Credentials for cloud.gov's UAA to support authentication for the admin app via SecureAuth. This service provides the following:
+  - `clientID`: The UAA client id for the environments admin app
+  - `clientSecret`: The UAA client secret for the environments admin app
+  - `authorizationURL`: The url to login and authorize a user
+  - `tokenURL`: The UAA url to get a user's token
+  - `userURL`: The UAA url to get a user's info
+  - `logoutURL`: The UAA url to logout a user
+- `app-<environment>-uaa-client`: Credentials for cloud.gov's UAA to support authentication for the app via SecureAuth. This service provides the following:
+  - `clientID`: The UAA client id for the environments app
+  - `clientSecret`: The UAA client secret for the environments app
+  - `authorizationURL`: The url to login and authorize a user
+  - `tokenURL`: The UAA url to get a user's token
+  - `userURL`: The UAA url to get a user's info
+  - `logoutURL`: The UAA url to logout a user
 
 #### Deploy in CloudFoundry
 To deploy to CloudFoundry submit the following:

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -138,14 +138,12 @@ module.exports.userEnvVar = {
   key: cfUserEnvVar.key,
 };
 
-const uaaCredentials = appEnv.getServiceCreds('uaa-client');
-const uaaOptions = {
-  clientID: uaaCredentials.client_id,
-  clientSecret: uaaCredentials.client_secret,
-};
+const uaaAppCredentials = appEnv.getServiceCreds(`app-${process.env.APP_ENV}-uaa-client`);
+const uaaAdminCredentials = appEnv.getServiceCreds(`admin-${process.env.APP_ENV}-uaa-client`);
+
 module.exports.passport = {
   uaa: {
-    options: uaaOptions,
-    adminOptions: uaaOptions,
+    options: uaaAppCredentials,
+    adminOptions: uaaAdminCredentials,
   },
 };


### PR DESCRIPTION
Update UAA credentials to use two user provided services per environment with client credentials via the cloud.gov uaa deployment.

To Do:
- [x] Add two services per env `admin-<environment>-uaa-client` & `app-<environment>-uaa-client`
- [x] Remove current `uaa-client` relying on the brokered service
- [x] Update docs 