### PR TITLE
Add better error message for 401

### DIFF
--- a/api/responses/unauthorized.js
+++ b/api/responses/unauthorized.js
@@ -1,7 +1,7 @@
 module.exports = (error = {}, { res }) => {
   res.status(401);
   return res.json({
-    message: error.message || 'Unauthorized',
+    message: error.message || 'Unauthorized. If you need access to Federalist, please message #federalist-support on Slack and include your GitHub username.',
     status: 401,
   });
 };


### PR DESCRIPTION
If we can't modify the Federalist OAuth to be less restrictive, the next best solution, in my view, is to give folks a better error message. Specifically, I'd like for it to be more clear where you need to go to get access to Federalist services. 

Open to suggestions on how to word this!