### PR TITLE
Remove SOCKET_HOST env var and use APP_HOSTNAME

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -42,7 +42,6 @@ applications:
       LOG_LEVEL: ((log_level))
       NPM_CONFIG_PRODUCTION: true
       NODE_MODULES_CACHE: false
-      SOCKET_HOST: https://((app_subdomain))((domain))
       USER_AUDITOR: federalist
       S3_SERVICE_PLAN_ID: F36820DC-FDB6-496C-9D96-68861F5D0D95
       FEATURE_AUTH_GITHUB: ((feature_auth_github))

--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -67,7 +67,6 @@ module.exports = {
     context.username = req.user.username;
     context.siteWideError = SiteWideErrorLoader.loadSiteWideError();
     context.csrfToken = req.csrfToken();
-    context.socketHost = process.env.SOCKET_HOST;
     context.hasUAAIdentity = !!hasUAAIdentity;
 
     const frontendConfig = {
@@ -103,7 +102,6 @@ module.exports = {
     if (req.session.authenticated) {
       context.isAuthenticated = true;
       context.username = req.user.username;
-      context.socketHost = process.env.SOCKET_HOST;
     }
 
     res.render('404.njk', context);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       APP_HOSTNAME: http://localhost:1337
       UAA_HOST: http://localhost:9000
       UAA_HOST_DOCKER_URL: http://uaa:8080
-      SOCKET_HOST: http://localhost:1337
   bull-board:
     build:
       dockerfile: Dockerfile-app

--- a/frontend/util/buildStatusNotifier.js
+++ b/frontend/util/buildStatusNotifier.js
@@ -1,3 +1,4 @@
+/* global APP_HOSTNAME */
 import io from 'socket.io-client';
 
 class BuildStatusNotifier {
@@ -11,8 +12,7 @@ class BuildStatusNotifier {
       return false;
     }
 
-    const socketHost = (document.querySelectorAll('meta[name="socketHost"]')[0] || {}).content;
-    const socket = this.io(socketHost, { transports: ['websocket'] });
+    const socket = this.io(APP_HOSTNAME, { transports: ['websocket'] });
 
     socket.on('build status', (build) => {
       this.notify(build);

--- a/views/base.njk
+++ b/views/base.njk
@@ -52,12 +52,6 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:image" content="https://federalist.18f.gov/images/social-cards/twitter-1024x512.png" />
 
-    <!-- For socket.io -->
-    {% if accessToken and socketHost %}
-      <meta name='accessToken' content='{{ accessToken }}' />
-      <meta name='socketHost' content='{{ socketHost }}' />
-    {% endif %}
-
     <script src="/uswds/js/uswds.min.js" type="text/javascript"></script>
     <title>
       Federalist{% if siteDisplayEnv %} | {{ siteDisplayEnv }}{% endif %}


### PR DESCRIPTION
These are the same, no need for both and we should reduce the amount of data that the server renders for the React App so these can eventually be decoupled.