### PR TITLE
3368 update concourse staging

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -143,7 +143,7 @@ jobs:
           path: src-api
           status: pending
           base_context: concourse
-          context: test
+          context: test-api
       - do: *test-api
 
     on_failure:
@@ -154,7 +154,7 @@ jobs:
             path: src-api
             status: failure
             base_context: concourse
-            context: test
+            context: test-api
         - put: slack
           params:
             text: |
@@ -173,7 +173,7 @@ jobs:
             path: src-api
             status: success
             base_context: concourse
-            context: test
+            context: test-api
         - put: slack
           params:
             text: |
@@ -183,34 +183,57 @@ jobs:
             username: ((slack-username))
             icon_url: ((slack-icon-url))   
 
-  # - name: test-admin-client
-  #   plan:
-  #     - get: src-admin-client
-  #       resource: src-all
-  #       trigger: true
-  #       params: {depth: 1}
-  #     - put: gh-status
-  #       inputs: [src-admin-client]
-  #       params: {state: pending}        
-  #     - do: *test-admin-client
-  #   on_failure:
-  #     in_parallel:
-  #       - put: gh-status
-  #         inputs: [src-admin-client]
-  #         params: {state: failure}          
-  #       - put: slack
-  #         params:
-  #           text: |
-  #             :x: FAILED pages admin client tests
-  #             ((build-url))
-  #             <@U01J8B463T5> <@U01J0M3E8NS> <@U01J7LKV5MZ>
-  #           channel: ((slack-channel))
-  #           username: ((slack-username))
-  #           icon_url: ((slack-icon-url))
-  #   on_success:
-  #     put: gh-status
-  #     inputs: [src-admin-client]
-  #     params: {state: success}
+  - name: test-admin-client-staging
+    plan:
+      - get: src-admin-client
+        resource: pr-staging
+        trigger: true
+        version: every
+      - put: src-admin-client
+        resource: pr-staging
+        params:
+          path: src-admin-client
+          status: pending
+          base_context: concourse
+          context: test-admin-client
+      - do: *test-admin-client
+      
+    on_failure:
+      in_parallel:
+        - put: src-admin-client
+          resource: pr-staging
+          params:
+            path: src-admin-client
+            status: failure
+            base_context: concourse
+            context: test-admin-client
+        - put: slack
+          params:
+            text: |
+              :x: FAILED: pages admin client tests on staging
+              ((build-url))
+              <@U01J8B463T5> <@U01J0M3E8NS> <@U01J7LKV5MZ>
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+
+    on_success:
+      in_parallel:
+        - put: src-admin-client
+          resource: pr-staging
+          params:
+            path: src-admin-client
+            status: success
+            base_context: concourse
+            context: test-admin-client
+        - put: slack
+          params:
+            text: |
+              :white_check_mark: SUCCESS: Successfully tested pages admin client on staging
+              ((build-url))
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))   
 
   - name: test-and-deploy-api-staging
     plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -131,34 +131,57 @@ test-admin-client: &test-admin-client
 
 jobs:
 
-  # - name: test-api
-  #   plan:
-  #     - get: src-api
-  #       resource: src-all
-  #       trigger: true
-  #       params: {depth: 1}
-  #     - put: gh-status
-  #       inputs: [src-api]
-  #       params: {state: pending}
-  #     - do: *test-api
-  #   on_failure:
-  #     in_parallel:
-  #       - put: gh-status
-  #         inputs: [src-api]
-  #         params: {state: failure}      
-  #       - put: slack
-  #         params:
-  #           text: |
-  #             :x: FAILED: pages api tests
-  #             ((build-url))
-  #             <@U01J8B463T5> <@U01J0M3E8NS> <@U01J7LKV5MZ>
-  #           channel: ((slack-channel))
-  #           username: ((slack-username))
-  #           icon_url: ((slack-icon-url))
-  #   on_success:
-  #     put: gh-status
-  #     inputs: [src-api]
-  #     params: {state: success}
+  - name: test-api-staging
+    plan:
+      - get: src-api
+        resource: pr-staging
+        trigger: true
+        version: every
+      - put: src-api
+        resource: pr-staging
+        params:
+          path: src-api
+          status: pending
+          base_context: concourse
+          context: test
+      - do: *test-api
+
+    on_failure:
+      in_parallel:
+        - put: src-api
+          resource: pr-staging
+          params:
+            path: src-api
+            status: failure
+            base_context: concourse
+            context: test
+        - put: slack
+          params:
+            text: |
+              :x: FAILED: pages api tests on staging
+              ((build-url))
+              <@U01J8B463T5> <@U01J0M3E8NS> <@U01J7LKV5MZ>
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+
+    on_success:
+      in_parallel:
+        - put: src-api
+          resource: pr-staging
+          params:
+            path: src-api
+            status: success
+            base_context: concourse
+            context: test
+        - put: slack
+          params:
+            text: |
+              :white_check_mark: SUCCESS: Successfully tested pages api on staging
+              ((build-url))
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))   
 
   # - name: test-admin-client
   #   plan:
@@ -417,11 +440,15 @@ jobs:
 
 resources:
 
-  # - name: src-all
-  #   type: git
-  #   icon: github
-  #   source:
-  #     uri: https://github.com/18F/federalist
+  - name: pr-staging
+    type: pull-request
+    check_every: 1m
+    source:
+      repository: 18F/federalist
+      access_token: ((gh-access-token))
+      base_branch: staging
+      disable_forks: true
+      ignore_drafts: false
 
   - name: src-staging
     type: git
@@ -429,13 +456,6 @@ resources:
     source:
       uri: https://github.com/18F/federalist   
       branch: staging
-
-  # - name: src-production
-  #   type: git
-  #   icon: github
-  #   source:
-  #     uri: https://github.com/18F/federalist   
-  #     branch: main
 
   - name: nightly
     type: time
@@ -491,6 +511,11 @@ resource_types:
     check_every: 24h
     source:
       repository: pix4d/cogito
+
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
 
   - name: slack-notification
     type: docker-image

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -205,7 +205,6 @@ describe('Site model', () => {
   });
 
   it('should validate that the subdomain is unique', async () => {
-    const errMsg = 'subdomain: Subdomains may only contain up to 63 alphanumeric and hyphen characters.';
     const site = await factory.site();
 
     const error = await factory.site({ subdomain: site.subdomain }).catch(e => e);

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -26,14 +26,15 @@ describe('Site model', () => {
   });
 
   describe('.withUsers', () => {
-    it('returns the site object with user association', () => {
-      factory.site({
+    it('returns the site object with user association', async () => {
+      const { id: siteId } = await factory.site({
         users: Promise.all([factory.user()]),
-      }).then(site => Site.withUsers(site.id))
-        .then((site) => {
-          expect(site.Users).to.be.an('array');
-          expect(site.Users.length).to.equal(1);
-        });
+      });
+
+      const site = await Site.withUsers(siteId);
+
+      expect(site.Users).to.be.an('array');
+      expect(site.Users.length).to.equal(1);
     });
   });
 


### PR DESCRIPTION
Resolves #3368 
- adds Concourse CI runs for PRs to `staging`
- fixes a test causing Deadlocks

This adds `concourse/test-api` and `concourse/test-admin-client` Github checks to PRs. Once merged to `staging` we should make these required as part of the branch protections for `staging` and remove CircleCIs `build-test-deploy`.