### PR TITLE
return 404 for options requests

### DIFF
--- a/api/routers/main.js
+++ b/api/routers/main.js
@@ -13,5 +13,6 @@ router.get('/settings', csrfProtection, MainController.app);
 router.get('/robots.txt', MainController.robots);
 
 router.get('/404-not-found/', MainController.notFound);
+router.options('(/*)?', (_req, res) => res.notFound());
 
 module.exports = router;

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -85,6 +85,19 @@ describe('Main Site', () => {
     });
   });
 
+  describe('options method', () => {
+    it('should respond with a 404 for an options request without path', async () => {
+      await request(app)
+        .options('/')
+        .expect(404);
+    });
+
+    it('should respond with a 404 for an options request with a path', async () => {
+      await request(app)
+        .options('/boo/hoo')
+        .expect(404);
+    });
+  });
   describe('App /sites', () => {
     it('should redirect to / with a flash error when not authenticated', (done) => {
       request(app)


### PR DESCRIPTION
HTTP OPTIONS request return a 404 instead of displaying options

Reference: https://github.com/18F/federalist/issues/3627