### PR TITLE
Add UAA Identity table to support authentication

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -44,6 +44,7 @@ applications:
       FEATURE_PROXY_EDGE_LINKS: ((feature_proxy_edge_links))
       FEATURE_BULL_SITE_BUILD_QUEUE: ((feature_bull_site_build_queue))
       AUTH_IDP: ((auth_idp))
+      UAA_HOST: ((uaa_host))
   - name: federalist-admin((env_postfix))
     buildpack: staticfile_buildpack
     path: ../admin-client

--- a/.cloudgov/vars/production.yml
+++ b/.cloudgov/vars/production.yml
@@ -9,3 +9,4 @@ feature_proxy_edge_links: 'false'
 feature_proxy_edge_dynamo: 'false'
 feature_bull_site_build_queue: 'false'
 auth_idp: github
+uaa_host: https://uaa.fr.cloud.gov

--- a/.cloudgov/vars/staging.yml
+++ b/.cloudgov/vars/staging.yml
@@ -9,3 +9,4 @@ feature_proxy_edge_links: 'true'
 feature_proxy_edge_dynamo: 'true'
 feature_bull_site_build_queue: 'true'
 auth_idp: uaa
+uaa_host: https://uaa.fr-stage.cloud.gov

--- a/Dockerfile-uaa
+++ b/Dockerfile-uaa
@@ -1,0 +1,23 @@
+FROM openjdk:8u141-jre
+
+ENV UAA_CONFIG_PATH /uaa
+ENV CATALINA_HOME /tomcat
+
+COPY ./uaa/uaa.yml /uaa/uaa.yml
+
+RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.28/bin/apache-tomcat-8.0.28.tar.gz
+RUN wget -qO- https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.28/bin/apache-tomcat-8.0.28.tar.gz.md5 | md5sum -c -
+
+RUN tar zxf apache-tomcat-8.0.28.tar.gz
+RUN rm apache-tomcat-8.0.28.tar.gz
+
+RUN mkdir /tomcat
+RUN mv apache-tomcat-8.0.28/* /tomcat
+RUN rm -rf /tomcat/webapps/*
+
+COPY ./uaa/cloudfoundry-identity-uaa-4.19.0.war /tomcat/webapps/cloudfoundry-identity-uaa-4.19.0.war
+RUN mv /tomcat/webapps/cloudfoundry-identity-uaa-4.19.0.war /tomcat/webapps/ROOT.war
+
+EXPOSE 8080
+
+CMD ["/tomcat/bin/catalina.sh", "run"]

--- a/api/admin/passport.js
+++ b/api/admin/passport.js
@@ -1,21 +1,19 @@
 const Passport = require('passport');
 const config = require('../../config');
 const { User } = require('../models');
-const { createUAAStrategy } = require('../services/uaaStrategy');
+const { createUAAStrategy, verifyUAAUser } = require('../services/uaaStrategy');
 
 const passport = new Passport.Passport();
 
 const uaaOptions = config.passport.uaa.adminOptions;
 
-const verify = async (accessToken, _refreshToken, profile, callback) => {
-  const { email } = profile;
+const verify = async (accessToken, refreshToken, profile, callback) => {
+  const { user_id: uaaId } = profile;
 
   try {
-    const user = await User.findOne({ where: { adminEmail: email } });
+    const user = await verifyUAAUser(accessToken, refreshToken, uaaId, 'pages.admin');
 
-    if (!user) {
-      return callback(null, false);
-    }
+    if (!user) return callback(null, false);
 
     return callback(null, user);
   } catch (err) {

--- a/api/admin/passport.js
+++ b/api/admin/passport.js
@@ -8,10 +8,8 @@ const passport = new Passport.Passport();
 const uaaOptions = config.passport.uaa.adminOptions;
 
 const verify = async (accessToken, refreshToken, profile, callback) => {
-  const { user_id: uaaId } = profile;
-
   try {
-    const user = await verifyUAAUser(accessToken, refreshToken, uaaId, 'pages.admin');
+    const user = await verifyUAAUser(accessToken, refreshToken, profile, ['pages.admin']);
 
     if (!user) return callback(null, false);
 

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -25,6 +25,7 @@ require('./event')(sequelize, DataTypes);
 require('./role')(sequelize, DataTypes);
 require('./organization')(sequelize, DataTypes);
 require('./organization-role')(sequelize, DataTypes);
+require('./uaa-identity')(sequelize, DataTypes);
 
 Object
   .keys(sequelize.models)

--- a/api/models/uaa-identity.js
+++ b/api/models/uaa-identity.js
@@ -1,0 +1,57 @@
+const associate = ({ UAAIdentity, User }) => {
+  UAAIdentity.belongsTo(User, {
+    foreignKey: 'userId',
+    allowNull: false,
+  });
+};
+
+module.exports = (sequelize, DataTypes) => {
+  const UAAIdentity = sequelize.define('UAAIdentity', {
+    uaaId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    userName: {
+      type: DataTypes.STRING,
+      unique: true,
+      allowNull: false,
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        isEmail: true,
+      },
+    },
+    origin: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    verified: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    accessToken: {
+      type: DataTypes.TEXT,
+    },
+    refreshToken: {
+      type: DataTypes.TEXT,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      references: 'User',
+    },
+  }, {
+    paranoid: true,
+    tableName: 'uaa_identity',
+  });
+
+  UAAIdentity.associate = associate;
+
+  return UAAIdentity;
+};

--- a/api/models/uaa-identity.js
+++ b/api/models/uaa-identity.js
@@ -9,7 +9,6 @@ module.exports = (sequelize, DataTypes) => {
   const UAAIdentity = sequelize.define('UAAIdentity', {
     uaaId: {
       type: DataTypes.STRING,
-      allowNull: false,
       unique: true,
       validate: {
         notEmpty: true,

--- a/api/models/uaa-identity.js
+++ b/api/models/uaa-identity.js
@@ -9,6 +9,7 @@ module.exports = (sequelize, DataTypes) => {
   const UAAIdentity = sequelize.define('UAAIdentity', {
     uaaId: {
       type: DataTypes.STRING,
+      allowNull: false,
       unique: true,
       validate: {
         notEmpty: true,

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -7,6 +7,7 @@ const associate = ({
   OrganizationRole,
   Site,
   SiteUser,
+  UAAIdentity,
   User,
   UserAction,
 }) => {
@@ -33,6 +34,9 @@ const associate = ({
     through: OrganizationRole,
     foreignKey: 'userId',
     otherKey: 'organizationId',
+  });
+  User.hasOne(UAAIdentity, {
+    foreignKey: 'userId',
   });
 
   // Scopes

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -49,10 +49,13 @@ async function verifyGithub(accessToken, _refreshToken, profile, callback) {
 }
 
 async function verifyUAA(accessToken, refreshToken, profile, callback) {
-  const { user_id: uaaId } = profile;
-
   try {
-    const user = await verifyUAAUser(accessToken, refreshToken, uaaId, 'pages.admin', callback);
+    const user = await verifyUAAUser(
+      accessToken,
+      refreshToken,
+      profile,
+      ['pages.user', 'pages.admin']
+    );
 
     if (!user) return callback(null, false);
 

--- a/api/services/uaaStrategy.js
+++ b/api/services/uaaStrategy.js
@@ -35,15 +35,17 @@ function createUAAStrategy(options, verify) {
   return strategy;
 }
 
-async function verifyUAAUser(accessToken, refreshToken, uaaId, uaaGroup) {
+async function verifyUAAUser(accessToken, refreshToken, profile, uaaGroups) {
+  const { user_id: uaaId, email } = profile;
+
   const client = new UAAClient(accessToken);
-  const isVerified = await client.verifyUserGroup(uaaId, uaaGroup);
+  const isVerified = await client.verifyUserGroup(uaaId, uaaGroups);
 
   if (!isVerified) {
     return null;
   }
 
-  const identity = await UAAIdentity.findOne({ where: { uaaId } });
+  const identity = await UAAIdentity.findOne({ where: { email } });
 
   if (!identity) {
     return null;
@@ -55,6 +57,7 @@ async function verifyUAAUser(accessToken, refreshToken, uaaId, uaaGroup) {
     return null;
   }
 
+  identity.uaaId = uaaId;
   identity.accessToken = accessToken;
   identity.refreshToken = refreshToken;
   await identity.save();

--- a/api/services/uaaStrategy.js
+++ b/api/services/uaaStrategy.js
@@ -1,6 +1,6 @@
 const { Strategy } = require('passport-oauth2');
 const UAAClient = require('../utils/uaaClient');
-const { UAAIdentity } = require('../models');
+const { UAAIdentity, User } = require('../models');
 
 function createUAAStrategy(options, verify) {
   const {
@@ -45,24 +45,15 @@ async function verifyUAAUser(accessToken, refreshToken, profile, uaaGroups) {
     return null;
   }
 
-  const identity = await UAAIdentity.findOne({ where: { email } });
+  const identity = await UAAIdentity.findOne({ where: { email }, include: User });
 
   if (!identity) {
     return null;
   }
 
-  const user = await identity.getUser();
+  await identity.update({ uaaId, accessToken, refreshToken });
 
-  if (!user) {
-    return null;
-  }
-
-  identity.uaaId = uaaId;
-  identity.accessToken = accessToken;
-  identity.refreshToken = refreshToken;
-  await identity.save();
-
-  return user;
+  return identity.User;
 }
 
 module.exports = { createUAAStrategy, verifyUAAUser };

--- a/api/utils/uaaClient.js
+++ b/api/utils/uaaClient.js
@@ -7,21 +7,24 @@ class UAAClient {
     this.accessToken = accessToken;
   }
 
-  async verifyUserGroup(userId, groupName) {
+  async verifyUserGroup(userId, groupNames = []) {
     const { groups, origin, verified } = await this.request('GET', `/Users/${userId}`);
     if (origin === 'cloud.gov' && !verified) {
       return false;
     }
 
-    return groups.filter(group => group.display === groupName).length === 1;
+    return groups.filter(group => groupNames.indexOf(group.display) > -1).length > 0;
   }
 
   request(method, path, json) {
+    const host = config.env.uaaHost === 'http://localhost:9000'
+      ? 'http://uaa:8080' : config.env.uaaHost;
+
     return new Promise((resolve, reject) => {
       request({
         method: method.toUpperCase(),
         url: url.resolve(
-          config.env.uaaHost,
+          host,
           path
         ),
         headers: {

--- a/api/utils/uaaClient.js
+++ b/api/utils/uaaClient.js
@@ -1,0 +1,48 @@
+const request = require('request');
+const url = require('url');
+const config = require('../../config');
+
+class UAAClient {
+  constructor(accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  async verifyUserGroup(userId, groupName) {
+    const { groups, origin, verified } = await this.request('GET', `/Users/${userId}`);
+    if (origin === 'cloud.gov' && !verified) {
+      return false;
+    }
+
+    return groups.filter(group => group.display === groupName).length === 1;
+  }
+
+  request(method, path, json) {
+    return new Promise((resolve, reject) => {
+      request({
+        method: method.toUpperCase(),
+        url: url.resolve(
+          config.env.uaaHost,
+          path
+        ),
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+        },
+        json,
+      }, (error, response, body) => {
+        const result = body ? JSON.parse(body) : {};
+        const { error: bodyError } = result;
+
+        if (error || bodyError) {
+          reject(error || bodyError);
+        } else if (response.statusCode > 399) {
+          const errorMessage = `Received status code: ${response.statusCode}`;
+          reject(new Error(JSON.stringify(body) || errorMessage));
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  }
+}
+
+module.exports = UAAClient;

--- a/api/utils/uaaClient.js
+++ b/api/utils/uaaClient.js
@@ -13,7 +13,7 @@ class UAAClient {
       return false;
     }
 
-    return groups.filter(group => groupNames.indexOf(group.display) > -1).length > 0;
+    return groups.filter(group => groupNames.includes(group.display)).length > 0;
   }
 
   request(method, path, json) {

--- a/api/utils/uaaClient.js
+++ b/api/utils/uaaClient.js
@@ -17,13 +17,10 @@ class UAAClient {
   }
 
   request(method, path, json) {
-    const host = config.env.uaaHost === 'http://localhost:9000'
-      ? 'http://uaa:8080' : config.env.uaaHost;
-
     return new Promise((resolve, reject) => {
       request({
         method: method.toUpperCase(),
-        url: url.resolve(host, path),
+        url: url.resolve(config.env.uaaHostUrl, path),
         headers: {
           Authorization: `Bearer ${this.accessToken}`,
         },

--- a/api/utils/uaaClient.js
+++ b/api/utils/uaaClient.js
@@ -23,10 +23,7 @@ class UAAClient {
     return new Promise((resolve, reject) => {
       request({
         method: method.toUpperCase(),
-        url: url.resolve(
-          host,
-          path
-        ),
+        url: url.resolve(host, path),
         headers: {
           Authorization: `Bearer ${this.accessToken}`,
         },

--- a/config/env.js
+++ b/config/env.js
@@ -5,4 +5,5 @@ module.exports = {
   cfOauthTokenUrl: process.env.CLOUD_FOUNDRY_OAUTH_TOKEN_URL || 'https://login.example.com/oauth/token',
   cfApiHost: process.env.CLOUD_FOUNDRY_API_HOST || 'https://api.example.com',
   authIDP: process.env.AUTH_IDP,
+  uaaHost: process.env.UAA_HOST || 'http://uaa.example.com',
 };

--- a/config/env.js
+++ b/config/env.js
@@ -6,4 +6,5 @@ module.exports = {
   cfApiHost: process.env.CLOUD_FOUNDRY_API_HOST || 'https://api.example.com',
   authIDP: process.env.AUTH_IDP,
   uaaHost: process.env.UAA_HOST || 'http://uaa.example.com',
+  uaaHostUrl: process.env.UAA_HOST_DOCKER_URL || process.env.UAA_HOST || 'http://uaa.example.com',
 };

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -98,6 +98,7 @@ module.exports = {
     cfApiHost: 'https://api.example.com',
     proxySiteTable: 'testSiteTable',
     uaaHost: 'https://uaa.example.com',
+    uaaHostUrl: 'https://uaa.example.com',
   },
   userEnvVar: {
     key: 'shhhhhhhhhhh',

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -39,6 +39,7 @@ module.exports = {
       ],
     },
     uaa: {
+      host: 'https://uaa.example.com',
       options: {
         clientID: '123abc',
         clientSecret: '456def',
@@ -72,6 +73,7 @@ module.exports = {
     cfOauthTokenUrl: 'https://login.example.com/oauth/token',
     cfApiHost: 'https://api.example.com',
     proxySiteTable: 'testSiteTable',
+    uaaHost: 'https://uaa.example.com',
   },
   userEnvVar: {
     key: 'shhhhhhhhhhh',

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -43,10 +43,14 @@ module.exports = {
       options: {
         clientID: '123abc',
         clientSecret: '456def',
+        tokenURL: 'https://uaa.example.com/oauth/token',
+        userURL: 'https://uaa.example.com/userinfo',
       },
       adminOptions: {
         clientID: '123abc',
         clientSecret: '456def',
+        tokenURL: 'https://uaa.example.com/oauth/token',
+        userURL: 'https://uaa.example.com/userinfo',
       },
     },
   },

--- a/config/local.sample.js
+++ b/config/local.sample.js
@@ -14,14 +14,20 @@ if (process.env.NODE_ENV !== 'test') {
           1234567, // YOUR GITHUB ORGANIZATION ID
         ],
       },
+      // Keep these options below in your local.js config
+      // to connect the the docker-compose uaa service
       uaa: {
         options: {
-          clientID: 'UAA_OAUTH_CLIENT_ID',
-          clientSecret: 'UAA_OAUTH_CLIENT_SECRET',
+          clientID: 'user-client',
+          clientSecret: 'user-client-secret',
+          tokenURL: 'http://uaa:8080/oauth/token',
+          userURL: 'http://uaa:8080/userinfo',
         },
         adminOptions: {
-          clientID: 'UAA_OAUTH_CLIENT_ID',
-          clientSecret: 'UAA_OAUTH_CLIENT_SECRET',
+          clientID: 'admin-client',
+          clientSecret: 'admin-client-secret',
+          tokenURL: 'http://uaa:8080/oauth/token',
+          userURL: 'http://uaa:8080/userinfo',
         },
       },
     },

--- a/config/passport.js
+++ b/config/passport.js
@@ -7,9 +7,9 @@ const url = path => `${env.APP_HOSTNAME}${path}`;
 
 const uaaOptions = {
   authorizationURL: 'https://login.fr.cloud.gov/oauth/authorize',
-  tokenURL: 'https://uaa.fr.cloud.gov/oauth/token',
-  userURL: 'https://uaa.fr.cloud.gov/userinfo',
-  logoutURL: 'https://uaa.fr.cloud.gov/logout.do',
+  tokenURL: `https://${env.UAA_HOST}/oauth/token`,
+  userURL: `https://${env.UAA_HOST}/userinfo`,
+  logoutURL: `https://${env.UAA_HOST}/logout.do`,
 };
 
 module.exports = {
@@ -32,6 +32,7 @@ module.exports = {
     ],
   },
   uaa: {
+    host: env.UAA_HOST,
     options: {
       ...uaaOptions,
       callbackURL: url('/auth/uaa/callback'),

--- a/config/passport.js
+++ b/config/passport.js
@@ -6,10 +6,10 @@ const clientSecret = env.GITHUB_CLIENT_SECRET || 'not_set';
 const url = path => `${env.APP_HOSTNAME}${path}`;
 
 const uaaOptions = {
-  authorizationURL: 'https://login.fr.cloud.gov/oauth/authorize',
-  tokenURL: `https://${env.UAA_HOST}/oauth/token`,
-  userURL: `https://${env.UAA_HOST}/userinfo`,
-  logoutURL: `https://${env.UAA_HOST}/logout.do`,
+  authorizationURL: `${env.UAA_HOST}/oauth/authorize`,
+  tokenURL: `${env.UAA_HOST}/oauth/token`,
+  userURL: `${env.UAA_HOST}/userinfo`,
+  logoutURL: `${env.UAA_HOST}/logout.do`,
 };
 
 module.exports = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       APP_HOSTNAME: http://localhost:1337
       AUTH_IDP: uaa
       UAA_HOST: http://localhost:9000
+      UAA_HOST_DOCKER_URL: http://uaa:8080
   admin-client:
     build:
       dockerfile: ./admin-client/Dockerfile-admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     depends_on:
       - db
       - redis
+      - uaa
     environment:
       JWT_SECRET: 'shhHhh...'
       USER_AUDITOR: federalist
@@ -32,6 +33,7 @@ services:
       FEATURE_ADMIN_AUTH: 'true'
       APP_HOSTNAME: http://localhost:1337
       AUTH_IDP: uaa
+      UAA_HOST: http://localhost:9000
   admin-client:
     build:
       dockerfile: ./admin-client/Dockerfile-admin
@@ -62,3 +64,18 @@ services:
     image: redis
     ports:
       - 6379:6379
+  uaa:
+    build:
+      dockerfile: ./Dockerfile-uaa
+      context: .
+    ports:
+      - 9000:8080
+    environment:
+      POSTGRES_DB: federalist
+      POSTGRES_PORT: 5432
+      POSTGRES_HOST: db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    depends_on:
+      - db
+    command: ["/tomcat/bin/catalina.sh", "run"]

--- a/migrations/20201105114246-remove-users-never-logged-in.js
+++ b/migrations/20201105114246-remove-users-never-logged-in.js
@@ -2,3 +2,5 @@
 exports.up = (db, callback) => db.runSql('update "user" set "deletedAt" = now() where "githubAccessToken" is null and "deletedAt" is null')
   .then(() => db.runSql('update build b set "user" = null from "user" u where u."deletedAt" is not null and u.id = b.user'))
   .then(() => callback());
+
+exports.down = async () => {};

--- a/migrations/20210304213706-init-uaa-identity.js
+++ b/migrations/20210304213706-init-uaa-identity.js
@@ -1,7 +1,7 @@
 const uaaIdentity = 'uaa_identity';
 const UAA_IDENTITY_TABLE = {
   id: { type: 'int', primaryKey: true, autoIncrement: true },
-  uaaId: { type: 'string', unique: true },
+  uaaId: { type: 'string', notNull: true, unique: true },
   userName: { type: 'string', notNull: true, unique: true },
   email: { type: 'string', notNull: true, unique: true },
   origin: { type: 'string', notNull: true },

--- a/migrations/20210304213706-init-uaa-identity.js
+++ b/migrations/20210304213706-init-uaa-identity.js
@@ -1,0 +1,35 @@
+const uaaIdentity = 'uaa_identity';
+const UAA_IDENTITY_TABLE = {
+  id: { type: 'int', primaryKey: true, autoIncrement: true },
+  uaaId: { type: 'string', notNull: true, unique: true },
+  userName: { type: 'string', notNull: true, unique: true },
+  email: { type: 'string', notNull: true, unique: true },
+  origin: { type: 'string', notNull: true },
+  verified: { type: 'boolean', notNull: true, defaultValue: false },
+  accessToken: { type: 'text' },
+  refreshToken: { type: 'text' },
+  userId: {
+    type: 'int',
+    notNull: true,
+    foreignKey: {
+      name: 'uaa_identity_user_id_fk',
+      table: 'user',
+      mapping: 'id',
+      rules: {
+        onDelete: 'CASCADE',
+        onUpdate: 'RESTRICT',
+      },
+    },
+  },
+  createdAt: { type: 'timestamp', notNull: true },
+  updatedAt: { type: 'timestamp', notNull: true },
+  deletedAt: { type: 'timestamp', allowNull: true },
+};
+
+exports.up = async db => {
+  await db.createTable(uaaIdentity, UAA_IDENTITY_TABLE);
+};
+
+exports.down = async db => {
+  return db.dropTable(uaaIdentity);
+};

--- a/migrations/20210304213706-init-uaa-identity.js
+++ b/migrations/20210304213706-init-uaa-identity.js
@@ -1,7 +1,7 @@
 const uaaIdentity = 'uaa_identity';
 const UAA_IDENTITY_TABLE = {
   id: { type: 'int', primaryKey: true, autoIncrement: true },
-  uaaId: { type: 'string', notNull: true, unique: true },
+  uaaId: { type: 'string', unique: true },
   userName: { type: 'string', notNull: true, unique: true },
   email: { type: 'string', notNull: true, unique: true },
   origin: { type: 'string', notNull: true },

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -88,6 +88,7 @@ async function createData({ githubUsername }) {
 
   console.log('Create fake-user@example.com uaa identity');
   await user2.createUAAIdentity({
+    uaaId: 'fake-user-placeholder-id',
     email: user2.email,
     userName: user2.email,
     origin: 'example.com',
@@ -278,18 +279,21 @@ async function createData({ githubUsername }) {
   await Promise.all([
     User.findOne({ where: { email: 'amirbey@example.com' } })
       .then(user => user.createUAAIdentity({
+        uaaId: 'amirbey-placeholder-id',
         email: user.email,
         userName: user.email,
         origin: 'example.com',
       })),
     User.findOne({ where: { email: 'apburnes@example.com' } })
       .then(user => user.createUAAIdentity({
+        uaaId: 'apburnes-placeholder-id',
         email: user.email,
         userName: user.email,
         origin: 'example.com',
       })),
     User.findOne({ where: { email: 'davemcorwin@example.com' } })
       .then(user => user.createUAAIdentity({
+        uaaId: 'davemcorwin-placeholder-id',
         email: user.email,
         userName: user.email,
         origin: 'example.com',

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -86,6 +86,14 @@ async function createData({ githubUsername }) {
     }),
   ]);
 
+  console.log('Create fake-user@example.com uaa identity');
+  await user2.createUAAIdentity({
+    email: user2.email,
+    userName: user2.email,
+    origin: 'example.com',
+    userId: user2.id,
+  });
+
   console.log('Creating sites...');
   const [site1, nodeSite, goSite] = await Promise.all([
     siteFactory({
@@ -264,6 +272,28 @@ async function createData({ githubUsername }) {
     User.upsert({ username: 'amirbey', email: 'amirbey@example.com', adminEmail: 'amir.reavis-bey@gsa.gov' }),
     User.upsert({ username: 'apburnes', email: 'apburnes@example.com', adminEmail: 'andrew.burnes@gsa.gov' }),
     User.upsert({ username: 'davemcorwin', email: 'davemcorwin@example.com', adminEmail: 'david.corwin@gsa.gov' }),
+  ]);
+
+  console.log('Creating Admin User UAA Identities');
+  await Promise.all([
+    User.findOne({ where: { email: 'amirbey@example.com' } })
+      .then(user => user.createUAAIdentity({
+        email: user.email,
+        userName: user.email,
+        origin: 'example.com',
+      })),
+    User.findOne({ where: { email: 'apburnes@example.com' } })
+      .then(user => user.createUAAIdentity({
+        email: user.email,
+        userName: user.email,
+        origin: 'example.com',
+      })),
+    User.findOne({ where: { email: 'davemcorwin@example.com' } })
+      .then(user => user.createUAAIdentity({
+        email: user.email,
+        userName: user.email,
+        origin: 'example.com',
+      })),
   ]);
 
   console.log('Crearing Error Events');

--- a/test/api/admin/requests/admin-auth.test.js
+++ b/test/api/admin/requests/admin-auth.test.js
@@ -3,7 +3,7 @@ const request = require('supertest');
 const { UAAIdentity, User } = require('../../../../api/models');
 const cfUAANock = require('../../support/cfUAANock');
 const userFactory = require('../../support/factory/user');
-const { uaaUser, createUAAIdentity } = require('../../support/factory/uaa-identity');
+const { uaaUser, uaaProfile, createUAAIdentity } = require('../../support/factory/uaa-identity');
 const { sessionForCookie } = require('../../support/cookieSession');
 const { unauthenticatedSession } = require('../../support/session');
 const sessionConfig = require('../../../../api/admin/sessionConfig');
@@ -57,26 +57,31 @@ describe('Admin authentication request', () => {
     describe('when successful', () => {
       const uaaId = 'admin_id_1';
       const code = 'code';
-      const profile = { email: 'hello@example.com', user_id: uaaId };
-      const userProfile = uaaUser({
-        id: uaaId,
+      const email = 'hello@example.com';
+      const uaaUserProfile = uaaProfile({
+        userId: uaaId,
+        email,
+      });
+      const uaaUserInfo = uaaUser({
+        uaaId,
+        email,
         groups: [{
           display: 'pages.admin',
         }],
-        ...profile,
       });
 
       before(async () => {
         const user = await userFactory();
         await createUAAIdentity({
           uaaId,
+          email,
           userId: user.id,
         });
       });
 
       beforeEach(() => {
-        cfUAANock.uaaAuth(profile, code);
-        cfUAANock.getUser(uaaId, userProfile);
+        cfUAANock.uaaAuth(uaaUserProfile, code);
+        cfUAANock.getUser(uaaId, uaaUserInfo);
       });
 
       it('returns a script tag', (done) => {

--- a/test/api/support/cfUAANock.js
+++ b/test/api/support/cfUAANock.js
@@ -1,5 +1,5 @@
 const nock = require('nock');
-const { options: uaaConfig } = require('../../../config').passport.uaa;
+const { options: uaaConfig, host: uaaHost } = require('../../../config').passport.uaa;
 
 function userProfile(profile, accessToken) {
   const url = new URL(uaaConfig.userURL);
@@ -32,6 +32,45 @@ function uaaAuth(profile, code) {
   userProfile(profile, accessToken);
 }
 
+function getUser(userId, profile, accessToken = 'accessToken') {
+  return nock(uaaHost, {
+    reqheaders: {
+      authorization: `Bearer ${accessToken}`,
+    },
+  })
+    .get(`/Users/${userId}`)
+    .reply(200, {
+      ...profile,
+    });
+}
+
+function serverError(path, message, accessToken, method = 'get') {
+  const httpMethod = method.toLowerCase();
+  return nock(uaaHost, {
+    reqheaders: {
+      authorization: `Bearer ${accessToken}`,
+    },
+  })[httpMethod](path)
+    .replyWithError({
+      ...message,
+    });
+}
+
+function serverErrorStatus(status, path, message, accessToken, method = 'get') {
+  const httpMethod = method.toLowerCase();
+  return nock(uaaHost, {
+    reqheaders: {
+      authorization: `Bearer ${accessToken}`,
+    },
+  })[httpMethod](path)
+    .reply(status, {
+      ...message,
+    });
+}
+
 module.exports = {
   uaaAuth,
+  getUser,
+  serverError,
+  serverErrorStatus,
 };

--- a/test/api/support/factory/index.js
+++ b/test/api/support/factory/index.js
@@ -5,6 +5,7 @@ const event = require('./event');
 const organization = require('./organization');
 const responses = require('./responses');
 const site = require('./site');
+const { createUAAIdentity } = require('./uaa-identity');
 const user = require('./user');
 const userEnvironmentVariable = require('./user-environment-variable');
 
@@ -17,6 +18,7 @@ module.exports = {
   organization,
   responses,
   site,
+  uaaIdentity: createUAAIdentity,
   user,
   userEnvironmentVariable,
 };

--- a/test/api/support/factory/uaa-identity.js
+++ b/test/api/support/factory/uaa-identity.js
@@ -1,0 +1,69 @@
+const crypto = require('crypto');
+const { UAAIdentity } = require('../../../../api/models');
+
+function generateRandomId() {
+  const bytes = crypto.randomBytes(10);
+  return crypto.createHash('md5').update(bytes).digest('hex');
+}
+
+let userNameStep = 1;
+function generateUniqueUserNameEmail() {
+  const userName = `user${userNameStep}@example.gov`;
+  userNameStep += 1;
+  return userName;
+}
+
+function profileAttributes({ userId, username, ...rest } = {}) {
+  const uname = username || generateUniqueUserNameEmail();
+  const id = userId || generateRandomId();
+
+  return {
+    user_id: id,
+    user_name: uname,
+    email_verified: false,
+    email: uname,
+    username: uname,
+    ...rest,
+  };
+}
+
+function userAttributes({
+  uaaId, userId, username, groups, ...rest
+} = {}) {
+  const uname = username || generateUniqueUserNameEmail();
+  const email = generateUniqueUserNameEmail();
+  const usersGroups = groups || [];
+  const userUaaId = uaaId || generateRandomId();
+  const userUserId = userId || generateRandomId();
+
+  return {
+    uaaId: userUaaId,
+    userName: uname,
+    email,
+    groups: usersGroups,
+    active: true,
+    verified: false,
+    origin: 'gsa.gov',
+    userId: userUserId,
+    ...rest,
+  };
+}
+
+function uaaProfile(overrides) {
+  return profileAttributes(overrides);
+}
+
+function uaaUser(overrides) {
+  return userAttributes(overrides);
+}
+
+function createUAAIdentity(overrides) {
+  const attributes = userAttributes(overrides);
+  return UAAIdentity.create(attributes);
+}
+
+module.exports = {
+  createUAAIdentity,
+  uaaProfile,
+  uaaUser,
+};

--- a/test/api/unit/models/uaa-identity.test.js
+++ b/test/api/unit/models/uaa-identity.test.js
@@ -16,13 +16,6 @@ describe('UAAIdentity model', () => {
 
   after(clean);
 
-  it('`uuaId` is required', async () => {
-    const error = await UAAIdentity.create({}).catch(e => e);
-
-    expect(error).to.be.an('error');
-    expect(error.name).to.eq('SequelizeValidationError');
-  });
-
   it('`uuaId` is unique', async () => {
     const [user1, user2] = await Promise.all([createUser(), createUser()]);
     const uaaId = 'test-uuaId';

--- a/test/api/unit/models/uaa-identity.test.js
+++ b/test/api/unit/models/uaa-identity.test.js
@@ -16,6 +16,13 @@ describe('UAAIdentity model', () => {
 
   after(clean);
 
+  it('`uuaId` is required', async () => {
+    const error = await UAAIdentity.create({}).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeValidationError');
+  });
+
   it('`uuaId` is unique', async () => {
     const [user1, user2] = await Promise.all([createUser(), createUser()]);
     const uaaId = 'test-uuaId';

--- a/test/api/unit/models/uaa-identity.test.js
+++ b/test/api/unit/models/uaa-identity.test.js
@@ -1,0 +1,187 @@
+const { expect } = require('chai');
+const { UAAIdentity, User } = require('../../../../api/models');
+
+const { createUAAIdentity } = require('../../support/factory/uaa-identity');
+const createUser = require('../../support/factory/user');
+
+function clean() {
+  return Promise.all([
+    UAAIdentity.truncate({ force: true, cascade: true }),
+    User.truncate({ force: true, cascade: true }),
+  ]);
+}
+
+describe('UAAIdentity model', () => {
+  beforeEach(clean);
+
+  after(clean);
+
+  it('`uuaId` is required', async () => {
+    const error = await UAAIdentity.create({}).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeValidationError');
+  });
+
+  it('`uuaId` is unique', async () => {
+    const [user1, user2] = await Promise.all([createUser(), createUser()]);
+    const uaaId = 'test-uuaId';
+    await createUAAIdentity({
+      uaaId,
+      userId: user1.id,
+    });
+    const error = await createUAAIdentity({
+      uaaId,
+      userId: user2.id,
+    }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeUniqueConstraintError');
+  });
+
+  it('`userName` is required', async () => {
+    const uaaId = 'uaa-id';
+    const error = await UAAIdentity.create({ uaaId }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeValidationError');
+  });
+
+  it('`userName` is unique', async () => {
+    const [user1, user2] = await Promise.all([createUser(), createUser()]);
+    const username = 'name';
+    await createUAAIdentity({
+      username,
+      userId: user1.id,
+    });
+    const error = await createUAAIdentity({
+      username,
+      userId: user2.id,
+    }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeUniqueConstraintError');
+  });
+
+  it('`email` is required', async () => {
+    const uaaId = 'uaa-id';
+    const userName = 'username';
+    const error = await UAAIdentity.create({ uaaId, userName }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeValidationError');
+  });
+
+  it('`email` is valid', async () => {
+    const user = await createUser();
+    const email = 'not-an-email';
+    const error = await createUAAIdentity({
+      email,
+      userId: user.id,
+    }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeValidationError');
+  });
+
+  it('`email` is unique', async () => {
+    const [user1, user2] = await Promise.all([createUser(), createUser()]);
+    const email = 'email@example.gov';
+    await createUAAIdentity({
+      email,
+      userId: user1.id,
+    });
+
+    const error = await createUAAIdentity({
+      email,
+      userId: user2.id,
+    }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeUniqueConstraintError');
+  });
+
+  it('`origin` is required', async () => {
+    const uaaId = 'uaa-id';
+    const userName = 'username';
+    const email = 'email@example.gov';
+    const error = await UAAIdentity.create({
+      uaaId,
+      userName,
+      email,
+    }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeValidationError');
+  });
+
+  it('`verified` defaults to false', async () => {
+    const user = await createUser();
+    const uaaId = 'uaa-id';
+    const userName = 'username';
+    const email = 'email@example.gov';
+    const origin = 'example.gov';
+    const identity = await UAAIdentity.create({
+      uaaId,
+      userName,
+      email,
+      origin,
+      userId: user.id,
+    });
+
+    expect(identity.verified).to.be.false;
+  });
+
+  it('`userId` is required', async () => {
+    const uaaId = 'uaa-id';
+    const userName = 'username';
+    const email = 'email@example.gov';
+    const origin = 'example.gov';
+    const error = await UAAIdentity.create({
+      uaaId,
+      userName,
+      email,
+      origin,
+    }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeDatabaseError');
+  });
+
+  it('`userId` is unique', async () => {
+    const user = await createUser();
+    const uaaId = 'uaa-id';
+    const userName = 'username';
+    const email = 'email@example.gov';
+    const origin = 'example.gov';
+    await UAAIdentity.create({
+      uaaId,
+      userName,
+      email,
+      origin,
+      userId: user.id,
+    });
+
+    const error = await UAAIdentity.create({
+      uaaId,
+      userName,
+      email,
+      origin,
+      userId: user.id,
+    }).catch(e => e);
+
+    expect(error).to.be.an('error');
+    expect(error.name).to.eq('SequelizeUniqueConstraintError');
+  });
+
+  it('should belong to one user', async () => {
+    const [user1, user2] = await Promise.all([createUser(), createUser()]);
+    const identity = await createUAAIdentity({ userId: user1.id });
+    const user1Identity = await user1.getUAAIdentity();
+    const identityUser = await identity.getUser();
+
+    expect(user1Identity.dataValues).to.deep.equal(identity.dataValues);
+    expect(identityUser.dataValues).to.deep.equal(user1.dataValues);
+    expect(await user2.getUAAIdentity()).to.be.null;
+  });
+});

--- a/test/api/unit/services/uaaStrategy.test.js
+++ b/test/api/unit/services/uaaStrategy.test.js
@@ -1,0 +1,110 @@
+const { expect } = require('chai');
+const { verifyUAAUser } = require('../../../../api/services/uaaStrategy');
+const { UAAIdentity, User } = require('../../../../api/models');
+const cfUAANock = require('../../support/cfUAANock');
+const createUser = require('../../support/factory/user');
+const { createUAAIdentity, uaaUser } = require('../../support/factory/uaa-identity');
+
+function clean() {
+  return Promise.all([
+    UAAIdentity.truncate({ force: true, cascade: true }),
+    User.truncate({ force: true, cascade: true }),
+  ]);
+}
+
+describe('verifyUAAUser', () => {
+  beforeEach(clean);
+
+  after(clean);
+
+  it('should return a verified user in the specified group', async () => {
+    const accessToken = 'a-token';
+    const refreshToken = 'refresh-token';
+    const user = await createUser();
+    const identity = await createUAAIdentity({ userId: user.id });
+    const profile = uaaUser({
+      id: identity.uaaId,
+      groups: [{
+        display: 'group.one',
+      }, {
+        display: 'group.two',
+      }],
+    });
+
+    cfUAANock.getUser(identity.uaaId, profile, accessToken);
+
+    expect(identity.accessToken).to.be.null;
+    expect(identity.refreshToken).to.be.null;
+
+    const verifiedUser = await verifyUAAUser(
+      accessToken, refreshToken, identity.uaaId, 'group.one'
+    );
+
+    await identity.reload();
+
+    expect(verifiedUser.dataValues).to.deep.equal(user.dataValues);
+    expect(identity.accessToken).to.equal(accessToken);
+    expect(identity.refreshToken).to.equal(refreshToken);
+  });
+
+  it('should return null when user is not in the specified group', async () => {
+    const accessToken = 'a-token';
+    const refreshToken = 'refresh-token';
+    const user = await createUser();
+    const { uaaId } = await createUAAIdentity({ userId: user.id });
+    const profile = uaaUser({
+      id: uaaId,
+      groups: [{
+        display: 'group.one',
+      }, {
+        display: 'group.two',
+      }],
+    });
+
+    cfUAANock.getUser(uaaId, profile, accessToken);
+
+    const result = await verifyUAAUser(accessToken, refreshToken, uaaId, 'group.three');
+    return expect(result).to.be.null;
+  });
+
+  it('should return null when uaa identity does not exist', async () => {
+    const accessToken = 'a-token';
+    const refreshToken = 'refresh-token';
+    const uaaId = 'not-a-saved-identity';
+    const profile = uaaUser({
+      id: uaaId,
+      groups: [{
+        display: 'group.one',
+      }, {
+        display: 'group.two',
+      }],
+    });
+
+    cfUAANock.getUser(uaaId, profile, accessToken);
+
+    const result = await verifyUAAUser(accessToken, refreshToken, uaaId, 'group.three');
+    return expect(result).to.be.null;
+  });
+
+  it('should return null when user related to identity does not exist', async () => {
+    const accessToken = 'a-token';
+    const refreshToken = 'refresh-token';
+    const user = await createUser();
+    const { uaaId } = await createUAAIdentity({ userId: user.id });
+    const profile = uaaUser({
+      id: uaaId,
+      groups: [{
+        display: 'group.one',
+      }, {
+        display: 'group.two',
+      }],
+    });
+
+    cfUAANock.getUser(uaaId, profile, accessToken);
+
+    await user.destroy();
+
+    const result = await verifyUAAUser(accessToken, refreshToken, uaaId, 'group.one');
+    return expect(result).to.be.null;
+  });
+});

--- a/test/api/unit/utils/uaaClient.test.js
+++ b/test/api/unit/utils/uaaClient.test.js
@@ -13,6 +13,7 @@ describe('UAAClient', () => {
       const accessToken = 'a-token';
       const username = 'a-user@example.gov';
       const groupName = 'users-group';
+      const groupNames = [groupName];
       const groups = [{ display: 'group-1' }, { display: groupName }];
       const userIdentity = uaaUser({ username, groups });
 
@@ -20,7 +21,23 @@ describe('UAAClient', () => {
 
       cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
 
-      const verified = await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      const verified = await uaaClient.verifyUserGroup(userIdentity.id, groupNames);
+      return expect(verified).to.be.true;
+    });
+
+    it('should verify an active user when one of the group names matches', async () => {
+      const accessToken = 'a-token';
+      const username = 'a-user@example.gov';
+      const groupName = 'users-group';
+      const groupNames = [groupName, 'another-group'];
+      const groups = [{ display: 'group-1' }, { display: groupName }];
+      const userIdentity = uaaUser({ username, groups });
+
+      const uaaClient = new UAAClient(accessToken);
+
+      cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
+
+      const verified = await uaaClient.verifyUserGroup(userIdentity.id, groupNames);
       return expect(verified).to.be.true;
     });
 
@@ -28,16 +45,19 @@ describe('UAAClient', () => {
       const accessToken = 'a-token';
       const username = 'a-user@example.gov';
       const groupName = 'users-group';
+      const groupNames = [groupName];
       const groups = [{ display: 'group-1' }, { display: groupName }];
       const origin = 'cloud.gov';
       const verified = true;
-      const userIdentity = uaaUser({ username, groups, origin, verified });
+      const userIdentity = uaaUser({
+        username, groups, origin, verified,
+      });
 
       const uaaClient = new UAAClient(accessToken);
 
       cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
 
-      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupNames);
       return expect(userVerified).to.be.true;
     });
 
@@ -45,6 +65,7 @@ describe('UAAClient', () => {
       const accessToken = 'a-token';
       const username = 'a-user@example.gov';
       const groupName = 'users-group';
+      const groupNames = [groupName];
       const groups = [{ display: 'group-1' }, { display: groupName }];
       const origin = 'cloud.gov';
       const verified = false;
@@ -54,7 +75,7 @@ describe('UAAClient', () => {
 
       cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
 
-      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupNames);
       return expect(userVerified).to.be.false;
     });
 
@@ -62,6 +83,7 @@ describe('UAAClient', () => {
       const accessToken = 'a-token';
       const username = 'a-user@example.gov';
       const groupName = 'user-not-a-member-group';
+      const groupNames = [groupName];
       const groups = [{ display: 'group-1' }, { display: 'group-2' }];
       const userIdentity = uaaUser({ username, groups });
 
@@ -69,13 +91,14 @@ describe('UAAClient', () => {
 
       cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
 
-      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupNames);
       return expect(userVerified).to.be.false;
     });
 
     it('should throw and error when uaa returns an error message', async () => {
       const accessToken = 'a-token';
       const groupName = 'a-group';
+      const groupNames = [groupName];
       const userIdentity = uaaUser();
       const errorMessage = { error: 'User not allowed' };
 
@@ -84,7 +107,7 @@ describe('UAAClient', () => {
       cfUAANock.getUser(userIdentity.id, errorMessage, accessToken);
 
       try {
-        return await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+        return await uaaClient.verifyUserGroup(userIdentity.id, groupNames);
       } catch (error) {
         return expect(error).to.be.throw;
       }
@@ -93,6 +116,7 @@ describe('UAAClient', () => {
     it('should throw and error when status code greater than 399', async () => {
       const accessToken = 'a-token';
       const groupName = 'a-group';
+      const groupNames = [groupName];
       const userIdentity = uaaUser();
       const errorMessage = { error: 'Server not responding' };
       const uaaPath = `/Users/${userIdentity.id}`;
@@ -102,7 +126,7 @@ describe('UAAClient', () => {
       cfUAANock.serverErrorStatus(500, uaaPath, errorMessage, accessToken);
 
       try {
-        return await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+        return await uaaClient.verifyUserGroup(userIdentity.id, groupNames);
       } catch (error) {
         return expect(error).to.be.throw;
       }
@@ -111,6 +135,7 @@ describe('UAAClient', () => {
     it('should throw an error when uaa server is down', async () => {
       const accessToken = 'a-token';
       const groupName = 'a-group';
+      const groupNames = [groupName];
       const userIdentity = uaaUser();
       const errorMessage = { error: 'Server not responding' };
       const uaaPath = `/Users/${userIdentity.id}`;
@@ -120,7 +145,7 @@ describe('UAAClient', () => {
       cfUAANock.serverError(uaaPath, errorMessage, accessToken);
 
       try {
-        return await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+        return await uaaClient.verifyUserGroup(userIdentity.id, groupNames);
       } catch (error) {
         return expect(error).to.be.throw;
       }

--- a/test/api/unit/utils/uaaClient.test.js
+++ b/test/api/unit/utils/uaaClient.test.js
@@ -1,0 +1,129 @@
+const { expect } = require('chai');
+const nock = require('nock');
+
+const UAAClient = require('../../../../api/utils/uaaClient');
+const cfUAANock = require('../../support/cfUAANock');
+const { uaaUser } = require('../../support/factory/uaa-identity');
+
+describe('UAAClient', () => {
+  describe('.verifyUserGroup()', () => {
+    afterEach(() => nock.cleanAll());
+
+    it('should verify an active user', async () => {
+      const accessToken = 'a-token';
+      const username = 'a-user@example.gov';
+      const groupName = 'users-group';
+      const groups = [{ display: 'group-1' }, { display: groupName }];
+      const userIdentity = uaaUser({ username, groups });
+
+      const uaaClient = new UAAClient(accessToken);
+
+      cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
+
+      const verified = await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      return expect(verified).to.be.true;
+    });
+
+    it('should verify a user with cloud.gov origin and verified email', async () => {
+      const accessToken = 'a-token';
+      const username = 'a-user@example.gov';
+      const groupName = 'users-group';
+      const groups = [{ display: 'group-1' }, { display: groupName }];
+      const origin = 'cloud.gov';
+      const verified = true;
+      const userIdentity = uaaUser({ username, groups, origin, verified });
+
+      const uaaClient = new UAAClient(accessToken);
+
+      cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
+
+      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      return expect(userVerified).to.be.true;
+    });
+
+    it('should not verify a user with cloud.gov origin and unverified verified email', async () => {
+      const accessToken = 'a-token';
+      const username = 'a-user@example.gov';
+      const groupName = 'users-group';
+      const groups = [{ display: 'group-1' }, { display: groupName }];
+      const origin = 'cloud.gov';
+      const verified = false;
+      const userIdentity = uaaUser({ username, groups, origin, verified });
+
+      const uaaClient = new UAAClient(accessToken);
+
+      cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
+
+      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      return expect(userVerified).to.be.false;
+    });
+
+    it('should not verify a user not in the specified group', async () => {
+      const accessToken = 'a-token';
+      const username = 'a-user@example.gov';
+      const groupName = 'user-not-a-member-group';
+      const groups = [{ display: 'group-1' }, { display: 'group-2' }];
+      const userIdentity = uaaUser({ username, groups });
+
+      const uaaClient = new UAAClient(accessToken);
+
+      cfUAANock.getUser(userIdentity.id, userIdentity, accessToken);
+
+      const userVerified = await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      return expect(userVerified).to.be.false;
+    });
+
+    it('should throw and error when uaa returns an error message', async () => {
+      const accessToken = 'a-token';
+      const groupName = 'a-group';
+      const userIdentity = uaaUser();
+      const errorMessage = { error: 'User not allowed' };
+
+      const uaaClient = new UAAClient(accessToken);
+
+      cfUAANock.getUser(userIdentity.id, errorMessage, accessToken);
+
+      try {
+        return await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      } catch (error) {
+        return expect(error).to.be.throw;
+      }
+    });
+
+    it('should throw and error when status code greater than 399', async () => {
+      const accessToken = 'a-token';
+      const groupName = 'a-group';
+      const userIdentity = uaaUser();
+      const errorMessage = { error: 'Server not responding' };
+      const uaaPath = `/Users/${userIdentity.id}`;
+
+      const uaaClient = new UAAClient(accessToken);
+
+      cfUAANock.serverErrorStatus(500, uaaPath, errorMessage, accessToken);
+
+      try {
+        return await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      } catch (error) {
+        return expect(error).to.be.throw;
+      }
+    });
+
+    it('should throw an error when uaa server is down', async () => {
+      const accessToken = 'a-token';
+      const groupName = 'a-group';
+      const userIdentity = uaaUser();
+      const errorMessage = { error: 'Server not responding' };
+      const uaaPath = `/Users/${userIdentity.id}`;
+
+      const uaaClient = new UAAClient(accessToken);
+
+      cfUAANock.serverError(uaaPath, errorMessage, accessToken);
+
+      try {
+        return await uaaClient.verifyUserGroup(userIdentity.id, groupName);
+      } catch (error) {
+        return expect(error).to.be.throw;
+      }
+    });
+  });
+});

--- a/uaa/uaa.yml
+++ b/uaa/uaa.yml
@@ -1,0 +1,115 @@
+spring_profiles: hsqldb
+
+scim:
+  username_pattern: '[A-Za-z0-9+\-_.@!'']+'
+  groups:
+    pages.user: A user for Pages
+    pages.admin: An admin for Pages
+  userids_enabled: true
+  username_pattern: '[a-z0-9+\-_.@]+'
+  users:
+    - amirbey@example.com|password|amirbey@example.com|Amir|Admin|pages.admin
+    - apburnes@example.com|password|apburnes@example.com|Andrew|Admin|pages.admin
+    - davemcorwin@example.com|password|davemcorwin@example.com|David|Admin|pages.admin
+    - fake-user@example.com|password|fake-user@example.com|Fake|User|pages.user
+
+disableInternalAuth: false
+disableInternalUserManagement: false
+
+authentication:
+  policy:
+    lockoutAfterFailures: 10
+    countFailuresWithinSeconds: 3600
+    lockoutPeriodSeconds: 30
+
+oauth:
+  user:
+    authorities:
+      - openid
+      - scim.me
+      - scim.read
+
+  clients:
+    admin-client:
+      id: admin-client
+      name: Admin client
+      override: true
+      scope: scim.read,openid
+      authorized-grant-types: authorization_code,client_credentials,refresh_token
+      authorities: uaa.none
+      access-token-validity: 600
+      refresh-token-validity: 259200
+      autoapprove: true
+      app-launch-url: http://localhost:1337
+      redirect-uri: http://localhost:1337/admin/auth/uaa/callback
+      secret: admin-client-secret
+    user-client:
+      id: user-client
+      name: User client
+      override: true
+      scope: scim.read,openid
+      authorized-grant-types: authorization_code,client_credentials,refresh_token
+      authorities: uaa.none
+      access-token-validity: 600
+      refresh-token-validity: 259200
+      autoapprove: true
+      app-launch-url: http://localhost:1337
+      redirect-uri: http://localhost:1337/auth/uaa/callback
+      secret: user-client-secret
+login:
+  serviceProviderKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIICXQIBAAKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5
+    L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vA
+    fpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQAB
+    AoGAVOj2Yvuigi6wJD99AO2fgF64sYCm/BKkX3dFEw0vxTPIh58kiRP554Xt5ges
+    7ZCqL9QpqrChUikO4kJ+nB8Uq2AvaZHbpCEUmbip06IlgdA440o0r0CPo1mgNxGu
+    lhiWRN43Lruzfh9qKPhleg2dvyFGQxy5Gk6KW/t8IS4x4r0CQQD/dceBA+Ndj3Xp
+    ubHfxqNz4GTOxndc/AXAowPGpge2zpgIc7f50t8OHhG6XhsfJ0wyQEEvodDhZPYX
+    kKBnXNHzAkEAyCA76vAwuxqAd3MObhiebniAU3SnPf2u4fdL1EOm92dyFs1JxyyL
+    gu/DsjPjx6tRtn4YAalxCzmAMXFSb1qHfwJBAM3qx3z0gGKbUEWtPHcP7BNsrnWK
+    vw6By7VC8bk/ffpaP2yYspS66Le9fzbFwoDzMVVUO/dELVZyBnhqSRHoXQcCQQCe
+    A2WL8S5o7Vn19rC0GVgu3ZJlUrwiZEVLQdlrticFPXaFrn3Md82ICww3jmURaKHS
+    N+l4lnMda79eSp3OMmq9AkA0p79BvYsLshUJJnvbk76pCjR28PK4dV1gSDUEqQMB
+    qy45ptdwJLqLJCeNoR0JUcDNIRhOCuOPND7pcMtX6hI/
+    -----END RSA PRIVATE KEY-----
+  serviceProviderKeyPassword: password
+  serviceProviderCertificate: |
+    -----BEGIN CERTIFICATE-----
+    MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEO
+    MAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEO
+    MAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5h
+    cnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwx
+    CzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAM
+    BgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAb
+    BgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GN
+    ADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39W
+    qS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOw
+    znoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4Ha
+    MIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGc
+    gBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYD
+    VQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYD
+    VQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJh
+    QGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ
+    0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxC
+    KdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkK
+    RpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0=
+    -----END CERTIFICATE-----
+
+jwt:
+  token:
+    signing-key: tokenKey
+    verification-key: verificationKey
+
+zones:
+  internal:
+    hostnames:
+      - localhost
+
+encryption:
+  active_key_label: dev-uaa-key
+  encryption_keys:
+  - label: dev-uaa-key
+    passphrase: changeme
+
+LOGIN_SECRET: secret


### PR DESCRIPTION
To support our transition to using UAA and UA groups, use a uaa identity table and the uaa api to verify and save information for our users.

To Do:
- [x] Add uaa_identity table and one-to-one relationship to user
- [x] Add verification of uaa user's access to the pages group for users and admins
- [x] Create a local UAA dev env 