### PR TITLE
Add stubs for env vars that are interpolated in concourse for pages

### DIFF
--- a/.cloudgov/vars/production.yml
+++ b/.cloudgov/vars/production.yml
@@ -11,3 +11,9 @@ feature_proxy_edge_dynamo: 'false'
 feature_bull_site_build_queue: 'false'
 uaa_host: https://uaa.fr.cloud.gov
 new_relic_app_name: web
+smtp_cert: NA
+smtp_from: NA
+smtp_host: NA
+smtp_password: NA
+smtp_port: NA
+smtp_user: NA


### PR DESCRIPTION
Not sure if CF will bork if these aren't defined.