### PR TITLE
only use websocket transport

### DIFF
--- a/frontend/util/buildStatusNotifier.js
+++ b/frontend/util/buildStatusNotifier.js
@@ -12,7 +12,8 @@ class BuildStatusNotifier {
     }
 
     const socketHost = (document.querySelectorAll('meta[name="socketHost"]')[0] || {}).content;
-    const socket = this.io(socketHost);
+    const socket = this.io(socketHost, { transports: ['websocket'] });
+
     socket.on('build status', (build) => {
       this.notify(build);
     });


### PR DESCRIPTION
Wacky, something about the cloud.gov routing layer is preventing long polling from working or preventing the "upgrade" to websockets, but websockets work just fine. Could be a header not making it through or something to do with (non)sticky sessions?