### PR TITLE
Add deprovision domain button to admin client

### DIFF
--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -140,6 +140,10 @@ async function provisionDomain(id) {
   return post(`/domains/${id}/provision`);
 }
 
+async function deprovisionDomain(id) {
+  return post(`/domains/${id}/deprovision`);
+}
+
 async function fetchEvents(query = {}) {
   return get('/events', query).catch(() => []);
 }
@@ -226,6 +230,7 @@ export {
   fetchDomainDns,
   fetchDomainDnsResult,
   provisionDomain,
+  deprovisionDomain,
   fetchEvents,
   createOrganization,
   fetchOrganization,

--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -63,6 +63,9 @@
         {#if domain.state === 'pending'}
           <button class="usa-button usa-button--big" disabled>Provision</button>
         {/if}
+        {#if domain.state === 'provisioned'}
+          <button class="usa-button usa-button--big" disabled>Deprovision</button>
+        {/if}
       </span>
       <div class="display-flex flex-justify flex-align-center">
         <h3>Dns</h3>
@@ -75,6 +78,14 @@
           disabled={!dnsResults.canProvision}
           on:click={provision}>
           Provision
+        </button>
+      {/if}
+      {#if domain.state === 'provisioned'}
+        <button
+          class="usa-button usa-button--big"
+          disabled={!dnsResults.canDeprovision}
+          on:click={deprovision}>
+          Deprovision
         </button>
       {/if}
     </Await>

--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -64,12 +64,7 @@
           Loading...
         </div>
         <DnsTable {dnsRecords}/>
-        {#if domain.state === 'pending'}
-          <button class="usa-button usa-button--big" disabled>Provision</button>
-        {/if}
-        {#if domain.state === 'provisioned'}
-          <button class="usa-button usa-button--big" disabled>Deprovision</button>
-        {/if}
+        <button class="usa-button usa-button--big" disabled>Loading...</button>
       </span>
       <div class="display-flex flex-justify flex-align-center">
         <h3>Dns</h3>
@@ -84,7 +79,7 @@
           Provision
         </button>
       {/if}
-      {#if domain.state === 'provisioned'}
+      {#if dnsResults.canDeprovision}
         <button
           class="usa-button usa-button--big"
           disabled={!dnsResults.canDeprovision}

--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -1,6 +1,6 @@
 <script>
   import { router } from '../../stores';
-  import { fetchDomain, fetchDomainDnsResult, provisionDomain } from '../../lib/api';
+  import { fetchDomain, fetchDomainDnsResult, provisionDomain, deprovisionDomain } from '../../lib/api';
   import { formatDateTime } from '../../helpers/formatter';
   import { siteName } from '../../lib/utils';
   import {
@@ -22,6 +22,10 @@
 
   function provision() {
     domainPromise = provisionDomain(id);
+  }
+
+  function deprovision() {
+    domainPromise = deprovisionDomain(id);
   }
 </script>
 

--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -1,6 +1,11 @@
 <script>
   import { router } from '../../stores';
-  import { fetchDomain, fetchDomainDnsResult, provisionDomain, deprovisionDomain } from '../../lib/api';
+  import {
+    fetchDomain,
+    fetchDomainDnsResult,
+    provisionDomain,
+    deprovisionDomain,
+  } from '../../lib/api';
   import { formatDateTime } from '../../helpers/formatter';
   import { siteName } from '../../lib/utils';
   import {

--- a/api/admin/controllers/domain.js
+++ b/api/admin/controllers/domain.js
@@ -164,7 +164,10 @@ module.exports = wrapHandlers({
     try {
       const updatedDomain = await DomainService.deprovision(domain);
       EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'Domain Deprovisioned', { domain });
-      return res.json(domainSerializer.serialize(updatedDomain, true));
+      return res.json({
+        dnsRecords: DomainService.buildDnsRecords(updatedDomain),
+        domain: domainSerializer.serialize(updatedDomain, true),
+      });
     } catch (error) {
       return res.unprocessableEntity(error);
     }

--- a/api/admin/controllers/domain.js
+++ b/api/admin/controllers/domain.js
@@ -142,8 +142,11 @@ module.exports = wrapHandlers({
 
     const canProvision = DomainService.canProvision(domain, dnsResults);
 
+    const canDeprovision = DomainService.canDeprovision(domain);
+
     return res.json({
       canProvision,
+      canDeprovision,
       data: dnsResults,
     });
   },

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -228,6 +228,7 @@ async function checkProvisionStatus(id) {
 
 module.exports.buildDnsRecords = buildDnsRecords;
 module.exports.canProvision = canProvision;
+module.exports.canDeprovision = canDeprovision;
 module.exports.checkDeprovisionStatus = checkDeprovisionStatus;
 module.exports.checkAcmeChallengeDnsRecord = checkAcmeChallengeDnsRecord;
 module.exports.checkDnsRecords = checkDnsRecords;

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -62,6 +62,40 @@ describe('Domain Service', () => {
     });
   });
 
+  describe('.canDeprovision()', () => {
+    it('returns true if domain is provisioned', () => {
+      const domain = DomainFactory.build({ state: Domain.States.Provisioned });
+
+      const result = DomainService.canDeprovision(domain);
+
+      expect(result).to.be.true;
+    });
+
+    it('returns true if domain is provisioning', () => {
+      const domain = DomainFactory.build({ state: Domain.States.Provisioning });
+
+      const result = DomainService.canDeprovision(domain);
+
+      expect(result).to.be.true;
+    });
+
+    it('returns true if domain is failed', () => {
+      const domain = DomainFactory.build({ state: Domain.States.Failed });
+
+      const result = DomainService.canDeprovision(domain);
+
+      expect(result).to.be.true;
+    });
+
+    it('returns false if the domain is pending', () => {
+      const domain = DomainFactory.build();
+
+      const result = DomainService.canDeprovision(domain);
+
+      expect(result).to.be.false;
+    });
+  });
+
   describe('.checkDeprovisionStatus()', () => {
     it('does nothing if the domain is not deprovisioning', async () => {
       sinon.spy(CloudFoundryAPIClient.prototype, 'fetchServiceInstances');


### PR DESCRIPTION
## Changes proposed in this pull request:
In /domains when viewing an individual domain's show page, when a domain is in the Provisioned state (and once the DNS lookup has completed) a Deprovision button is displayed which can initiate the deprovision functionality in the Domain service. This is work toward #3689.

In my development environment the `deprovision` call fails with a message like "Something went wrong: getaddrinfo ENOTFOUND login.example.com" and an HTTP 422, just as the `provision` call does. I suspect this functionality will need to be verified in staging, and I'll need some help learning to do that properly.

I also added a few tests in `unit/services/DomainTest.js` for `canDeprovision`, since it didn't have any, while `canProvision` did. I have not written any tests for the admin client changes, as I haven't (yet?) found a suitable existing place to add them.

Note: right now the deprovision button only appears when the domain is in the Provisioned state, but this is not completely consistent with the Domain model's `canProvision` method, which also returns true in Provisioning and Failed states. It wouldn't be hard to allows these as well in the Admin client, but a) I'm uncertain whether I should, and b) not thrilled with the idea of duplicating this model logic in the client, though if I don't have a model instance there maybe that's necessary.

## security considerations
I don't believe there are any new security considerations. All this is doing is making the deprovision functionality available to admin client users, who already have less convenient ways to initiate it.