### PR TITLE
Add confirmation dialog before deprovisioning domain

### DIFF
--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -32,7 +32,10 @@
   }
 
   function deprovision() {
-    domainPromise = deprovisionDomain(id);
+    // eslint-disable-next-line no-alert
+    if (window.confirm('Are you sure you want to destroy this domain?')) {
+      domainPromise = deprovisionDomain(id);
+    }
   }
 
   async function destroy() {

--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -33,7 +33,7 @@
 
   function deprovision() {
     // eslint-disable-next-line no-alert
-    if (window.confirm('Are you sure you want to destroy this domain?')) {
+    if (window.confirm('Are you sure you want to deprovision this domain?')) {
       domainPromise = deprovisionDomain(id);
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a confirmation dialog before deprovisioning a domain through the admin client

This uses the same UX as the recently-added confirmation before deleting. It addresses #3729.

## security considerations
None
