### PR TITLE
Upgrade js-yaml to 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
     - dependency-name: "uswds"
     # Temporary
     - dependency-name: "autoprefixer"
-    - dependency-name: "js-yaml"
     - dependency-name: "postcss-loader"
     - dependency-name: "react"
     - dependency-name: "react-dom"

--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -50,7 +50,7 @@ function serializeNew(site, isSystemAdmin = false) {
 
   yamlFields
     .filter(yamlField => object[yamlField])
-    .forEach((yamlField) => { filtered[yamlField] = yaml.safeDump(object[yamlField]); });
+    .forEach((yamlField) => { filtered[yamlField] = yaml.dump(object[yamlField]); });
 
   Object
     .keys(viewLinks)

--- a/api/utils/validators.js
+++ b/api/utils/validators.js
@@ -18,7 +18,7 @@ class CustomError extends Error {
 
 function isValidYaml(yamlString) {
   try {
-    yaml.safeLoad(yamlString);
+    yaml.load(yamlString);
   } catch (e) {
     // for Sequelize validators, we need to throw an error
     // on invalid values
@@ -33,7 +33,7 @@ function parseSiteConfig(siteConfig, configName = null) {
 
   try {
     if ((typeof siteConfig) === 'string' && siteConfig.length > 0) {
-      obj = yaml.safeLoad(siteConfig);
+      obj = yaml.load(siteConfig);
     }
 
     if ((typeof siteConfig) === 'object') { return siteConfig; }

--- a/frontend/util/validators.js
+++ b/frontend/util/validators.js
@@ -23,7 +23,7 @@ const validBasicAuthPassword = s => (/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,255}$/.
 
 function isValidYaml(yamlString) {
   try {
-    yaml.safeLoad(yamlString);
+    yaml.load(yamlString);
   } catch (e) {
     // for Sequelize validators, we need to throw an error
     // on invalid values

--- a/migrations/20190820200142-config-to-jsonb.js
+++ b/migrations/20190820200142-config-to-jsonb.js
@@ -8,15 +8,15 @@ const cmdGetSitesText = 'SELECT id, config, "demoConfig", "previewConfig" from s
 const convertSiteConfigsToJSON = (db, site) => {
   const atts = [];
   if (site.config && site.config.trim().length > 0) {
-    atts.push(`"defaultConfig" = '${JSON.stringify(yaml.safeLoad(site.config.trim()))}'::jsonb`);
+    atts.push(`"defaultConfig" = '${JSON.stringify(yaml.load(site.config.trim()))}'::jsonb`);
   }
 
   if (site.demoConfig && site.demoConfig.trim().length > 0) {
-    atts.push(`"demoConfig" = '${JSON.stringify(yaml.safeLoad(site.demoConfig.trim()))}'::jsonb`);
+    atts.push(`"demoConfig" = '${JSON.stringify(yaml.load(site.demoConfig.trim()))}'::jsonb`);
   }
 
   if (site.previewConfig && site.previewConfig.trim().length > 0) {
-    atts.push(`"previewConfig" = '${JSON.stringify(yaml.safeLoad(site.previewConfig.trim()))}'::jsonb`);
+    atts.push(`"previewConfig" = '${JSON.stringify(yaml.load(site.previewConfig.trim()))}'::jsonb`);
   }
 
   const cmdUpdateSiteRecord = `

--- a/migrations/20200716100000-set-site-subdomain.js
+++ b/migrations/20200716100000-set-site-subdomain.js
@@ -1,4 +1,3 @@
-const yaml = require('js-yaml');
 const { generateSubdomain } = require('../api/utils');
 
 const getSites = 'SELECT id, owner, repository from site';

--- a/migrations/20200826100000-update-site-subdomains.js
+++ b/migrations/20200826100000-update-site-subdomains.js
@@ -1,4 +1,3 @@
-const yaml = require('js-yaml');
 const { generateSubdomain, generateS3ServiceName } = require('../api/utils');
 
 const getSites = 'SELECT id, owner, repository from site';

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express-slow-down": "^1.4.0",
     "express-winston": "^4.0.5",
     "js-file-download": "^0.4.11",
-    "js-yaml": "^3.14.1",
+    "js-yaml": "^4.1.0",
     "json-to-csv": "^1.0.0",
     "jsonwebtoken": "^8.5.1",
     "method-override": "^3.0.0",

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -1552,9 +1552,9 @@ describe('Site API', () => {
         previewConfig: { name: 'old-preview-config' },
       };
       const newConfigs = {
-        defaultConfig: yaml.safeDump({ name: 'new-config' }),
-        demoConfig: yaml.safeDump({ name: 'new-demo-config' }),
-        previewConfig: yaml.safeDump({ name: 'new-preview-config' }),
+        defaultConfig: yaml.dump({ name: 'new-config' }),
+        demoConfig: yaml.dump({ name: 'new-demo-config' }),
+        previewConfig: yaml.dump({ name: 'new-preview-config' }),
       };
       factory.site(origConfigs)
         .then(s => Site.findByPk(s.id, { include: [User] }))
@@ -1574,11 +1574,11 @@ describe('Site API', () => {
         })
         .then((foundSite) => {
           validateAgainstJSONSchema('PUT', '/site/{id}', 200, response.body);
-          expect(yaml.safeLoad(response.body.defaultConfig).name).to.equal('new-config');
+          expect(yaml.load(response.body.defaultConfig).name).to.equal('new-config');
           expect(foundSite.defaultConfig.name).to.equal('new-config');
-          expect(yaml.safeLoad(response.body.demoConfig).name).to.equal('new-demo-config');
+          expect(yaml.load(response.body.demoConfig).name).to.equal('new-demo-config');
           expect(foundSite.demoConfig.name).to.equal('new-demo-config');
-          expect(yaml.safeLoad(response.body.previewConfig).name).to.equal('new-preview-config');
+          expect(yaml.load(response.body.previewConfig).name).to.equal('new-preview-config');
           expect(foundSite.previewConfig.name).to.equal('new-preview-config');
           siteResponseExpectations(response.body, foundSite);
           done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6717,13 +6717,20 @@ js-yaml@4.0.0, js-yaml@4.0.x:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.13.1, js-yaml@^3.14.1:
+js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Resolves #3375 

The `safe` methods have been removed in v4 as the normal methods are now safe by default.