### PR TITLE
Domain management site integration

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -172,8 +172,16 @@ module.exports = wrapHandlers({
     };
 
     // Include domain URL(s) in update only if they're managed by an associated Domain
-    const canEditLiveUrl = !DomainService.isSiteUrlManagedByDomain(site, site.Domains, 'site');
-    const canEditDemoUrl = !DomainService.isSiteUrlManagedByDomain(site, site.Domains, 'demo');
+    const canEditLiveUrl = !DomainService.isSiteUrlManagedByDomain(
+      site,
+      site.Domains,
+      Domain.Contexts.Site
+    );
+    const canEditDemoUrl = !DomainService.isSiteUrlManagedByDomain(
+      site,
+      site.Domains,
+      Domain.Contexts.Demo
+    );
     if (canEditLiveUrl) {
       updateParams.domain = params.domain;
     }

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -164,20 +164,22 @@ module.exports = wrapHandlers({
     const params = Object.assign(site, body);
     const updateParams = {
       demoBranch: params.demoBranch,
-      demoDomain: params.demoDomain,
       defaultConfig: params.defaultConfig,
       previewConfig: params.previewConfig,
       demoConfig: params.demoConfig,
       defaultBranch: params.defaultBranch,
-      domain: params.domain,
       engine: params.engine,
     };
 
-    // Exclude domain URL(s) from update if they're managed by an associated Domain
+    // Include domain URL(s) in update only if they're managed by an associated Domain
     const canEditLiveUrl = !DomainService.isSiteUrlManagedByDomain(site, site.Domains, 'site');
     const canEditDemoUrl = !DomainService.isSiteUrlManagedByDomain(site, site.Domains, 'demo');
-    if (!canEditLiveUrl) { delete updateParams.domain; }
-    if (!canEditDemoUrl) { delete updateParams.demoDomain; }
+    if (canEditLiveUrl) {
+      updateParams.domain = params.domain;
+    }
+    if (canEditDemoUrl) {
+      updateParams.demoDomain = params.demoDomain;
+    }
 
     await site.update(updateParams);
     EventCreator.audit(req.user, Event.labels.USER_ACTION, 'Site Updated', {

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -7,7 +7,7 @@ const UserActionCreator = require('../services/UserActionCreator');
 const EventCreator = require('../services/EventCreator');
 const siteSerializer = require('../serializers/site');
 const {
-  Build, Organization, Site, User, Event,
+  Build, Organization, Site, User, Event, Domain,
 } = require('../models');
 const siteErrors = require('../responses/siteErrors');
 const {
@@ -30,7 +30,7 @@ module.exports = wrapHandlers({
   async findAllForUser(req, res) {
     const { user } = req;
 
-    const sites = await Site.forUser(user).findAll();
+    const sites = await Site.forUser(user).findAll({ include: [Domain] });
 
     if (!sites) {
       return res.notFound();

--- a/api/models/domain.js
+++ b/api/models/domain.js
@@ -111,6 +111,9 @@ function define(sequelize, DataTypes) {
   Domain.prototype.namesArray = function namesArray() {
     return this.names.split(',');
   };
+  Domain.prototype.firstName = function firstName() {
+    return this.namesArray()[0];
+  };
   return Domain;
 }
 

--- a/api/models/domain.js
+++ b/api/models/domain.js
@@ -108,6 +108,9 @@ function define(sequelize, DataTypes) {
   Domain.prototype.isProvisioning = function isProvisioning() {
     return this.state === Domain.States.Provisioning;
   };
+  Domain.prototype.namesArray = function namesArray() {
+    return this.names.split(',');
+  };
   return Domain;
 }
 

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -255,5 +255,6 @@ module.exports = (sequelize, DataTypes) => {
   Site.searchScope = search => ({ method: ['byIdOrText', search] });
   Site.forUser = user => Site.scope({ method: ['forUser', user] });
   Site.domainFromContext = context => (context === 'site' ? 'domain' : 'demoDomain');
+  Site.branchFromContext = context => (context === 'site' ? 'defaultBranch' : 'demoBranch');
   return Site;
 };

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -254,5 +254,6 @@ module.exports = (sequelize, DataTypes) => {
   Site.orgScope = id => ({ method: ['byOrg', id] });
   Site.searchScope = search => ({ method: ['byIdOrText', search] });
   Site.forUser = user => Site.scope({ method: ['forUser', user] });
+  Site.domainFromContext = context => (context === 'site' ? 'domain' : 'demoDomain');
   return Site;
 };

--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -3,6 +3,7 @@ const { omitBy, pick } = require('../utils');
 const { Organization, Site, User } = require('../models');
 const userSerializer = require('./user');
 const { siteViewLink, hideBasicAuthPassword } = require('../utils/site');
+const DomainService = require('../services/Domain');
 
 const allowedAttributes = [
   'id',
@@ -79,6 +80,11 @@ const serializeObject = (site, isSystemAdmin) => {
     delete json.Organization;
   }
 
+  if (site.Domains) {
+    json.canEditLiveUrl = !DomainService.isSiteUrlManagedByDomain(site, site.Domains, 'site');
+    json.canEditDemoUrl = !DomainService.isSiteUrlManagedByDomain(site, site.Domains, 'demo');
+  }
+
   return json;
 };
 
@@ -101,5 +107,5 @@ const serialize = (serializable) => {
 };
 
 module.exports = {
-  serialize, toJSON: serializeNew, serializeNew, serializeMany,
+  serialize, serializeObject, toJSON: serializeNew, serializeNew, serializeMany,
 };

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -124,7 +124,7 @@ function isSiteUrlManagedByDomain(site, domains, context) {
   let siteUrlIsManagedByDomain = false;
   domains.forEach((domain) => {
     if (domain.context === context) {
-      if (domain.names.split(',').find(name => `https://${name}` === site[siteDomain])) {
+      if (domain.namesArray().find(name => `https://${name}` === site[siteDomain])) {
         siteUrlIsManagedByDomain = true;
       }
     }
@@ -154,7 +154,7 @@ async function rebuildAssociatedSite(domain) {
 async function updateSiteForProvisionedDomain(domain) {
   // Populate appropriate site URL if it isn't already set
   const site = await domain.getSite();
-  const firstDomain = `https://${domain.names.split(',')[0]}`;
+  const firstDomain = `https://${domain.namesArray()[0]}`;
   const siteDomain = Site.domainFromContext(domain.context);
   if (isSiteUrlManagedByDomain(site, [domain], domain.context) && site[siteDomain] === null) {
     await site.update({ [siteDomain]: firstDomain });
@@ -216,7 +216,7 @@ async function provision(domain, dnsResults) {
 
   const site = await domain.getSite();
 
-  const [firstDomainName] = domain.names.split(',');
+  const [firstDomainName] = domain.namesArray();
 
   const serviceName = `${firstDomainName}-ext`;
   const origin = siteViewOrigin(site);

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -139,7 +139,6 @@ async function rebuildAssociatedSite(domain) {
   const branch = site[Site.branchFromContext(domain.context)];
   if (branch) {
     await Build.create({
-      user: null,
       site: site.id,
       branch,
       username: 'Federalist Operators',

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -212,7 +212,7 @@ async function provision(domain, dnsResults) {
 
   const site = await domain.getSite();
 
-  const [firstDomainName] = domain.namesArray();
+  const firstDomainName = domain.firstName();
 
   const serviceName = `${firstDomainName}-ext`;
   const origin = siteViewOrigin(site);

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -167,7 +167,7 @@ async function updateSiteForDeprovisionedDomain(domain) {
   // Clear appropriate site URL if it matches a domain name
   const site = await domain.getSite();
   if (isSiteUrlManagedByDomain(site, [domain], domain.context)) {
-    const siteDomain = domain.context === Domain.Contexts.Site ? 'domain' : 'demoDomain';
+    const siteDomain = Site.domainFromContext(domain.context);
     await site.update({ [siteDomain]: null });
     await module.exports.rebuildAssociatedSite(domain, site);
   }

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -12,8 +12,11 @@ const { States } = Domain;
 
 /**
  * @typedef {object} DomainModel
- * @typedef {object} SiteModel
  * @prop {string} state
+ */
+
+/**
+ * @typedef {object} SiteModel
  */
 
 function cfApi() {

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -113,6 +113,22 @@ function checkAcmeChallengeDnsRecord(domain) {
 
 /**
  * @param {DomainModel} domain
+ */
+async function rebuildAssociatedSite(domain) {
+  const site = await domain.getSite();
+  const branch = site[domain.context === 'site' ? 'defaultBranch' : 'demoBranch'];
+  if (branch) {
+    await Build.create({
+      user: null,
+      site: site.id,
+      branch,
+      username: 'Federalist Operators',
+    }).then(b => b.enqueue());
+  }
+}
+
+/**
+ * @param {DomainModel} domain
  * @returns {Promise<DomainModel>}
  */
 async function updateSiteForProvisionedDomain(domain) {
@@ -126,15 +142,7 @@ async function updateSiteForProvisionedDomain(domain) {
     rebuildNeeded = true;
   }
   if (rebuildNeeded) {
-    const branch = site[domain.context === 'site' ? 'defaultBranch' : 'demoBranch'];
-    if (branch) {
-      await Build.create({
-        user: null,
-        site: site.id,
-        branch,
-        username: 'Federalist Operators',
-      }).then(b => b.enqueue());
-    }
+    await rebuildAssociatedSite(domain);
   }
   return domain;
 }
@@ -153,15 +161,7 @@ async function updateSiteForDeprovisionedDomain(domain) {
     rebuildNeeded = true;
   }
   if (rebuildNeeded) {
-    const branch = site[domain.context === 'site' ? 'defaultBranch' : 'demoBranch'];
-    if (branch) {
-      await Build.create({
-        user: null,
-        site: site.id,
-        branch,
-        username: 'Federalist Operators',
-      }).then(b => b.enqueue());
-    }
+    await rebuildAssociatedSite(domain);
   }
   return domain;
 }

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -134,9 +134,9 @@ function isSiteUrlManagedByDomain(site, domains, context) {
 
 /**
  * @param {DomainModel} domain
+ * @param {SiteModel} site
  */
-async function rebuildAssociatedSite(domain) {
-  const site = await domain.getSite();
+async function rebuildAssociatedSite(domain, site) {
   const branch = site[Site.branchFromContext(domain.context)];
   if (branch) {
     await Build.create({
@@ -158,7 +158,7 @@ async function updateSiteForProvisionedDomain(domain) {
   const siteDomain = Site.domainFromContext(domain.context);
   if (isSiteUrlManagedByDomain(site, [domain], domain.context) && site[siteDomain] === null) {
     await site.update({ [siteDomain]: firstDomain });
-    await module.exports.rebuildAssociatedSite(domain);
+    await module.exports.rebuildAssociatedSite(domain, site);
   }
   return domain;
 }
@@ -173,7 +173,7 @@ async function updateSiteForDeprovisionedDomain(domain) {
   if (isSiteUrlManagedByDomain(site, [domain], domain.context)) {
     const siteDomain = domain.context === Domain.Contexts.Site ? 'domain' : 'demoDomain';
     await site.update({ [siteDomain]: null });
-    await module.exports.rebuildAssociatedSite(domain);
+    await module.exports.rebuildAssociatedSite(domain, site);
   }
   return domain;
 }

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -169,6 +169,12 @@ async function provision(domain, dnsResults) {
     state: States.Provisioning,
   });
 
+  // Populate appropriate site URL if it isn't already set
+  const firstDomain = `https://${domain.names.split(',')[0]}`;
+  const siteDomain = domain.context === 'site' ? 'domain' : 'demoDomain';
+  await site.update({ [siteDomain]: firstDomain });
+  // TODO: check whether Site.domain is set before updating
+
   queueProvisionStatusCheck(domain.id);
 
   return domain;

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -154,7 +154,7 @@ async function deprovision(domain) {
 
   await domain.update({ state: States.Deprovisioning });
 
-  await updateSiteForDeprovisionedDomain(domain);
+  await module.exports.updateSiteForDeprovisionedDomain(domain);
 
   queueDeprovisionStatusCheck(domain.id);
 
@@ -201,7 +201,7 @@ async function provision(domain, dnsResults) {
     state: States.Provisioning,
   });
 
-  await updateSiteForProvisionedDomain(domain);
+  await module.exports.updateSiteForProvisionedDomain(domain);
 
   queueProvisionStatusCheck(domain.id);
 
@@ -261,6 +261,8 @@ async function checkProvisionStatus(id) {
 }
 
 module.exports.buildDnsRecords = buildDnsRecords;
+module.exports.updateSiteForProvisionedDomain = updateSiteForProvisionedDomain;
+module.exports.updateSiteForDeprovisionedDomain = updateSiteForDeprovisionedDomain;
 module.exports.canProvision = canProvision;
 module.exports.canDeprovision = canDeprovision;
 module.exports.canDestroy = canDestroy;

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -156,7 +156,7 @@ async function updateSiteForProvisionedDomain(domain) {
   const site = await domain.getSite();
   const firstDomain = `https://${domain.names.split(',')[0]}`;
   const siteDomain = Site.domainFromContext(domain.context);
-  if (site[siteDomain] === null) {
+  if (isSiteUrlManagedByDomain(site, [domain], domain.context) && site[siteDomain] === null) {
     await site.update({ [siteDomain]: firstDomain });
     await module.exports.rebuildAssociatedSite(domain);
   }

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -120,8 +120,13 @@ async function updateSiteForProvisionedDomain(domain) {
   const site = await domain.getSite();
   const firstDomain = `https://${domain.names.split(',')[0]}`;
   const siteDomain = domain.context === 'site' ? 'domain' : 'demoDomain';
+  let rebuildNeeded = false;
   if (site[siteDomain] === null) {
     await site.update({ [siteDomain]: firstDomain });
+    rebuildNeeded = true;
+  }
+  if (rebuildNeeded) {
+    // TODO: Rebuild
   }
   return domain;
 }
@@ -131,12 +136,20 @@ async function updateSiteForProvisionedDomain(domain) {
  * @returns {Promise<DomainModel>}
  */
 async function updateSiteForDeprovisionedDomain(domain) {
-  // Clear appropriate site URL if it matches first domain
+  // Clear appropriate site URL if it matches a domain name
   const site = await domain.getSite();
-  const firstDomain = `https://${domain.names.split(',')[0]}`;
   const siteDomain = domain.context === 'site' ? 'domain' : 'demoDomain';
-  if (site[siteDomain] === firstDomain) {
-    await site.update({ [siteDomain]: null });
+  let rebuildNeeded = false;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const domainName of domain.names.split(',')) {
+    if (site[siteDomain] === `https://${domainName}`) {
+      // eslint-disable-next-line no-await-in-loop
+      await site.update({ [siteDomain]: null });
+      rebuildNeeded = true;
+    }
+  }
+  if (rebuildNeeded) {
+    // TODO: Rebuild
   }
   return domain;
 }

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -140,13 +140,9 @@ async function updateSiteForDeprovisionedDomain(domain) {
   const site = await domain.getSite();
   const siteDomain = domain.context === 'site' ? 'domain' : 'demoDomain';
   let rebuildNeeded = false;
-  // eslint-disable-next-line no-restricted-syntax
-  for (const domainName of domain.names.split(',')) {
-    if (site[siteDomain] === `https://${domainName}`) {
-      // eslint-disable-next-line no-await-in-loop
-      await site.update({ [siteDomain]: null });
-      rebuildNeeded = true;
-    }
+  if (domain.names.split(',').find(name => `https://${name}` === site[siteDomain])) {
+    await site.update({ [siteDomain]: null });
+    rebuildNeeded = true;
   }
   if (rebuildNeeded) {
     // TODO: Rebuild

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -115,7 +115,7 @@ function checkAcmeChallengeDnsRecord(domain) {
 /**
  * @param {SiteModel} site
  * @param {DomainModel[]} domains
- * @param {string} context 'site' or 'demo' corresponding to Domain.context
+ * @param {string} context Domain.Contexts.Site or DomainContexts.Demo
  */
 function isSiteUrlManagedByDomain(site, domains, context) {
   const siteDomain = Site.domainFromContext(context);
@@ -171,7 +171,7 @@ async function updateSiteForDeprovisionedDomain(domain) {
   // Clear appropriate site URL if it matches a domain name
   const site = await domain.getSite();
   if (isSiteUrlManagedByDomain(site, [domain], domain.context)) {
-    const siteDomain = domain.context === 'site' ? 'domain' : 'demoDomain';
+    const siteDomain = domain.context === Domain.Contexts.Site ? 'domain' : 'demoDomain';
     await site.update({ [siteDomain]: null });
     await module.exports.rebuildAssociatedSite(domain);
   }

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -124,6 +124,14 @@ async function deprovision(domain) {
 
   await domain.update({ state: States.Deprovisioning });
 
+  // Clear appropriate site URL if it matches first domain
+  const site = await domain.getSite();
+  const firstDomain = `https://${domain.names.split(',')[0]}`;
+  const siteDomain = domain.context === 'site' ? 'domain' : 'demoDomain';
+  if (site[siteDomain] === firstDomain) {
+    await site.update({ [siteDomain]: null });
+  }
+
   queueDeprovisionStatusCheck(domain.id);
 
   return domain;

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -121,14 +121,10 @@ function isSiteUrlManagedByDomain(site, domains, context) {
   const siteDomain = Site.domainFromContext(context);
   if (site[siteDomain] === null) { return true; }
   if (domains.length === 0) { return false; }
-  let siteUrlIsManagedByDomain = false;
-  domains.forEach((domain) => {
-    if (domain.context === context) {
-      if (domain.namesArray().find(name => `https://${name}` === site[siteDomain])) {
-        siteUrlIsManagedByDomain = true;
-      }
-    }
-  });
+  const siteUrlIsManagedByDomain = domains
+    .filter(domain => domain.context === context)
+    .some(domain => domain.namesArray()
+      .some(name => `https://${name}` === site[siteDomain]));
   return siteUrlIsManagedByDomain;
 }
 

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -1,6 +1,6 @@
 const IORedis = require('ioredis');
 
-const { Domain } = require('../models');
+const { Domain, Build } = require('../models');
 const { path: sitePath, siteViewOrigin } = require('../utils/site');
 const CloudFoundryAPIClient = require('../utils/cfApiClient');
 const { DomainQueue } = require('../queues');
@@ -126,7 +126,15 @@ async function updateSiteForProvisionedDomain(domain) {
     rebuildNeeded = true;
   }
   if (rebuildNeeded) {
-    // TODO: Rebuild
+    const branch = site[domain.context === 'site' ? 'defaultBranch' : 'demoBranch'];
+    if (branch) {
+      await Build.create({
+        user: null,
+        site: site.id,
+        branch,
+        username: 'Federalist Operators',
+      }).then(b => b.enqueue());
+    }
   }
   return domain;
 }
@@ -145,7 +153,15 @@ async function updateSiteForDeprovisionedDomain(domain) {
     rebuildNeeded = true;
   }
   if (rebuildNeeded) {
-    // TODO: Rebuild
+    const branch = site[domain.context === 'site' ? 'defaultBranch' : 'demoBranch'];
+    if (branch) {
+      await Build.create({
+        user: null,
+        site: site.id,
+        branch,
+        username: 'Federalist Operators',
+      }).then(b => b.enqueue());
+    }
   }
   return domain;
 }

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -154,8 +154,6 @@ async function deprovision(domain) {
 
   await domain.update({ state: States.Deprovisioning });
 
-  await module.exports.updateSiteForDeprovisionedDomain(domain);
-
   queueDeprovisionStatusCheck(domain.id);
 
   return domain;
@@ -201,8 +199,6 @@ async function provision(domain, dnsResults) {
     state: States.Provisioning,
   });
 
-  await module.exports.updateSiteForProvisionedDomain(domain);
-
   queueProvisionStatusCheck(domain.id);
 
   return domain;
@@ -227,6 +223,7 @@ async function checkDeprovisionStatus(id) {
       serviceName: null,
       state: States.Pending,
     });
+    await module.exports.updateSiteForDeprovisionedDomain(domain);
     return `Domain ${id}|${domain.names} successfully deprovisioned.`;
   }
   // TODO - this does not handle the case where deprovisioning fails
@@ -250,6 +247,7 @@ async function checkProvisionStatus(id) {
   switch (lastOperation) {
     case 'succeeded':
       await domain.update({ state: States.Provisioned });
+      await module.exports.updateSiteForProvisionedDomain(domain);
       return `Domain ${id}|${domain.names} successfully provisioned.`;
     case 'failed':
       await domain.update({ state: States.Failed });

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -142,7 +142,7 @@ async function updateSiteForProvisionedDomain(domain) {
     rebuildNeeded = true;
   }
   if (rebuildNeeded) {
-    await rebuildAssociatedSite(domain);
+    await module.exports.rebuildAssociatedSite(domain);
   }
   return domain;
 }
@@ -161,7 +161,7 @@ async function updateSiteForDeprovisionedDomain(domain) {
     rebuildNeeded = true;
   }
   if (rebuildNeeded) {
-    await rebuildAssociatedSite(domain);
+    await module.exports.rebuildAssociatedSite(domain);
   }
   return domain;
 }
@@ -284,6 +284,7 @@ async function checkProvisionStatus(id) {
 }
 
 module.exports.buildDnsRecords = buildDnsRecords;
+module.exports.rebuildAssociatedSite = rebuildAssociatedSite;
 module.exports.updateSiteForProvisionedDomain = updateSiteForProvisionedDomain;
 module.exports.updateSiteForDeprovisionedDomain = updateSiteForDeprovisionedDomain;
 module.exports.canProvision = canProvision;

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -172,8 +172,9 @@ async function provision(domain, dnsResults) {
   // Populate appropriate site URL if it isn't already set
   const firstDomain = `https://${domain.names.split(',')[0]}`;
   const siteDomain = domain.context === 'site' ? 'domain' : 'demoDomain';
-  await site.update({ [siteDomain]: firstDomain });
-  // TODO: check whether Site.domain is set before updating
+  if (site[siteDomain] === null) {
+    await site.update({ [siteDomain]: firstDomain });
+  }
 
   queueProvisionStatusCheck(domain.id);
 

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -1,6 +1,6 @@
 const IORedis = require('ioredis');
 
-const { Domain, Build } = require('../models');
+const { Domain, Build, Site } = require('../models');
 const { path: sitePath, siteViewOrigin } = require('../utils/site');
 const CloudFoundryAPIClient = require('../utils/cfApiClient');
 const { DomainQueue } = require('../queues');
@@ -117,7 +117,7 @@ function checkAcmeChallengeDnsRecord(domain) {
  * @param {string} context 'site' or 'demo' corresponding to Domain.context
  */
 function isSiteUrlManagedByDomain(site, domains, context) {
-  const siteDomain = context === 'site' ? 'domain' : 'demoDomain';
+  const siteDomain = Site.domainFromContext(context);
   if (site[siteDomain] === null) { return true; }
   if (domains.length === 0) { return false; }
   let siteUrlIsManagedByDomain = false;
@@ -155,7 +155,7 @@ async function updateSiteForProvisionedDomain(domain) {
   // Populate appropriate site URL if it isn't already set
   const site = await domain.getSite();
   const firstDomain = `https://${domain.names.split(',')[0]}`;
-  const siteDomain = domain.context === 'site' ? 'domain' : 'demoDomain';
+  const siteDomain = Site.domainFromContext(domain.context);
   if (site[siteDomain] === null) {
     await site.update({ [siteDomain]: firstDomain });
     await module.exports.rebuildAssociatedSite(domain);

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -154,7 +154,7 @@ async function rebuildAssociatedSite(domain) {
 async function updateSiteForProvisionedDomain(domain) {
   // Populate appropriate site URL if it isn't already set
   const site = await domain.getSite();
-  const firstDomain = `https://${domain.namesArray()[0]}`;
+  const firstDomain = `https://${domain.firstName()}`;
   const siteDomain = Site.domainFromContext(domain.context);
   if (isSiteUrlManagedByDomain(site, [domain], domain.context) && site[siteDomain] === null) {
     await site.update({ [siteDomain]: firstDomain });

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -12,6 +12,7 @@ const { States } = Domain;
 
 /**
  * @typedef {object} DomainModel
+ * @typedef {object} SiteModel
  * @prop {string} state
  */
 

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -136,7 +136,7 @@ function isSiteUrlManagedByDomain(site, domains, context) {
  */
 async function rebuildAssociatedSite(domain) {
   const site = await domain.getSite();
-  const branch = site[domain.context === 'site' ? 'defaultBranch' : 'demoBranch'];
+  const branch = site[Site.branchFromContext(domain.context)];
   if (branch) {
     await Build.create({
       user: null,

--- a/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
+++ b/frontend/components/site/SiteSettings/BasicSiteSettings.jsx
@@ -51,6 +51,7 @@ export const BasicSiteSettings = ({
             id="domainInput"
             placeholder="https://example.gov"
             className="form-control"
+            disabled={!initialValues.canEditLiveUrl}
           />
           )}
       </fieldset>
@@ -82,6 +83,7 @@ export const BasicSiteSettings = ({
             id="demoDomainInput"
             placeholder="https://demo.example.gov"
             className="form-control"
+            disabled={!initialValues.canEditDemoUrl}
           />
           )}
       </fieldset>
@@ -112,6 +114,8 @@ BasicSiteSettings.propTypes = {
     domain: PropTypes.string,
     demoBranch: PropTypes.string,
     demoDomain: PropTypes.string,
+    canEditLiveUrl: PropTypes.bool,
+    canEditDemoUrl: PropTypes.bool,
   }).isRequired,
 
   // the following props are from reduxForm:

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -45,6 +45,8 @@ class SiteSettings extends React.Component {
       domain: site.domain || '',
       demoBranch: site.demoBranch || '',
       demoDomain: site.demoDomain || '',
+      canEditLiveUrl: site.canEditLiveUrl,
+      canEditDemoUrl: site.canEditDemoUrl,
     };
 
     const advancedInitialValues = {

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -111,6 +111,12 @@
           "required": ["githubAccessToken", "githubUserId"]
         }
       }
+    },
+    "canEditLiveUrl": {
+      "type": "boolean"
+    },
+    "canEditDemoUrl": {
+      "type": "boolean"
     }
   }
 }

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -23,6 +23,7 @@ const siteErrors = require('../../../api/responses/siteErrors');
 const SiteBuildQueue = require('../../../api/services/SiteBuildQueue');
 const FederalistUsersHelper = require('../../../api/services/FederalistUsersHelper');
 const EventCreator = require('../../../api/services/EventCreator');
+const DomainService = require('../../../api/services/Domain');
 
 const authErrorMessage = 'You are not permitted to perform this action. Are you sure you are logged in?';
 
@@ -1649,6 +1650,50 @@ describe('Site API', () => {
         .then((foundSite) => {
           expect(foundSite.defaultConfig).to.deep.equal({ new: true });
           expect(foundSite.domain).to.equal('https://example.com');
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should ignore domain URLs in the request body if the URLs are managed by an associated domain', (done) => {
+      let site;
+      const userPromise = factory.user();
+      const sitePromise = factory.site({
+        users: Promise.all([userPromise]),
+        defaultConfig: { old: true },
+        domain: 'https://example.com',
+        demoDomain: 'https://demo.example.com'
+      });
+      const cookiePromise = authenticatedSession(userPromise);
+      sinon.stub(DomainService, 'isSiteUrlManagedByDomain').returns(true);
+
+      Promise.props({
+        user: userPromise,
+        site: sitePromise,
+        cookie: cookiePromise,
+      })
+        .then((results) => {
+          ({ site } = results);
+
+          return request(app)
+            .put(`/v0/site/${site.id}`)
+            .set('x-csrf-token', csrfToken.getToken())
+            .send({
+              defaultConfig: 'new: true',
+              domain: 'https://changed.example.gov',
+              demoDomain: 'https://new.example.gov'
+            })
+            .set('Cookie', results.cookie)
+            .expect(200);
+        })
+        .then((response) => {
+          validateAgainstJSONSchema('PUT', '/site/{id}', 200, response.body);
+          return Site.findByPk(site.id);
+        })
+        .then((foundSite) => {
+          expect(foundSite.defaultConfig).to.deep.equal({ new: true });
+          expect(foundSite.domain).to.equal('https://example.com');
+          expect(foundSite.demoDomain).to.equal('https://demo.example.com');
           done();
         })
         .catch(done);

--- a/test/api/unit/serializers/site.test.js
+++ b/test/api/unit/serializers/site.test.js
@@ -3,7 +3,7 @@ const validateJSONSchema = require('jsonschema').validate;
 
 const siteSchema = require('../../../../public/swagger/Site.json');
 const factory = require('../../support/factory');
-const { Domain, Site } = require('../../../../api/models');
+const { Domain } = require('../../../../api/models');
 
 const SiteSerializer = require('../../../../api/serializers/site');
 

--- a/test/api/unit/serializers/site.test.js
+++ b/test/api/unit/serializers/site.test.js
@@ -68,7 +68,7 @@ describe('SiteSerializer', () => {
 
     it('includes URL editability when associated to domain', async () => {
       const site = await factory.site({ domain: 'https://www.agency.gov', demoDomain: null });
-      const domain = await factory.domain.create({ siteId: site.id, names: 'www.agency.gov', context: 'site' });
+      const domain = await factory.domain.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Site });
       await site.reload({ include: [ Domain ] });
       const object = await SiteSerializer.serializeObject(site);
 

--- a/test/api/unit/serializers/site.test.js
+++ b/test/api/unit/serializers/site.test.js
@@ -1,4 +1,4 @@
-const { expect, assert } = require('chai');
+const { expect } = require('chai');
 const validateJSONSchema = require('jsonschema').validate;
 
 const siteSchema = require('../../../../public/swagger/Site.json');

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -462,7 +462,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov' });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.true;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Site)).to.be.true;
     });
 
     it('reports a domain-managed site demo URL when the URL matches a demo-context domain', async () => {
@@ -470,7 +470,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Demo)).to.be.true;
     });
 
     it('reports a domain-managed site live URL when the site live URL is null', async () => {
@@ -478,7 +478,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov' });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.true;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Site)).to.be.true;
     });
 
     it('reports a domain-managed site demo URL when the site demo URL is null', async () => {
@@ -486,7 +486,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Demo)).to.be.true;
     });
 
     it('reports a domain-managed site live URL when the URL matches a first site-context domain name', async () => {
@@ -494,7 +494,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov' });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.true;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Site)).to.be.true;
     });
 
     it('reports a domain-managed site live URL when the URL matches a first demo-context domain name', async () => {
@@ -502,7 +502,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Demo)).to.be.true;
     });
 
     it('reports a domain-managed site live URL when the URL matches a non-first site-context domain name', async () => {
@@ -510,7 +510,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov' });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.true;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Site)).to.be.true;
     });
 
     it('reports a domain-managed site live URL when the URL matches a non-first demo-context domain name', async () => {
@@ -518,7 +518,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Demo)).to.be.true;
     });
 
     it('reports a non domain-managed site live URL when the URL does not match a site-context domain name', async () => {
@@ -526,7 +526,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov' });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.false;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Site)).to.be.false;
     });
 
     it('reports a non domain-managed site demo URL when the URL does not match a demo-context domain name', async () => {
@@ -534,7 +534,7 @@ describe('Domain Service', () => {
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
-      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.false;
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], Domain.Contexts.Demo)).to.be.false;
     });
 
     it('reports a non domain-managed site URL when an empty domain array is offered for evaluation', async () => {

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -352,7 +352,7 @@ describe('Domain Service', () => {
       await site.reload( { include: [ Build ] });
       expect(site.Builds).to.have.length(0);
 
-      await DomainService.rebuildAssociatedSite(domain);
+      await DomainService.rebuildAssociatedSite(domain, site);
 
       await site.reload( { include: [ Build ] });
       expect(site.Builds).to.have.length(1);
@@ -366,7 +366,7 @@ describe('Domain Service', () => {
       await site.reload( { include: [ Build ] });
       expect(site.Builds).to.have.length(0);
 
-      await DomainService.rebuildAssociatedSite(domain);
+      await DomainService.rebuildAssociatedSite(domain, site);
 
       await site.reload( { include: [ Build ] });
       expect(site.Builds).to.have.length(1);
@@ -392,7 +392,7 @@ describe('Domain Service', () => {
       await site.reload();
       expect(site.domain).to.eq('https://www.agency.gov');
       expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain);
+      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain, site);
     });
 
     it('sets the demo domain name on the associated site if not previously set', async () => {
@@ -412,7 +412,7 @@ describe('Domain Service', () => {
       await site.reload();
       expect(site.domain).to.eq(null);
       expect(site.demoDomain).to.eq('https://www.agency.gov');
-      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain);
+      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain, site);
     });
 
     it('leaves the existing domain name on its associated site unchanged', async () => {
@@ -581,7 +581,7 @@ describe('Domain Service', () => {
       await site.reload();
       expect(site.domain).to.eq(null);
       expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain);
+      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain, site);
     });
 
     it('unsets a matching first domain name on its associated site', async () => {
@@ -600,7 +600,7 @@ describe('Domain Service', () => {
       await site.reload();
       expect(site.domain).to.eq(null);
       expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain);
+      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain, site);
     });
 
     it('unsets a matching non-first domain name on its associated site', async () => {
@@ -619,7 +619,7 @@ describe('Domain Service', () => {
       await site.reload();
       expect(site.domain).to.eq(null);
       expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain);
+      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain, site);
     });
 
     it('unsets a matching demo domain name on its associated site', async () => {
@@ -638,7 +638,7 @@ describe('Domain Service', () => {
       await site.reload();
       expect(site.domain).to.eq(null);
       expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain);
+      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain, site);
     });
 
     it('unsets a matching first demo domain name on its associated site', async () => {
@@ -657,7 +657,7 @@ describe('Domain Service', () => {
       await site.reload();
       expect(site.domain).to.eq(null);
       expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain);
+      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain, site);
     });
 
     it('unsets a matching non-first demo domain name on its associated site', async () => {
@@ -676,7 +676,7 @@ describe('Domain Service', () => {
       await site.reload();
       expect(site.domain).to.eq(null);
       expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain);
+      sinon.assert.calledOnceWithExactly(siteBuildSpy, domain, site);
     });
 
     it('leaves a non-matching domain name on its associated site alone', async () => {

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -437,11 +437,79 @@ describe('Domain Service', () => {
       expect(site.demoDomain).to.eq(null);
     });
 
+    it('unsets a matching first domain name on its associated site', async () => {
+      const site = await SiteFactory({ domain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov', state: Domain.States.Provisioning });
+
+      expect(domain.names).to.eq('www.agency.gov,www.foo.gov,www.bar.gov');
+      expect(domain.context).to.eq('site');
+
+      await domain.reload({ include: [ Site ] });
+      expect(site.domain).to.eq('https://www.agency.gov');
+      expect(site.demoDomain).to.eq(null);
+
+      await DomainService.updateSiteForDeprovisionedDomain(domain);
+      await site.reload();
+      expect(site.domain).to.eq(null);
+      expect(site.demoDomain).to.eq(null);
+    });
+
+    it('unsets a matching non-first domain name on its associated site', async () => {
+      const site = await SiteFactory({ domain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov', state: Domain.States.Provisioning });
+
+      expect(domain.names).to.eq('www.foo.gov,www.agency.gov,www.bar.gov');
+      expect(domain.context).to.eq('site');
+
+      await domain.reload({ include: [ Site ] });
+      expect(site.domain).to.eq('https://www.agency.gov');
+      expect(site.demoDomain).to.eq(null);
+
+      await DomainService.updateSiteForDeprovisionedDomain(domain);
+      await site.reload();
+      expect(site.domain).to.eq(null);
+      expect(site.demoDomain).to.eq(null);
+    });
+
     it('unsets a matching demo domain name on its associated site', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
       const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo', state: Domain.States.Provisioning });
 
       expect(domain.names).to.eq('www.agency.gov');
+      expect(domain.context).to.eq('demo');
+
+      await domain.reload({ include: [ Site ] });
+      expect(site.domain).to.eq(null);
+      expect(site.demoDomain).to.eq('https://www.agency.gov');
+
+      await DomainService.updateSiteForDeprovisionedDomain(domain);
+      await site.reload();
+      expect(site.domain).to.eq(null);
+      expect(site.demoDomain).to.eq(null);
+    });
+
+    it('unsets a matching first demo domain name on its associated site', async () => {
+      const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov', context: 'demo', state: Domain.States.Provisioning });
+
+      expect(domain.names).to.eq('www.agency.gov,www.foo.gov,www.bar.gov');
+      expect(domain.context).to.eq('demo');
+
+      await domain.reload({ include: [ Site ] });
+      expect(site.domain).to.eq(null);
+      expect(site.demoDomain).to.eq('https://www.agency.gov');
+
+      await DomainService.updateSiteForDeprovisionedDomain(domain);
+      await site.reload();
+      expect(site.domain).to.eq(null);
+      expect(site.demoDomain).to.eq(null);
+    });
+
+    it('unsets a matching non-first demo domain name on its associated site', async () => {
+      const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov', context: 'demo', state: Domain.States.Provisioning });
+
+      expect(domain.names).to.eq('www.foo.gov,www.agency.gov,www.bar.gov');
       expect(domain.context).to.eq('demo');
 
       await domain.reload({ include: [ Site ] });

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -3,8 +3,7 @@ const sinon = require('sinon');
 
 const { Domain, Build } = require('../../../../api/models');
 const { Site } = require('../../../../api/models');
-const { domain: DomainFactory } = require('../../support/factory');
-const { site: SiteFactory } = require('../../support/factory');
+const { domain: DomainFactory, site: SiteFactory } = require('../../support/factory');
 const DnsService = require('../../../../api/services/Dns');
 const DomainService = require('../../../../api/services/Domain');
 const CloudFoundryAPIClient = require('../../../../api/utils/cfApiClient');

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -1,8 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const { Domain, Build } = require('../../../../api/models');
-const { Site } = require('../../../../api/models');
+const { Domain, Build, Site } = require('../../../../api/models');
 const { domain: DomainFactory, site: SiteFactory } = require('../../support/factory');
 const DnsService = require('../../../../api/services/Dns');
 const DomainService = require('../../../../api/services/Domain');

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -456,6 +456,114 @@ describe('Domain Service', () => {
     });
   });
 
+  describe('.isSiteUrlManagedByDomain()', () => {
+    it('reports a domain-managed site live URL when the URL matches a site-context domain', async () => {
+      const site = await SiteFactory({ domain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.true;
+    });
+
+    it('reports a domain-managed site demo URL when the URL matches a demo-context domain', async () => {
+      const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
+    });
+
+    it('reports a domain-managed site live URL when the site live URL is null', async () => {
+      const site = await SiteFactory({ domain: null });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.true;
+    });
+
+    it('reports a domain-managed site demo URL when the site demo URL is null', async () => {
+      const site = await SiteFactory({ demoDomain: null });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
+    });
+
+    it('reports a domain-managed site live URL when the URL matches a first site-context domain name', async () => {
+      const site = await SiteFactory({ domain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.true;
+    });
+
+    it('reports a domain-managed site live URL when the URL matches a first demo-context domain name', async () => {
+      const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov', context: 'demo' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
+    });
+
+    it('reports a domain-managed site live URL when the URL matches a non-first site-context domain name', async () => {
+      const site = await SiteFactory({ domain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.true;
+    });
+
+    it('reports a domain-managed site live URL when the URL matches a non-first demo-context domain name', async () => {
+      const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov', context: 'demo' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
+    });
+
+    it('reports a non domain-managed site live URL when the URL does not match a site-context domain name', async () => {
+      const site = await SiteFactory({ domain: 'https://www.example.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'site')).to.be.false;
+    });
+
+    it('reports a non domain-managed site demo URL when the URL does not match a demo-context domain name', async () => {
+      const site = await SiteFactory({ demoDomain: 'https://www.example.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo' });
+      await domain.reload({ include: [ Site ] });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.false;
+    });
+
+    it('reports a non domain-managed site URL when an empty domain array is offered for evaluation', async () => {
+      const site = await SiteFactory({ domain: 'https://www.example.gov' });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [], 'site')).to.be.false;
+    });
+
+    it('reports a non domain-managed demo URL when an empty domain array is offered for evaluation', async () => {
+      const site = await SiteFactory({ demoDomain: 'https://www.example.gov' });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [], 'demo')).to.be.false;
+    });
+
+    it('reports a domain-managed site URL when URL is null even if an empty domain array is offered for evaluation', async () => {
+      const site = await SiteFactory({ domain: null });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [], 'site')).to.be.true;
+    });
+
+    it('reports a domain-managed demo URL when URL is null even if an empty domain array is offered for evaluation', async () => {
+      const site = await SiteFactory({ demoDomain: null });
+
+      expect(DomainService.isSiteUrlManagedByDomain(site, [], 'demo')).to.be.true;
+    });
+
+
+  });
+
   describe('.updateSiteForDeprovisionedDomain()', () => {
     it('unsets a matching domain name on its associated site', async () => {
       const site = await SiteFactory({ domain: 'https://www.agency.gov' });

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -1,4 +1,4 @@
-const { expect, assert } = require('chai');
+const { expect } = require('chai');
 const sinon = require('sinon');
 
 const { Domain, Build } = require('../../../../api/models');

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -361,7 +361,7 @@ describe('Domain Service', () => {
 
     it('triggers a rebuild on its associated site with matching demo domain name', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.agency.gov', demoBranch: 'demo' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo', state: Domain.States.Provisioning });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo, state: Domain.States.Provisioning });
 
       await site.reload( { include: [ Build ] });
       expect(site.Builds).to.have.length(0);
@@ -397,7 +397,7 @@ describe('Domain Service', () => {
 
     it('sets the demo domain name on the associated site if not previously set', async () => {
       const site = await SiteFactory();
-      const domain = await DomainFactory.create({ siteId: site.id, context: 'demo', names: 'www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, context: Domain.Contexts.Demo, names: 'www.agency.gov' });
       const siteBuildSpy = sinon.spy(DomainService, 'rebuildAssociatedSite');
 
       expect(domain.names).to.eq('www.agency.gov');
@@ -437,7 +437,7 @@ describe('Domain Service', () => {
 
     it('leaves the existing domain name on its associated site unchanged', async () => {
       const site = await SiteFactory({ demoDomain: 'https://example.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, context: 'demo', names: 'www.agency.gov' });
+      const domain = await DomainFactory.create({ siteId: site.id, context: Domain.Contexts.Demo, names: 'www.agency.gov' });
       const siteBuildSpy = sinon.spy(DomainService, 'rebuildAssociatedSite');
 
       expect(domain.names).to.eq('www.agency.gov');
@@ -467,7 +467,7 @@ describe('Domain Service', () => {
 
     it('reports a domain-managed site demo URL when the URL matches a demo-context domain', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
       expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
@@ -483,7 +483,7 @@ describe('Domain Service', () => {
 
     it('reports a domain-managed site demo URL when the site demo URL is null', async () => {
       const site = await SiteFactory({ demoDomain: null });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
       expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
@@ -499,7 +499,7 @@ describe('Domain Service', () => {
 
     it('reports a domain-managed site live URL when the URL matches a first demo-context domain name', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov', context: 'demo' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
       expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
@@ -515,7 +515,7 @@ describe('Domain Service', () => {
 
     it('reports a domain-managed site live URL when the URL matches a non-first demo-context domain name', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov', context: 'demo' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
       expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.true;
@@ -531,7 +531,7 @@ describe('Domain Service', () => {
 
     it('reports a non domain-managed site demo URL when the URL does not match a demo-context domain name', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.example.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo' });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo });
       await domain.reload({ include: [ Site ] });
 
       expect(DomainService.isSiteUrlManagedByDomain(site, [domain], 'demo')).to.be.false;
@@ -624,7 +624,7 @@ describe('Domain Service', () => {
 
     it('unsets a matching demo domain name on its associated site', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo', state: Domain.States.Provisioning });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo, state: Domain.States.Provisioning });
       const siteBuildSpy = sinon.spy(DomainService, 'rebuildAssociatedSite');
 
       expect(domain.names).to.eq('www.agency.gov');
@@ -643,7 +643,7 @@ describe('Domain Service', () => {
 
     it('unsets a matching first demo domain name on its associated site', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov', context: 'demo', state: Domain.States.Provisioning });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov,www.foo.gov,www.bar.gov', context: Domain.Contexts.Demo, state: Domain.States.Provisioning });
       const siteBuildSpy = sinon.spy(DomainService, 'rebuildAssociatedSite');
 
       expect(domain.names).to.eq('www.agency.gov,www.foo.gov,www.bar.gov');
@@ -662,7 +662,7 @@ describe('Domain Service', () => {
 
     it('unsets a matching non-first demo domain name on its associated site', async () => {
       const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov', context: 'demo', state: Domain.States.Provisioning });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.foo.gov,www.agency.gov,www.bar.gov', context: Domain.Contexts.Demo, state: Domain.States.Provisioning });
       const siteBuildSpy = sinon.spy(DomainService, 'rebuildAssociatedSite');
 
       expect(domain.names).to.eq('www.foo.gov,www.agency.gov,www.bar.gov');
@@ -700,7 +700,7 @@ describe('Domain Service', () => {
 
     it('leaves a non-matching demo domain name on its associated site alone', async () => {
       const site = await SiteFactory({ demoDomain: 'https://example.gov' });
-      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: 'demo', state: Domain.States.Provisioning });
+      const domain = await DomainFactory.create({ siteId: site.id, names: 'www.agency.gov', context: Domain.Contexts.Demo, state: Domain.States.Provisioning });
       const siteBuildSpy = sinon.spy(DomainService, 'rebuildAssociatedSite');
 
       expect(domain.names).to.eq('www.agency.gov');

--- a/test/frontend/components/site/SiteSettings/BasicSiteSettings.test.jsx
+++ b/test/frontend/components/site/SiteSettings/BasicSiteSettings.test.jsx
@@ -11,6 +11,8 @@ describe('<BasicSiteSettings/>', () => {
       initialValues: {
         defaultBranch: 'main',
         domain: 'https://example.gov',
+        canEditLiveUrl: false,
+        canEditDemoUrl: true,
       },
       handleSubmit: spy(),
       reset: spy(),
@@ -41,6 +43,7 @@ describe('<BasicSiteSettings/>', () => {
       id: 'domainInput',
       placeholder: 'https://example.gov',
       className: 'form-control',
+      disabled: true,
     });
 
     const demoDomainField = wrapper.find('HttpsUrlField[name="demoDomain"]');
@@ -51,6 +54,7 @@ describe('<BasicSiteSettings/>', () => {
       id: 'demoDomainInput',
       placeholder: 'https://demo.example.gov',
       className: 'form-control',
+      disabled: false,
     });
   });
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update site live/demo URL as appropriate when de/provisioning a domain from the admin interface:
  - After a domain is provisioned and the corresponding live site/demo url _does not_ exist, populate the corresponding live site/demo url in the site table with the first domain name from `domain.names`.
  - After a domain is provisioned and the corresponding live site/demo url _does_ exist, do nothing
  - When a domain is deprovisioned, depopulate the corresponding live site/demo url in the site table _only_ if it corresponds to one of the names domain being deprovisioned
- When a site URL has been modified following provision/deprovision based on the rules above, enqueue a site rebuild
- A site's URL is considered to be managed by domains if the URL is null _or_ the the URL is non-null and matches the URL of an associated domain with corresponding context (site/demo).
- When a site URL is managed by domains the URL field is disabled in the UI and ignored in backend parameters.

This work will address #3733 upon production deployment.

## security considerations
None
