### PR TITLE
Configures TLS on cloud.gov, ignoring cert issues

### DIFF
--- a/api/models/index.js
+++ b/api/models/index.js
@@ -3,11 +3,12 @@ const { postgres } = require('../../config');
 const { databaseLogger } = require('../../winston');
 
 const {
-  database, host, password, port, user: username,
+  database, host, password, port, ssl, user: username,
 } = postgres;
 
 const sequelize = new Sequelize(database, username, password, {
   dialect: 'postgres',
+  dialectOptions: { ssl },
   host,
   port,
   logging: databaseLogger.info.bind(databaseLogger),

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -15,6 +15,9 @@ if (rdsCreds) {
     user: rdsCreds.username,
     password: rdsCreds.password,
     port: rdsCreds.port,
+    ssl: {
+      rejectUnauthorized: false,
+    },
   };
 } else {
   throw new Error('No database credentials found.');


### PR DESCRIPTION
Addresses #3607 

Configures the use of TLS when connecting to PG on cloud.gov. Node TLS complains about the presence of a self-signed cert in the certificate chain, so it is required to set `rejectUnauthorized: false`. The use of this flag should be revisited.

Confirmed the connection was encrypted by checking all connections tls status via:
```
SELECT datname,usename, ssl, client_addr
  FROM pg_stat_ssl
  JOIN pg_stat_activity
    ON pg_stat_ssl.pid = pg_stat_activity.pid;
```