### PR TITLE
Update the live URL link to documentation

### DIFF
--- a/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
@@ -24,7 +24,7 @@ export const BasicSiteSettings = ({
           After your DNS is pointed to Federalist, you&apos;ll set the
           {' '}
           <a
-            href="https://federalist.18f.gov/pages/how-federalist-works/custom-urls/"
+            href="https://federalist.18f.gov/documentation/custom-domains/#update-your-site-settings"
             target="_blank"
             rel="noopener noreferrer"
             title="Custom URL documentation"


### PR DESCRIPTION
Fix the "live URL" link to the documentation when setting up a custom domain for a site.