### PR TITLE
Updates to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Note that `npm run update-local-config` will need to be re-run with some frequen
 
 1. Run `docker-compose build`.
 1. Run `docker-compose run app yarn` to install dependencies.
+1. Run `docker-compose run admin-client yarn` to install dependencies.
 1. Run `docker-compose run app yarn create-dev-data` and answer its prompts to create some fake development data for your local database.
 1. Run `docker-compose up` to start the development environment.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ In our Docker Compose environment, `app` is the name of the container where the 
 For example:
 
 - Use `docker-compose run app yarn test` to run local testing on the app.
-- Use `docker-compose run app yarn lint:diff` to check that your local changes meet our linting standards.
+- Use `docker-compose run app yarn lint` to check that your local changes meet our linting standards.
 
 Similarly you can run any command in the context of the database container `db` by running `docker-compose run db <THE COMMAND>`.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Note that when using `docker-compose run`, the docker network will not be expose
 
 The `db` container is exposed on port `5433` of your host computer to make it easier to run commands on. For instance, you can open a `psql` session to it by running `psql -h localhost -p 5433 -d federalist -U postgres`.
 
+The admin client is running on port `3000` of hour host computer.
+
 #### Front end application
 
 If you are working on the front end of the application, the things you need to know are:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The `db` container is exposed on port `5433` of your host computer to make it ea
 
 The admin client is running on port `3000` of hour host computer.
 
-Some aspects of the system aren't expected to be fully functional in a development environment. For example: the "View site", "View logs", and "Uploaded files" links associated with sites in the seed data do not reach working URLs.
+Some aspects of the system aren't expected to be fully functional in a development environment. For example: the "View site" and "Uploaded files" links associated with sites in the seed data do not reach working URLs.
 
 #### Front end application
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,10 @@ This will be the file that holds your S3 and SQS configurations.
 
 1. Once you have created the application, you'll see a `Client ID` and `Client Secret`. Open the `config/local.js` file in your text or code editor and update it with these values:
     ```js
-    passport: {
-      github: {
-        options: {
-          clientID: 'VALUE FROM GITHUB',
-          clientSecret: 'VALUE FROM GITHUB',
-          callbackURL: 'http://localhost:1337/auth/github/callback'
-        }
-      }
-    }
+    const githubOptions = {
+      clientID: 'VALUE FROM GITHUB',
+      clientSecret: 'VALUE FROM GITHUB',
+    };
     ```
 1. [Register or create a new GitHub organization](https://github.com/settings/organizations) with a name of your choosing. Then find your organization's ID by visiting `https://api.github.com/orgs/<your-org-name>` and copying the `id` into the allowed `organizations` in `config/local.js`.
     ```js

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ _Note: some terminal commands may take a while to process, without offering feed
 
 1. Make a copy of `config/local.sample.js` and name it `local.js` and place it in the `config` folder. You can do this by running `cp config/local{.sample,}.js`
 This will be the file that holds your S3 and SQS configurations.
-1. [Register a new OAuth application on GitHub](https://github.com/settings/applications/new). Give your app a name and "Homepage URL" (`http://localhost:1337`), and use `http://localhost:1337/auth/github/callback` as the "Authorization callback url".
+1. [Register a new OAuth application on GitHub](https://github.com/settings/applications/new). Give your app a name and "Homepage URL" (`http://localhost:1337`), and use `http://localhost:1337/auth/github2/callback` as the "Authorization callback url".
 
 1. Once you have created the application, you'll see a `Client ID` and `Client Secret`. Open the `config/local.js` file in your text or code editor and update it with these values:
     ```js

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The `db` container is exposed on port `5433` of your host computer to make it ea
 
 The admin client is running on port `3000` of hour host computer.
 
+Some aspects of the system aren't expected to be fully functional in a development environment. For example: the "View site", "View logs", and "Uploaded files" links associated with sites in the seed data do not reach working URLs.
+
 #### Front end application
 
 If you are working on the front end of the application, the things you need to know are:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ More examples can be found at [https://federalist.18f.gov/success-stories/](http
 
 Before you start, ensure you have the following installed:
 
-- [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+- [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) (choose **cf CLI v7**)
 - [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
 
 ### Then follow these steps to set up and run your server

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Note that `npm run update-local-config` will need to be re-run with some frequen
 1. Run `docker-compose build`.
 1. Run `docker-compose run app yarn` to install dependencies.
 1. Run `docker-compose run admin-client yarn` to install dependencies.
+1. Run `docker-compose run app yarn migrate:up` to initialize the local database.
 1. Run `docker-compose run app yarn create-dev-data` and answer its prompts to create some fake development data for your local database.
 1. Run `docker-compose up` to start the development environment.
 

--- a/README.md
+++ b/README.md
@@ -256,10 +256,10 @@ We use [`eslint`](https://eslint.org/) and adhere to [Airbnb's eslint config](ht
 
 Because this project was not initially written in a way that complies with our current linting standard, we are taking the strategy of bringing existing files into compliance as they are touched during normal feature development or bug fixing.
 
-To lint the files you have created or changed in a branch, run:
+To lint the files in a branch, run:
 
 ```sh
-docker-compose run app yarn lint:diff
+docker-compose run app yarn lint
 ```
 
 `eslint` also has a helpful auto-fix command that can be run by:


### PR DESCRIPTION
## Changes proposed in this pull request:
Multiple changes to README.md:
- Adds the missing migrate:up setup step, fixing #3712.
- Adds the missing admin-client dependency setup step.
- Updates the GitHub OAuth app setup instruction to indicate the correct "github2" URL path.
- Updates the OAuth configuration setup step to match the initial state of `config/local.sample.js`.
- Adds specific call for the _v7_ version of the Cloud Foundry CLI.
- Adds a note of the admin client's local port.
- Adds mention that certain pieces of functionality aren't expected to work in the development environment (at least with regard to the seed data).

## security considerations
There are no changes to the code, but this does add explicit mention of admin-client to README.md. 
