### PR TITLE
Replace instances of `secureauth` with `cloud.gov authentication`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,14 +159,14 @@ The app expects the following user provided services to be provided:
   - `secret_key`: The AWS secret key for SQS queue
   - `region`: The AWS region
   - `sqs_url`: The AWS SQS queue URL
-- `admin-<environment>-uaa-client`: Credentials for cloud.gov's UAA to support authentication for the admin app via SecureAuth. This service provides the following:
+- `admin-<environment>-uaa-client`: Credentials for cloud.gov's UAA to support authentication for the admin app. This service provides the following:
   - `clientID`: The UAA client id for the environments admin app
   - `clientSecret`: The UAA client secret for the environments admin app
   - `authorizationURL`: The url to login and authorize a user
   - `tokenURL`: The UAA url to get a user's token
   - `userURL`: The UAA url to get a user's info
   - `logoutURL`: The UAA url to logout a user
-- `app-<environment>-uaa-client`: Credentials for cloud.gov's UAA to support authentication for the app via SecureAuth. This service provides the following:
+- `app-<environment>-uaa-client`: Credentials for cloud.gov's UAA to support authentication for the app. This service provides the following:
   - `clientID`: The UAA client id for the environments app
   - `clientSecret`: The UAA client secret for the environments app
   - `authorizationURL`: The url to login and authorize a user

--- a/views/home.njk
+++ b/views/home.njk
@@ -15,7 +15,7 @@
             <a href="/login">
               <button class="usa-button">
                 {% if isUAA %}
-                  Agree and continue with SecureAuth
+                  Agree and continue with cloud.gov authentication
                   {% else %}
                   <img src="/images/github-logo.png"> Agree and continue with GitHub
                 {% endif %}
@@ -23,7 +23,7 @@
             </a>
           </div>
           <p></p>
-          <p>Federalist users are authenticated with {% if isUAA %} SecureAuth {% else %} GitHub OAuth {% endif %}.<br></p>
+          <p>Federalist users are authenticated with {% if isUAA %} cloud.gov {% else %} GitHub OAuth {% endif %}.<br></p>
           {% if isUAA %}
           {% else %}
             <p>If your office uses Federalist, ask your team’s primary contact to send an email to federalist-support@gsa.gov with the GitHub usernames that need access.</p>


### PR DESCRIPTION
Resolves #3336 