### PR TITLE
2992 remove webhook on delete

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -29,6 +29,7 @@ applications:
       - federalist-site-wide-error
       - ((product))-((env))-s3-build-logs
       - mailer
+      - slack
     env:
       NODE_ENV: production
       APP_ENV: ((env))

--- a/admin-client/src/flows/destroySite.js
+++ b/admin-client/src/flows/destroySite.js
@@ -2,14 +2,14 @@ import page from 'page';
 import { notification } from '../stores';
 import { destroySite } from '../lib/api';
 
-function destroy(id) {
+function destroy(site) {
   return async () => {
     try {
-      const result = await destroySite(id);
+      await destroySite(site.id);
       page('/sites');
-      return notification.setSuccess(`Site ${result.id}: ${result.repository} deleted successfully!`);
+      return notification.setSuccess(`Site ${site.id}: ${site.repository} deleted successfully!`);
     } catch (error) {
-      return notification.setError(`Unable to delete site ${id}: ${error.message}`);
+      return notification.setError(`Unable to delete site ${site.id}: ${error.message}`);
     }
   };
 }

--- a/api/admin/controllers/site.js
+++ b/api/admin/controllers/site.js
@@ -70,7 +70,9 @@ module.exports = wrapHandlers({
     const { id } = req.params;
 
     const site = await fetchModelById(id, Site);
+
+    // This will not remove the webhook since we don't have permissions
     await SiteDestroyer.destroySite(site);
-    return res.json(serializeNew(site, true));
+    return res.json({});
   },
 });

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -65,9 +65,8 @@ module.exports = wrapHandlers({
     }
 
     await authorizer.destroy(user, site);
-    const siteJSON = siteSerializer.serializeNew(site);
-    await SiteDestroyer.destroySite(site);
-    return res.json(siteJSON);
+    await SiteDestroyer.destroySite(site, user);
+    return res.json({});
   },
 
   async addUser(req, res) {

--- a/api/queues/SlackQueue.js
+++ b/api/queues/SlackQueue.js
@@ -1,0 +1,23 @@
+const { Queue } = require('bullmq');
+
+const SlackQueueName = 'slack';
+
+class SlackQueue extends Queue {
+  constructor(connection) {
+    super(SlackQueueName, {
+      connection,
+      defaultJobOptions: {
+        attempts: 5,
+        backoff: {
+          type: 'exponential',
+          delay: 3000,
+        },
+      },
+    });
+  }
+}
+
+module.exports = {
+  SlackQueue,
+  SlackQueueName,
+};

--- a/api/queues/index.js
+++ b/api/queues/index.js
@@ -1,9 +1,12 @@
 const { MailQueue, MailQueueName } = require('./MailQueue');
 const { ScheduledQueue, ScheduledQueueName } = require('./ScheduledQueue');
+const { SlackQueue, SlackQueueName } = require('./SlackQueue');
 
 module.exports = {
   MailQueue,
   MailQueueName,
   ScheduledQueue,
   ScheduledQueueName,
+  SlackQueue,
+  SlackQueueName,
 };

--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -9,7 +9,8 @@ const createWebhook = (github, options) => github.repos.createWebhook(options);
 
 const deleteWebhook = (github, options) => github.repos.deleteWebhook(options);
 
-const listWebhooks = (github, options) => github.repos.listWebhooks(options);
+const listWebhooks = (github, options) => github.repos.listWebhooks(options)
+  .then(hooks => hooks.data);
 
 const getOrganizations = github => github.orgs.listForAuthenticatedUser().then(orgs => orgs.data);
 
@@ -72,6 +73,13 @@ const handleWebhookError = (err) => {
   } else {
     throw error;
   }
+};
+
+const ignore404 = (error) => {
+  if (error.status !== 404) {
+    throw error;
+  }
+  return null;
 };
 
 const sendNextCreateGithubStatusRequest = (github, options) => github.repos.createCommitStatus(
@@ -163,21 +171,22 @@ async function findWebhookId(github, site) {
 
   const { app_env: appEnv } = config.app;
 
-  //
-  // Hardcoded since:
+  // Hardcoded for staging and production since:
   // - only Federalist webhooks will be missing webhook Ids
   // - webhooks will only be present for production and staging environments
   // - this isn't configured by environment bc if this is Pages, we still want to remove the
   //   Federalist webhook and Pages webhooks will be stored in the site model so this function
   //   will not be called.
-  //
-  const ext = appEnv === 'staging' ? '-staging' : '';
-  const hookUrl = `https://federalistapp${ext}.18f.gov/webhook/github`;
+  const hookUrl = {
+    production: 'https://federalistapp.18f.gov/webhook/github',
+    staging: 'https://federalistapp-staging.18f.gov/webhook/github',
+  }[appEnv] || config.webhook.endpoint;
 
-  const hooks = await listWebhooks(github, { owner, repo });
-  const federalistHook = hooks.data.find(hook => hook.config.url === hookUrl);
+  const hooks = (await listWebhooks(github, { owner, repo }).catch(ignore404)) || [];
 
-  return federalistHook?.id;
+  const federalistHook = hooks.find(hook => hook.config.url === hookUrl);
+
+  return federalistHook?.config.id;
 }
 
 module.exports = {
@@ -257,8 +266,7 @@ module.exports = {
   deleteWebhook: async (site, githubAccessToken) => {
     const github = await githubClient(githubAccessToken);
 
-    const webhookId = site.webhookId || await findWebhookId(github, site)
-      .catch(handleWebhookError);
+    const webhookId = site.webhookId || await findWebhookId(github, site);
 
     if (!webhookId) {
       return null;
@@ -267,7 +275,7 @@ module.exports = {
     const { owner, repository: repo } = site;
 
     return deleteWebhook(github, { owner, repo, hook_id: webhookId })
-      .catch(handleWebhookError);
+      .catch(ignore404);
   },
 
   validateUser: (accessToken, throwOnUnauthorized = true) => {

--- a/api/services/SiteDestroyer.js
+++ b/api/services/SiteDestroyer.js
@@ -1,14 +1,27 @@
+const Mailer = require('./mailer');
+const Github = require('./GitHub');
 const S3SiteRemover = require('./S3SiteRemover');
 
-async function destroySite(site) {
-  const destroyComponents = [
+async function destroySite(site, user) {
+  await site.destroy();
+
+  // TODO move to background job
+  // Don't wait for the infra, this should be all good from the user's point of view
+  Promise.allSettled([
+    user && Github.deleteWebhook(site, user.githubAccessToken),
     S3SiteRemover.removeSite(site)
       .then(() => S3SiteRemover.removeInfrastructure(site)),
-    site.destroy(),
-  ];
+  ])
+    .then((results) => {
+      const errors = results
+        .filter(result => result.status === 'rejected')
+        .map(rejected => rejected.reason);
 
-  await Promise.all(destroyComponents);
-  return site;
+      if (errors.length > 0) {
+        const reason = `Site deletion failed for id: ${site.id} - ${site.owner}/${site.repository}`;
+        Mailer.sendAlert(reason, errors);
+      }
+    });
 }
 
 module.exports = {

--- a/api/services/mailer/index.js
+++ b/api/services/mailer/index.js
@@ -26,7 +26,7 @@ function init(connection) {
 async function sendUAAInvite(email, link) {
   ensureInit();
   return mailQueue.add('uaa-invite', {
-    to: email,
+    to: [email],
     subject: 'Invitation to join cloud.gov Pages',
     html: Templates.uaaInvite({ link }),
   });
@@ -35,7 +35,7 @@ async function sendUAAInvite(email, link) {
 async function sendAlert(reason, errors) {
   ensureInit();
   return mailQueue.add('alert', {
-    to: ['federalist-admins@gsa.gov'],
+    to: ['federalist-alerts@gsa.gov'],
     subject: `Federalist ${appEnv} Alert | ${reason}`,
     html: Templates.alert({ errors, reason }),
   });

--- a/api/services/mailer/index.js
+++ b/api/services/mailer/index.js
@@ -1,7 +1,9 @@
 const IORedis = require('ioredis');
-const { redis: redisConfig } = require('../../../config');
+const config = require('../../../config');
 const { MailQueue } = require('../../queues');
 const Templates = require('./templates');
+
+const { redis: redisConfig, app: { app_env: appEnv } } = config;
 
 let mailQueue;
 
@@ -30,7 +32,17 @@ async function sendUAAInvite(email, link) {
   });
 }
 
+async function sendAlert(reason, errors) {
+  ensureInit();
+  return mailQueue.add('alert', {
+    to: ['federalist-admins@gsa.gov'],
+    subject: `Federalist ${appEnv} Alert | ${reason}`,
+    html: Templates.alert({ errors, reason }),
+  });
+}
+
 module.exports = {
   init,
   sendUAAInvite,
+  sendAlert,
 };

--- a/api/services/mailer/templates/alert.js
+++ b/api/services/mailer/templates/alert.js
@@ -1,0 +1,14 @@
+const layout = require('./layout');
+
+function alert({ errors, reason }) {
+  return layout(`
+    <p><strong>${reason}</strong></p>
+    <p>
+      <ul>
+        ${errors.map(error => `<li>${error}</li>`)}
+      </ul>
+    </p>
+  `);
+}
+
+module.exports = alert;

--- a/api/services/mailer/templates/index.js
+++ b/api/services/mailer/templates/index.js
@@ -1,5 +1,9 @@
+const alert = require('./alert');
+const layout = require('./layout');
 const uaaInvite = require('./uaaInvite');
 
 module.exports = {
+  alert,
+  layout,
   uaaInvite,
 };

--- a/api/services/mailer/templates/layout.js
+++ b/api/services/mailer/templates/layout.js
@@ -1,0 +1,16 @@
+function layout(content) {
+  return `
+    <!DOCTYPE html>
+
+    <html>
+      <head lang="en">
+        <meta charset="UTF-8" />
+      </head>
+      <body>
+        ${content}
+      </body>
+    </html>
+  `;
+}
+
+module.exports = layout;

--- a/api/services/mailer/templates/uaaInvite.js
+++ b/api/services/mailer/templates/uaaInvite.js
@@ -1,53 +1,46 @@
-function uaaInvite({ link }) {
-  return `
-    <!DOCTYPE html>
+const layout = require('./layout');
 
-    <html>
-      <head lang="en">
-        <meta charset="UTF-8" />
-      </head>
-      <body>
-        <p>Hello!</p>
-        <p>
-          You've been invited to join
-          <a href="https://cloud.gov/pages">cloud.gov Pages [1]</a>.
-        </p>
-        <p>
-          cloud.gov Pages is a publishing platform for modern <a href="https://federalist.18f.gov/documentation/21st-century-idea/">21st Century IDEA </a>websites. There's no easier way to build, launch, and manage government sites.
-        </p>
-        <strong>Your next steps</strong>
-        <p>
-        <ol>
-          <li>
-          <strong>Accept the invitation</strong> - <a href="${link}">Accept your invite [2]</a> to continue the registration process. (The invitation will expire after 24 hours.) You can also copy the URL below and paste it into your browser's address bar:
-          <br />
-          ${link}
-          </li>
-          <li>
-            <strong>Read the documentation</strong> - After you register and log in, review the <a href="https://federalist.18f.gov/documentation/customer-responsibilities">customer responsibilities [3]</a>.
-          </li>
-          <li>
-          <strong>Then <a href="https://federalist.18f.gov/documentation/">set up your access and get started [4]</a></strong>.
-          </li>
-        </ol>
-        </p>
-        <p>
-          If you run into problems or have any questions, please email us at <a href="mailto:federalist-support@gsa.gov">federalist-support@gsa.gov</a>.
-        </p>
-        <p>
-          Thank you,<br />
-          cloud.gov Pages team
-        </p>
-        <hr>
-        <ul>
-          <li>[1] cloud.gov Pages: https://cloud.gov/pages</li>
-          <li>[2] Accept your invite: ${link}</li>
-          <li>[3] Customer responsibilities: https://federalist.18f.gov/documentation/customer-responsibilities</li>
-          <li>[4] Set up your access and get started: https://federalist.18f.gov/documentation/</li>
-        </ul>
-      </body>
-    </html>
-  `;
+function uaaInvite({ link }) {
+  return layout(`
+    <p>Hello!</p>
+    <p>
+      You've been invited to join
+      <a href="https://cloud.gov/pages">cloud.gov Pages [1]</a>.
+    </p>
+    <p>
+      cloud.gov Pages is a publishing platform for modern <a href="https://federalist.18f.gov/documentation/21st-century-idea/">21st Century IDEA </a>websites. There's no easier way to build, launch, and manage government sites.
+    </p>
+    <strong>Your next steps</strong>
+    <p>
+    <ol>
+      <li>
+      <strong>Accept the invitation</strong> - <a href="${link}">Accept your invite [2]</a> to continue the registration process. (The invitation will expire after 24 hours.) You can also copy the URL below and paste it into your browser's address bar:
+      <br />
+      ${link}
+      </li>
+      <li>
+        <strong>Read the documentation</strong> - After you register and log in, review the <a href="https://federalist.18f.gov/documentation/customer-responsibilities">customer responsibilities [3]</a>.
+      </li>
+      <li>
+      <strong>Then <a href="https://federalist.18f.gov/documentation/">set up your access and get started [4]</a></strong>.
+      </li>
+    </ol>
+    </p>
+    <p>
+      If you run into problems or have any questions, please email us at <a href="mailto:federalist-support@gsa.gov">federalist-support@gsa.gov</a>.
+    </p>
+    <p>
+      Thank you,<br />
+      cloud.gov Pages team
+    </p>
+    <hr>
+    <ul>
+      <li>[1] cloud.gov Pages: https://cloud.gov/pages</li>
+      <li>[2] Accept your invite: ${link}</li>
+      <li>[3] Customer responsibilities: https://federalist.18f.gov/documentation/customer-responsibilities</li>
+      <li>[4] Set up your access and get started: https://federalist.18f.gov/documentation/</li>
+    </ul>
+  `);
 }
 
 module.exports = uaaInvite;

--- a/api/services/slacker/index.js
+++ b/api/services/slacker/index.js
@@ -1,0 +1,38 @@
+const IORedis = require('ioredis');
+const config = require('../../../config');
+const { SlackQueue } = require('../../queues');
+const Templates = require('./templates');
+
+const { redis: redisConfig, app: { app_env: appEnv } } = config;
+
+let slackQueue;
+
+function ensureInit() {
+  if (!slackQueue) {
+    throw new Error('Slack Queue is not initialized, did you forget to call `init()`?');
+  }
+}
+
+function createConnection() {
+  return new IORedis(redisConfig.url, {
+    tls: redisConfig.tls,
+  });
+}
+
+function init(connection) {
+  slackQueue = new SlackQueue(connection || createConnection());
+}
+
+async function sendAlert(reason, errors) {
+  ensureInit();
+  return slackQueue.add('alert', {
+    channel: 'federalist-supportstream',
+    text: Templates.alert({ errors, reason }),
+    username: `Federalist ${appEnv} Alerts`,
+  });
+}
+
+module.exports = {
+  init,
+  sendAlert,
+};

--- a/api/services/slacker/templates/alert.js
+++ b/api/services/slacker/templates/alert.js
@@ -1,0 +1,9 @@
+function alert({ errors, reason }) {
+  return `
+    :flashing-alert: *${reason}*
+  
+    ${errors.map(error => `- ${error}`)}
+  `;
+}
+
+module.exports = alert;

--- a/api/services/slacker/templates/index.js
+++ b/api/services/slacker/templates/index.js
@@ -1,0 +1,5 @@
+const alert = require('./alert');
+
+module.exports = {
+  alert,
+};

--- a/api/workers/QueueWorker.js
+++ b/api/workers/QueueWorker.js
@@ -11,11 +11,11 @@ class QueueWorker extends Worker {
     });
 
     this.on('completed', (job) => {
-      logger.info(`Job Complete on '${queueName}' Queue: ${JSON.stringify(job)}`);
+      logger.info(`Job Complete on '${queueName}' Queue: ${job.toJSON()}`);
     });
 
     this.on('failed', (job, failedReason) => {
-      logger.error(`Job Failed on '${queueName}' Queue: ${JSON.stringify(job)}`, failedReason);
+      logger.error(`Job Failed on '${queueName}' Queue: ${job.toJSON()}`, failedReason);
     });
   }
 }

--- a/api/workers/Slack.js
+++ b/api/workers/Slack.js
@@ -1,0 +1,20 @@
+const HttpClient = require('../utils/httpClient');
+
+const { slack } = require('../../config');
+
+class Slack {
+  constructor({ url } = slack) {
+    this.httpClient = new HttpClient();
+    this.url = url;
+  }
+
+  send({ channel, text, username }) {
+    return this.httpClient.request({
+      method: 'POST',
+      url: this.url,
+      data: { channel, text, username },
+    });
+  }
+}
+
+module.exports = Slack;

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -140,3 +140,9 @@ module.exports.mailer = {
   password: mailerCredentials.password,
   username: mailerCredentials.username,
 };
+
+const slackCredentials = appEnv.getServiceCreds('slack');
+
+module.exports.mailer = {
+  url: slackCredentials.url,
+};

--- a/config/mailer.js
+++ b/config/mailer.js
@@ -1,0 +1,3 @@
+module.exports = {
+  host: 'http://echo:8989',
+};

--- a/config/slack.js
+++ b/config/slack.js
@@ -1,0 +1,3 @@
+module.exports = {
+  url: 'http://echo:8989',
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,18 @@ services:
     depends_on:
       - db
       - redis
+      - echo
     environment:
       APP_HOSTNAME: http://localhost:1337
       NODE_ENV: development
+  echo:
+    image: node:16
+    volumes:
+      - yarn:/usr/local/share/.cache/yarn
+      - .:/app
+      - /app/admin-client/
+      - nm-app:/app/node_modules
+    environment:
+      HOST: 0.0.0.0
+      PORT: 8989
+    command: node app/scripts/echo.js

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -562,7 +562,7 @@ paths:
         200:
           description: Acknowledgement that the site was deleted
           schema:
-            $ref: "Site.json"
+            type: object
         403:
           description: Not authorized
           schema:

--- a/scripts/echo.js
+++ b/scripts/echo.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-console */
+const Http = require('http');
+
+const {
+  HOST = 'localhost',
+  PORT = 8989,
+} = process.env;
+
+const dateFormat = new Intl.DateTimeFormat('en', { dateStyle: 'short', timeStyle: 'medium' });
+
+const server = Http.createServer(async (req, res) => {
+  res.writeHead(200);
+  res.end();
+
+  const buffers = [];
+
+  for await (const chunk of req) {
+    buffers.push(chunk);
+  }
+
+  const data = Buffer.concat(buffers).toString();
+  const { headers, method, url } = req;
+  const { pathname, searchParams } = new URL(url, `http://${headers.host}`);
+
+  console.log(`
+    ${dateFormat.format(new Date())}
+    ${method.toUpperCase()} ${pathname}
+      headers: ${JSON.stringify(headers)}
+      search: ${searchParams}
+      body: ${data}
+  `);
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Echo server listening on ${HOST}:${PORT}`);
+});

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -1257,8 +1257,7 @@ describe('Site API', () => {
           .set('Cookie', cookie)
           .expect(200))
         .then((response) => {
-          validateAgainstJSONSchema('DELETE', '/site/{id}', 200, response.body);
-          siteResponseExpectations(response.body, site);
+          expect(response.body).to.deep.eq({});
           return Site.findAll({ where: { id: site.id } });
         })
         .then((sites) => {
@@ -1387,8 +1386,7 @@ describe('Site API', () => {
           .set('Cookie', cookie)
           .expect(200))
         .then((response) => {
-          validateAgainstJSONSchema('DELETE', '/site/{id}', 200, response.body);
-          siteResponseExpectations(response.body, site);
+          expect(response.body).to.deep.eq({});
           return Site.findAll({ where: { id: site.id } });
         })
         .then((sites) => {

--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -304,6 +304,24 @@ const webhook = ({
   return webhookNock.reply(...resp);
 };
 
+function deleteWebhook({
+  accessToken, owner, repo: repository, webhookId, response,
+}) {
+  return nock('https://api.github.com')
+    .matchHeader('authorization', `token ${accessToken}`)
+    .delete(`/repos/${owner}/${repository}/hooks/${webhookId}`)
+    .reply(...response);
+}
+
+function listWebhooks({
+  accessToken, owner, repo: repository, response,
+}) {
+  return nock('https://api.github.com')
+    .matchHeader('authorization', `token ${accessToken}`)
+    .get(`/repos/${owner}/${repository}/hooks`)
+    .reply(...response);
+}
+
 const getBranch = ({
   // eslint-disable-next-line no-shadow
   accessToken, owner, repo, branch, expected,
@@ -488,6 +506,8 @@ module.exports = {
   user,
   userOrganizations,
   webhook,
+  deleteWebhook,
+  listWebhooks,
   getBranch,
   getTeamMembers,
   getOrganizationMembers,

--- a/test/api/unit/services/Mailer.test.js
+++ b/test/api/unit/services/Mailer.test.js
@@ -4,27 +4,44 @@ const Mailer = require('../../../../api/services/mailer');
 const Templates = require('../../../../api/services/mailer/templates');
 
 describe('mailer', () => {
-  describe('.sendUAAInvite()', () => {
-    context('when the Mailer has not been initialized', () => {
-      it('throws an error', async () => {
-        const error = await Mailer.sendUAAInvite().catch(e => e);
+  context('when the Mailer has not been initialized', () => {
+    // This test can only be run once since Mailer is a singleton
+    it('throws an error', async () => {
+      const error = await Mailer.sendUAAInvite().catch(e => e);
 
-        expect(error).to.be.an('error');
-        expect(error.message).to.eq('Mail Queue is not initialized, did you forget to call `init()`?');
-      });
+      expect(error).to.be.an('error');
+      expect(error.message).to.eq('Mail Queue is not initialized, did you forget to call `init()`?');
+    });
+  });
+
+  context('when the Mailer has been initialized', () => {
+    before(() => {
+      Mailer.init();
     });
 
-    context('when the Mailer has been initialized', async () => {
+    describe('.sendUAAInvite()', () => {
       it('adds a `uaa-invite` job to the mail queue', async () => {
         const email = 'foo@bar.gov';
         const link = 'https://foobar.gov';
 
-        Mailer.init();
         const job = await Mailer.sendUAAInvite(email, link);
 
         expect(job.name).to.eq('uaa-invite');
-        expect(job.data.to).to.eq(email);
+        expect(job.data.to).to.deep.eq([email]);
         expect(job.data.html).to.eq(Templates.uaaInvite({ link }));
+      });
+    });
+
+    describe('.sendAlert()', () => {
+      it('adds a `alert` job to the mail queue', async () => {
+        const errors = ['some error message'];
+        const reason = 'something bad happened';
+
+        const job = await Mailer.sendAlert(reason, errors);
+
+        expect(job.name).to.eq('alert');
+        expect(job.data.to).to.deep.eq(['federalist-alerts@gsa.gov']);
+        expect(job.data.html).to.eq(Templates.alert({ errors, reason }));
       });
     });
   });

--- a/test/api/unit/services/SiteDestroyer.test.js
+++ b/test/api/unit/services/SiteDestroyer.test.js
@@ -1,0 +1,118 @@
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+
+const { Site, User } = require('../../../../api/models');
+
+const factory = require('../../support/factory');
+
+const stubs = {
+  './mailer': {
+    sendAlert: sinon.stub().resolves(),
+  },
+  './slacker': {
+    sendAlert: sinon.stub().resolves(),
+  },
+  './GitHub': {
+    deleteWebhook: sinon.stub().resolves(),
+  },
+  './S3SiteRemover': {
+    removeSite: sinon.stub().resolves(),
+    removeInfrastructure: sinon.stub().resolves(),
+  },
+};
+
+const SiteDestroyer = proxyquire('../../../../api/services/SiteDestroyer', stubs);
+
+describe('SiteDestroyer', () => {
+  afterEach(async () => {
+    await Promise.all([
+      Site.truncate({ force: true, cascade: true }),
+      User.truncate({ force: true, cascade: true }),
+    ]);
+  });
+
+  describe('.destroySite(site, user)', () => {
+    beforeEach(() => {
+      sinon.stub(SiteDestroyer, 'destroySiteInfra').resolves();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('destroys the site if it exists', async () => {
+      const site = await factory.site();
+      const user = null;
+
+      await SiteDestroyer.destroySite(site, user);
+
+      await site.reload({ paranoid: false });
+
+      expect(site.isSoftDeleted()).to.be.true;
+      sinon.assert.calledOnceWithExactly(SiteDestroyer.destroySiteInfra, site, user);
+    });
+
+    it('throws an error when the site cannot be destroyed', async () => {
+      const error = await SiteDestroyer.destroySite(null, null).catch(e => e);
+
+      expect(error).to.be.an('error');
+      sinon.assert.notCalled(SiteDestroyer.destroySiteInfra);
+    });
+  });
+
+  describe('.destroySiteInfra(site, user)', () => {
+    afterEach(() => {
+      // sinon.resetHistory() doesn't work here, maybe bc the stubs are created outside of the
+      // test case?
+      stubs['./GitHub'].deleteWebhook.resetHistory();
+      stubs['./S3SiteRemover'].removeSite.resetHistory();
+      stubs['./S3SiteRemover'].removeInfrastructure.resetHistory();
+      stubs['./mailer'].sendAlert.resetHistory();
+      stubs['./slacker'].sendAlert.resetHistory();
+    });
+
+    it('removes the infra AND deletes the webhook when the user is provided', async () => {
+      const [site, user] = await Promise.all([
+        factory.site(),
+        factory.user(),
+      ]);
+
+      await SiteDestroyer.destroySiteInfra(site, user);
+
+      sinon.assert.calledOnceWithExactly(stubs['./GitHub'].deleteWebhook, site, user.githubAccessToken);
+      sinon.assert.calledOnceWithExactly(stubs['./S3SiteRemover'].removeSite, site);
+      sinon.assert.calledOnceWithExactly(stubs['./S3SiteRemover'].removeInfrastructure, site);
+      sinon.assert.notCalled(stubs['./mailer'].sendAlert);
+      sinon.assert.notCalled(stubs['./slacker'].sendAlert);
+    });
+
+    it('removes the infra when the user is not provided', async () => {
+      const site = await factory.site();
+
+      await SiteDestroyer.destroySiteInfra(site, null);
+
+      sinon.assert.calledOnceWithExactly(stubs['./S3SiteRemover'].removeSite, site);
+      sinon.assert.calledOnceWithExactly(stubs['./S3SiteRemover'].removeInfrastructure, site);
+      sinon.assert.notCalled(stubs['./mailer'].sendAlert);
+      sinon.assert.notCalled(stubs['./slacker'].sendAlert);
+    });
+
+    it('sends an alert if anything fails', async () => {
+      const stub = stubs['./S3SiteRemover'].removeSite;
+      stub.resetBehavior();
+      stub.rejects(new Error('Yikes'));
+
+      const site = await factory.site();
+
+      const error = await SiteDestroyer.destroySiteInfra(site, null).catch(e => e);
+
+      sinon.assert.calledOnceWithExactly(stubs['./S3SiteRemover'].removeSite, site);
+      sinon.assert.notCalled(stubs['./S3SiteRemover'].removeInfrastructure);
+      sinon.assert.calledOnce(stubs['./mailer'].sendAlert);
+      sinon.assert.calledOnce(stubs['./slacker'].sendAlert);
+
+      expect(error).to.be.an('error');
+    });
+  });
+});

--- a/test/api/unit/services/Slacker.test.js
+++ b/test/api/unit/services/Slacker.test.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+
+const config = require('../../../../config');
+const Slacker = require('../../../../api/services/slacker');
+const Templates = require('../../../../api/services/slacker/templates');
+
+describe('slacker', () => {
+  context('when the Slacker has not been initialized', () => {
+    // This test can only be run once since Slacker is a singleton
+    it('throws an error', async () => {
+      const error = await Slacker.sendAlert().catch(e => e);
+
+      expect(error).to.be.an('error');
+      expect(error.message).to.eq('Slack Queue is not initialized, did you forget to call `init()`?');
+    });
+  });
+
+  context('when the Slacker has been initialized', () => {
+    before(() => {
+      Slacker.init();
+    });
+
+    describe('.sendAlert()', () => {
+      it('adds a `alert` job to the slack queue', async () => {
+        const errors = ['some error message'];
+        const reason = 'something bad happened';
+
+        const job = await Slacker.sendAlert(reason, errors);
+
+        expect(job.name).to.eq('alert');
+        expect(job.data.channel).to.eq('federalist-supportstream');
+        expect(job.data.text).to.eq(Templates.alert({ errors, reason }));
+        expect(job.data.username).to.eq(`Federalist ${config.app.app_env} Alerts`);
+      });
+    });
+  });
+});

--- a/test/api/workers/Slack.test.js
+++ b/test/api/workers/Slack.test.js
@@ -1,0 +1,26 @@
+const { expect } = require('chai');
+const nock = require('nock');
+
+const Slack = require('../../../api/workers/Slack');
+
+describe('Slack', () => {
+  afterEach(() => expect(nock.isDone()).to.be.true);
+
+  describe('.send()', () => {
+    it('sends a POST request to slack', async () => {
+      const url = 'http://localhost:2343/foo/bar';
+
+      const channel = 'some channel';
+      const text = '*For real, only a test*';
+      const username = 'some user';
+
+      const slack = new Slack({ url });
+
+      nock('http://localhost:2343')
+        .post('/foo/bar', { channel, text, username })
+        .reply(200);
+
+      await slack.send({ channel, text, username });
+    });
+  });
+});


### PR DESCRIPTION
Resolves #2992 

I also think the error handling in the Github service is incorrect... (`parseGithubErrorMessage`, `handleCreateRepoError`, `handleWebhookError`) which might be why we get funky errors sometimes in the UI. This might have changed with Octokit upgrades.

I added some comments to explain my logic in certain places.

- Added an echo server to view results of email and slack messages locally
- Added Slack integration for alerts
- In Federalist, since email is not available, messages are rerouted to Slack
- Added tests for SIteDestroyer, there were previously none
- Added tests for new functionality
- Updated existing tests where necessary