### PR TITLE
send 404s for invalid requests

### DIFF
--- a/api/controllers/main.js
+++ b/api/controllers/main.js
@@ -1,30 +1,6 @@
 const config = require('../../config');
 const SiteWideErrorLoader = require('../services/SiteWideErrorLoader');
-const { loadAssetManifest, getSiteDisplayEnv, shouldIncludeTracking } = require('../utils');
-const Features = require('../features');
-
-const webpackAssets = loadAssetManifest();
-
-function defaultContext(req, res) {
-  const messages = {
-    errors: req.flash('error'),
-  };
-
-  const context = {
-    isAuthenticated: false,
-    messages,
-    shouldIncludeTracking: shouldIncludeTracking(),
-    siteDisplayEnv: getSiteDisplayEnv(),
-    homepageUrl: config.app.homepageUrl,
-    webpackAssets,
-    authGithub: Features.enabled(Features.Flags.FEATURE_AUTH_GITHUB),
-    authUAA: Features.enabled(Features.Flags.FEATURE_AUTH_UAA),
-    hasUAAIdentity: false,
-    nonce: res.locals.cspNonce,
-  };
-
-  return context;
-}
+const { defaultContext } = require('../utils');
 
 function alertGithubAuthDeprecation(hasUAAIdentity, context) {
   if (!hasUAAIdentity && context.authUAA) {
@@ -87,15 +63,5 @@ module.exports = {
 
     // send the "deny all" robots.txt content
     return res.send(DENY_ALL_CONTENT);
-  },
-
-  notFound(req, res) {
-    const context = defaultContext(req, res);
-    if (req.session.authenticated) {
-      context.isAuthenticated = true;
-      context.username = req.user.username;
-    }
-
-    res.render('404.njk', context);
   },
 };

--- a/api/init/index.js
+++ b/api/init/index.js
@@ -19,6 +19,7 @@ const responses = require('../responses');
 const passport = require('../services/passport');
 const router = require('../routers');
 const sessionConfig = require('./sessionConfig');
+const { defaultContext } = require('../utils');
 
 const { NODE_ENV } = process.env;
 
@@ -52,7 +53,13 @@ function maybeUseExpressLogger(app) {
 }
 
 function fourOhFourhandler(req, res) {
-  res.status(404).redirect(302, '/404-not-found/');
+  const context = defaultContext(req, res);
+  if (req.session.authenticated) {
+    context.isAuthenticated = true;
+    context.username = req.user.username;
+  }
+
+  res.status(404).render('404.njk', context);
 }
 
 function init(app) {

--- a/api/routers/main.js
+++ b/api/routers/main.js
@@ -10,9 +10,9 @@ router.get('/system-use', MainController.systemUse);
 router.get('/organizations(/*)?', csrfProtection, MainController.app);
 router.get('/sites(/*)?', csrfProtection, MainController.app);
 router.get('/settings', csrfProtection, MainController.app);
+
 router.get('/robots.txt', MainController.robots);
 
-router.get('/404-not-found/', MainController.notFound);
 router.options('(/*)?', (_req, res) => res.notFound());
 
 module.exports = router;

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -4,6 +4,7 @@ const moment = require('moment');
 
 const config = require('../../config');
 const { logger } = require('../../winston');
+const Features = require('../features');
 
 function filterEntity(res, name, field = 'name') {
   let errMsg = `Not found: Entity @${field} = ${name}`;
@@ -254,6 +255,27 @@ async function paginate(model, serialize, params, query = {}) {
   };
 }
 
+function defaultContext(req, res) {
+  const messages = {
+    errors: req.flash('error'),
+  };
+
+  const context = {
+    isAuthenticated: false,
+    messages,
+    shouldIncludeTracking: shouldIncludeTracking(),
+    siteDisplayEnv: getSiteDisplayEnv(),
+    homepageUrl: config.app.homepageUrl,
+    webpackAssets: loadAssetManifest(),
+    authGithub: Features.enabled(Features.Flags.FEATURE_AUTH_GITHUB),
+    authUAA: Features.enabled(Features.Flags.FEATURE_AUTH_UAA),
+    hasUAAIdentity: false,
+    nonce: res.locals.cspNonce,
+  };
+
+  return context;
+}
+
 module.exports = {
   filterEntity,
   firstEntity,
@@ -278,4 +300,5 @@ module.exports = {
   wait,
   wrapHandler,
   wrapHandlers,
+  defaultContext,
 };

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -31,57 +31,23 @@ describe('Main Site', () => {
     });
   });
 
-  describe('App /404', () => {
-    it('should redirect to / with a flash error when not authenticated', (done) => {
-      request(app)
+  describe.only('App /404', () => {
+    it('should redirect to / with a flash error when not authenticated', async () => {
+      const response = await request(app)
         .get('/blahblahpage')
-        .expect(302)
-        .then((response) => {
-          expect(response.headers.location).to.equal('/404-not-found/');
-          expect(response.text.indexOf('Found. Redirecting to /404-not-found/')).to.be.above(-1);
-          done();
-        })
-        .catch(done);
+        .expect(404);
+      expect(response.text.indexOf('Log in with cloud.gov')).to.be.above(-1);
+      expect(response.text.indexOf('404 / Page not found')).to.be.above(-1);
     });
 
-    it('should work when authenticated', (done) => {
-      authenticatedSession()
-        .then(cookie => request(app)
-          .get('/blahblahpage')
-          .set('Cookie', cookie)
-          .expect(302))
-        .then((response) => {
-          expect(response.headers.location).to.equal('/404-not-found/');
-          expect(response.text.indexOf('Found. Redirecting to /404-not-found/')).to.be.above(-1);
-          done();
-        })
-        .catch(done);
-    });
-
-    it('should have app content', (done) => {
-      authenticatedSession()
-        .then(cookie => request(app)
-          .get('/404-not-found/')
-          .set('Cookie', cookie)
-          .expect(200))
-        .then((response) => {
-          expect(response.text.indexOf('Log out')).to.be.above(-1);
-          expect(response.text.indexOf('404 / Page not found')).to.be.above(-1);
-          done();
-        })
-        .catch(done);
-    });
-
-    it('should have app content', (done) => {
-      request(app)
-        .get('/404-not-found/')
-        .expect(200)
-        .then((response) => {
-          expect(response.text.indexOf('Log in')).to.be.above(-1);
-          expect(response.text.indexOf('404 / Page not found')).to.be.above(-1);
-          done();
-        })
-        .catch(done);
+    it('should work when authenticated', async () => {
+      const cookie = await authenticatedSession();
+      const response = await request(app)
+        .get('/blahblahpage')
+        .set('Cookie', cookie)
+        .expect(404);
+      expect(response.text.indexOf('Log out')).to.be.above(-1);
+      expect(response.text.indexOf('404 / Page not found')).to.be.above(-1);
     });
   });
 

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -31,7 +31,7 @@ describe('Main Site', () => {
     });
   });
 
-  describe.only('App /404', () => {
+  describe('App /404', () => {
     it('should redirect to / with a flash error when not authenticated', async () => {
       const response = await request(app)
         .get('/blahblahpage')


### PR DESCRIPTION
Currently unknown request are 302 redirected to a 404 content page.  Unknown requests should receive a 404 status response.