### PR TITLE
Patched deprovision again

### DIFF
--- a/api/admin/controllers/domain.js
+++ b/api/admin/controllers/domain.js
@@ -156,7 +156,7 @@ module.exports = wrapHandlers({
       params: { id },
     } = req;
 
-    const domain = await fetchModelById(id, Domain('withSite'));
+    const domain = await fetchModelById(id, Domain.scope('withSite'));
     if (!domain) {
       return res.notFound();
     }


### PR DESCRIPTION
## Changes proposed in this pull request:
Fixes an error I introduced in the incomplete patch I submitted in #3723 

(`Domain('withSite')` caused a runtime error on staging but not in unit testing. This PR corrects it to the intended `Domain.scope('withSite')` and we'll hope that does the trick.)

## security considerations
None.
