### PR TITLE
Add domain Delete button in admin client

### DIFF
--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -144,6 +144,10 @@ async function deprovisionDomain(id) {
   return post(`/domains/${id}/deprovision`);
 }
 
+async function destroyDomain(id) {
+  return post(`/domains/${id}/destroy`);
+}
+
 async function fetchEvents(query = {}) {
   return get('/events', query).catch(() => []);
 }
@@ -231,6 +235,7 @@ export {
   fetchDomainDnsResult,
   provisionDomain,
   deprovisionDomain,
+  destroyDomain,
   fetchEvents,
   createOrganization,
   fetchOrganization,

--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -1,10 +1,12 @@
 <script>
-  import { router } from '../../stores';
+  import page from 'page';
+  import { notification, router } from '../../stores';
   import {
     fetchDomain,
     fetchDomainDnsResult,
     provisionDomain,
     deprovisionDomain,
+    destroyDomain,
   } from '../../lib/api';
   import { formatDateTime } from '../../helpers/formatter';
   import { siteName } from '../../lib/utils';
@@ -31,6 +33,18 @@
 
   function deprovision() {
     domainPromise = deprovisionDomain(id);
+  }
+
+  async function destroy() {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm('Are you sure you want to destroy this domain?')) { return null; }
+    try {
+      await destroyDomain(id);
+      page('/domains');
+      return notification.setSuccess(`Domain ${id} deleted successfully!`);
+    } catch (error) {
+      return notification.setError(`Unable to delete domain ${id}: ${error.message}`);
+    }
   }
 </script>
 
@@ -90,6 +104,14 @@
           disabled={!dnsResults.canDeprovision}
           on:click={deprovision}>
           Deprovision
+        </button>
+      {/if}
+      {#if dnsResults.canDestroy}
+        <button
+          class="usa-button usa-button--big"
+          disabled={!dnsResults.canDestroy}
+          on:click={destroy}>
+          Delete
         </button>
       {/if}
     </Await>

--- a/api/admin/controllers/domain.js
+++ b/api/admin/controllers/domain.js
@@ -144,9 +144,12 @@ module.exports = wrapHandlers({
 
     const canDeprovision = DomainService.canDeprovision(domain);
 
+    const canDestroy = DomainService.canDestroy(domain);
+
     return res.json({
       canProvision,
       canDeprovision,
+      canDestroy,
       data: dnsResults,
     });
   },

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -21,6 +21,7 @@ apiRouter.get('/domains/:id', AdminControllers.Domain.findById);
 apiRouter.delete('/domains/:id', AdminControllers.Domain.destroy);
 apiRouter.get('/domains/:id/dns', AdminControllers.Domain.dns);
 apiRouter.get('/domains/:id/dns-result', AdminControllers.Domain.dnsResult);
+apiRouter.post('/domains/:id/destroy', AdminControllers.Domain.destroy);
 apiRouter.post('/domains/:id/deprovision', AdminControllers.Domain.deprovision);
 apiRouter.post('/domains/:id/provision', AdminControllers.Domain.provision);
 apiRouter.post('/domains', parseJson, AdminControllers.Domain.create);

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -229,6 +229,7 @@ async function checkProvisionStatus(id) {
 module.exports.buildDnsRecords = buildDnsRecords;
 module.exports.canProvision = canProvision;
 module.exports.canDeprovision = canDeprovision;
+module.exports.canDestroy = canDestroy;
 module.exports.checkDeprovisionStatus = checkDeprovisionStatus;
 module.exports.checkAcmeChallengeDnsRecord = checkAcmeChallengeDnsRecord;
 module.exports.checkDnsRecords = checkDnsRecords;

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -96,6 +96,48 @@ describe('Domain Service', () => {
     });
   });
 
+  describe('.canDestroy()', () => {
+    it('returns false if domain is provisioned', () => {
+      const domain = DomainFactory.build({ state: Domain.States.Provisioned });
+
+      const result = DomainService.canDestroy(domain);
+
+      expect(result).to.be.false;
+    });
+
+    it('returns false if domain is provisioning', () => {
+      const domain = DomainFactory.build({ state: Domain.States.Provisioning });
+
+      const result = DomainService.canDestroy(domain);
+
+      expect(result).to.be.false;
+    });
+
+    it('returns false if domain is failed', () => {
+      const domain = DomainFactory.build({ state: Domain.States.Failed });
+
+      const result = DomainService.canDestroy(domain);
+
+      expect(result).to.be.false;
+    });
+
+    it('returns false if domain is deprovisioning', () => {
+      const domain = DomainFactory.build({ state: Domain.States.Deprovisioning });
+
+      const result = DomainService.canDestroy(domain);
+
+      expect(result).to.be.false;
+    });
+
+    it('returns true if the domain is pending', () => {
+      const domain = DomainFactory.build();
+
+      const result = DomainService.canDestroy(domain);
+
+      expect(result).to.be.true;
+    });
+  });
+
   describe('.checkDeprovisionStatus()', () => {
     it('does nothing if the domain is not deprovisioning', async () => {
       sinon.spy(CloudFoundryAPIClient.prototype, 'fetchServiceInstances');


### PR DESCRIPTION
## Changes proposed in this pull request:
- Once DNS status is loaded the admin client Show page now provides a Delete button when appropriate (when the domain is in the "Pending" state). 
- Clicking the Delete button triggers a confirmation dialog per #3729 before anything happens. If the admin user confirms then the domain is deleted. 
- On success the user is returned to the domains index page. On failure, any error is displayed as a notification. 

This pull request represents work toward #3689 and should be sufficient to satisfy #3729.

## security considerations
None
