### PR TITLE
3689 domain admin sites and search

### DIFF
--- a/admin-client/src/components/PaginatedQueryPage.svelte
+++ b/admin-client/src/components/PaginatedQueryPage.svelte
@@ -95,8 +95,8 @@
                             <select class="usa-select" name={field.name} id={field.name}>
                               <option value="">-</option>
                               {#each field.options(payload.meta) as opt}
-                                <option value={opt.value} selected={`${opt.value}` === params[field.name]}>
-                                  {opt.name}
+                                <option value={opt.value ?? opt} selected={`${opt.value ?? opt}` === params[field.name]}>
+                                  {opt.name ?? opt}
                                 </option>
                               {/each}
                             </select>

--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -180,6 +180,10 @@ async function fetchSites(query = {}) {
   return get('/sites', query).catch(() => []);
 }
 
+async function fetchRawSites() {
+  return get('/sites/raw').catch(() => []);
+}
+
 async function updateSite(id, params) {
   return put(`/sites/${id}`, params).catch(() => null);
 }
@@ -232,6 +236,7 @@ export {
   fetchRoles,
   fetchSite,
   fetchSites,
+  fetchRawSites,
   fetchUserEnvironmentVariables,
   fetchUser,
   fetchUsers,

--- a/admin-client/src/pages/domain/Index.svelte
+++ b/admin-client/src/pages/domain/Index.svelte
@@ -11,6 +11,10 @@
         value: site.id,
       })),
     },
+    state: {
+      type: 'select',
+      options: (meta) => meta.states,
+    },
   };
 </script>
 

--- a/admin-client/src/pages/domain/New.svelte
+++ b/admin-client/src/pages/domain/New.svelte
@@ -2,11 +2,11 @@
   import page from 'page';
   import { notification } from '../../stores';
   import { Await, GridContainer } from '../../components';
-  import { createDomain, fetchSites } from '../../lib/api';
+  import { createDomain, fetchRawSites } from '../../lib/api';
 
   import Form from './Form.svelte';
 
-  $: sitesPromise = fetchSites();
+  $: sitesPromise = fetchRawSites();
 
   function onSuccess() {
     page('/domains');
@@ -19,7 +19,7 @@
     <Form
       onSubmit={createDomain}
       {onSuccess}
-      sites={sites.data}
+      {sites}
     />
   </Await>
 </GridContainer>

--- a/api/admin/controllers/domain.js
+++ b/api/admin/controllers/domain.js
@@ -7,7 +7,7 @@ const domainSerializer = require('../../serializers/domain');
 module.exports = wrapHandlers({
   async list(req, res) {
     const {
-      limit, page, search, site,
+      limit, page, search, site, state,
     } = req.query;
 
     const scopes = ['withSite'];
@@ -18,6 +18,10 @@ module.exports = wrapHandlers({
 
     if (site) {
       scopes.push(Domain.siteScope(site));
+    }
+
+    if (state) {
+      scopes.push(Domain.stateScope(state));
     }
 
     const [pagination, sites] = await Promise.all([
@@ -31,7 +35,10 @@ module.exports = wrapHandlers({
     ]);
 
     const json = {
-      meta: { sites },
+      meta: {
+        sites,
+        states: Domain.States.values,
+      },
       ...pagination,
     };
 

--- a/api/admin/controllers/site.js
+++ b/api/admin/controllers/site.js
@@ -10,6 +10,11 @@ const updateableAttrs = [
 ];
 
 module.exports = wrapHandlers({
+  listRaw: async (req, res) => {
+    const sites = await Site.findAll({ attributes: ['id', 'owner', 'repository'], raw: true });
+    return res.json(sites);
+  },
+
   list: async (req, res) => {
     const {
       limit, page, organization, search,

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -33,6 +33,7 @@ apiRouter.delete('/organization-role', parseJson, AdminControllers.OrganizationR
 apiRouter.put('/organization-role', parseJson, AdminControllers.OrganizationRole.update);
 apiRouter.get('/roles', AdminControllers.Role.list);
 apiRouter.get('/sites', AdminControllers.Site.list);
+apiRouter.get('/sites/raw', AdminControllers.Site.listRaw);
 apiRouter.get('/sites/:id', AdminControllers.Site.findById);
 apiRouter.put('/sites/:id', parseJson, AdminControllers.Site.update);
 apiRouter.delete('/sites/:id', AdminControllers.Site.destroy);

--- a/api/models/domain.js
+++ b/api/models/domain.js
@@ -42,6 +42,12 @@ function associate({ Domain, Site }) {
       required: true,
     }],
   });
+
+  Domain.addScope('byState', state => ({
+    where: {
+      state,
+    },
+  }));
 }
 
 function define(sequelize, DataTypes) {
@@ -93,6 +99,7 @@ function define(sequelize, DataTypes) {
   Domain.associate = associate;
   Domain.searchScope = search => ({ method: ['byIdOrText', search] });
   Domain.siteScope = siteId => ({ method: ['bySite', siteId] });
+  Domain.stateScope = state => ({ method: ['byState', state] });
   Domain.States = States;
   Domain.Contexts = Contexts;
   Domain.prototype.isPending = function isPending() {

--- a/test/api/unit/models/domain.test.js
+++ b/test/api/unit/models/domain.test.js
@@ -108,4 +108,24 @@ describe('Domain model', () => {
       expect(result.Site.id).to.eq(site.id);
     });
   });
+
+  describe('.stateScope()', () => {
+    it('returns domains by state', async () => {
+      const site = await Factory.site();
+
+      const [domain1,, domain3] = await Promise
+        .all([
+          Domain.States.Provisioned,
+          Domain.States.Pending,
+          Domain.States.Provisioned,
+        ]
+          .map(state => Domain.create({
+            siteId: site.id, names: 'www.example.gov', context: Domain.Contexts.Site, state,
+          })));
+
+      const result = await Domain.scope(Domain.stateScope(Domain.States.Provisioned)).findAll();
+
+      expect(result.map(domain => domain.id)).to.have.members([domain1.id, domain3.id]);
+    });
+  });
 });


### PR DESCRIPTION
Partially addresses #3689 

- search domains by state in UI
- do not paginate sites in domain creation form site list

Regarding the solution for the second item, this could have been done just by passing a large number to the existing site query, but felt that the use case was so different that it really deserved it's own action. This will also be much more performant if we do have a lot of sites.