### PR TITLE
Fix api route, error handling and return value, add more helpful mess…

### DIFF
--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -137,7 +137,7 @@ async function fetchDomains(query = {}) {
 }
 
 async function provisionDomain(id) {
-  return post(`/domains/${id}`).catch(() => []);
+  return post(`/domains/${id}/provision`);
 }
 
 async function fetchEvents(query = {}) {

--- a/api/admin/controllers/domain.js
+++ b/api/admin/controllers/domain.js
@@ -161,7 +161,7 @@ module.exports = wrapHandlers({
       params: { id },
     } = req;
 
-    const domain = await fetchModelById(id, Domain);
+    const domain = await fetchModelById(id, Domain.scope('withSite'));
     if (!domain) {
       return res.notFound();
     }
@@ -170,7 +170,10 @@ module.exports = wrapHandlers({
 
     try {
       const updatedDomain = await DomainService.provision(domain, dnsResults);
-      return res.json(domainSerializer.serialize(updatedDomain, true));
+      return res.json({
+        dnsRecords: DomainService.buildDnsRecords(updatedDomain),
+        domain: domainSerializer.serialize(updatedDomain, true),
+      });
     } catch (error) {
       return res.unprocessableEntity(error);
     }

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -186,7 +186,7 @@ async function checkDeprovisionStatus(id) {
   });
 
   if (!domain) {
-    return;
+    return `Domain ${id}|${domain.names} must be ${Domain.States.Deprovisioning} to be deprovisioned, but is ${domain.state}.`;
   }
 
   const { resources } = await cfApi().fetchServiceInstances(domain.serviceName);
@@ -198,11 +198,16 @@ async function checkDeprovisionStatus(id) {
       serviceName: null,
       state: States.Pending,
     });
-  } else {
-    queueDeprovisionStatusCheck(id);
+    return `Domain ${id}|${domain.names} successfully deprovisioned.`;
   }
+  // TODO - this does not handle the case where deprovisioning fails
+  queueDeprovisionStatusCheck(id);
+  return `Domain ${id}|${domain.names} is currently deprovisioning.`;
 }
 
+/**
+ * @param {number} id The domain id
+ */
 async function checkProvisionStatus(id) {
   const domain = await Domain.findOne({
     where: {
@@ -212,21 +217,22 @@ async function checkProvisionStatus(id) {
   });
 
   if (!domain) {
-    return;
+    return `Domain ${id}|${domain.names} must be ${Domain.States.Provisioning} to be provisioned, but is ${domain.state}.`;
   }
 
   const service = await cfApi().fetchServiceInstance(domain.serviceName);
+  const { last_operation: lastOperation } = service.entity;
 
-  switch (service.entity.last_operation) {
+  switch (lastOperation) {
     case 'succeeded':
       await domain.update({ state: States.Provisioned });
-      break;
+      return `Domain ${id}|${domain.names} successfully provisioned.`;
     case 'failed':
       await domain.update({ state: States.Failed });
-      break;
+      throw new Error(`Domain ${id}|${domain.names} failed to provision.`);
     default:
       queueProvisionStatusCheck(id);
-      break;
+      return `Domain ${id}|${domain.names} is currently ${lastOperation}.`;
   }
 }
 

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -178,14 +178,9 @@ async function provision(domain, dnsResults) {
  * @param {number} id The domain id
  */
 async function checkDeprovisionStatus(id) {
-  const domain = await Domain.findOne({
-    where: {
-      state: Domain.States.Deprovisioning,
-      id,
-    },
-  });
+  const domain = await Domain.findByPk(id);
 
-  if (!domain) {
+  if (domain.state !== Domain.States.Deprovisioning) {
     return `Domain ${id}|${domain.names} must be ${Domain.States.Deprovisioning} to be deprovisioned, but is ${domain.state}.`;
   }
 
@@ -209,14 +204,9 @@ async function checkDeprovisionStatus(id) {
  * @param {number} id The domain id
  */
 async function checkProvisionStatus(id) {
-  const domain = await Domain.findOne({
-    where: {
-      state: Domain.States.Provisioning,
-      id,
-    },
-  });
+  const domain = await Domain.findByPk(id);
 
-  if (!domain) {
+  if (domain.state !== Domain.States.Provisioning) {
     return `Domain ${id}|${domain.names} must be ${Domain.States.Provisioning} to be provisioned, but is ${domain.state}.`;
   }
 

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -190,7 +190,7 @@ describe('Domain Service', () => {
 
       const domain = await DomainFactory.create({ state: Domain.States.Provisioning });
 
-      await DomainService.checkProvisionStatus(domain.id);
+      const error = await DomainService.checkProvisionStatus(domain.id).catch(e => e);
 
       await domain.reload();
 
@@ -200,6 +200,7 @@ describe('Domain Service', () => {
       );
       sinon.assert.notCalled(DomainQueue.prototype.add);
       expect(domain.state).to.eq(Domain.States.Failed);
+      expect(error).to.be.an('Error');
     });
 
     it('requeues the status check otherwise', async () => {


### PR DESCRIPTION
 Fix api route, error handling and return value, add more helpful messages in domain background jobs.


What should we consider when determining when we want the actual "job" to fail? Only something unexpected? When it can't DO THE THING? Here I'm failing the `checkProvisionStatus` job if the provisioning actually fails on CG to make it easier to track down in Bull