### PR TITLE
Use proxy domain for preview urls

### DIFF
--- a/api/utils/build.js
+++ b/api/utils/build.js
@@ -11,9 +11,9 @@ function buildPath(build, site) {
 }
 
 function buildUrl(build, site) {
-  const { domain } = config.app;
+  const { proxyDomain } = config.app;
   const path = buildPath(build, site);
-  return `https://${site.awsBucketName}.${domain}${path}`;
+  return `https://${site.awsBucketName}.${proxyDomain}${path}`;
 }
 
 function buildViewLink(build, site) {


### PR DESCRIPTION
Fix typo that uses app domain instead of proxy domain in preview urls.