### PR TITLE
Remove UAA war (DRAFT)

### DIFF
--- a/docker-compose.uaa.yml
+++ b/docker-compose.uaa.yml
@@ -2,23 +2,12 @@ services:
   app:
     depends_on:
       - uaa
-    environment:
-      UAA_HOST: http://localhost:9000
-      UAA_HOST_DOCKER_URL: http://uaa:8080
-      FEATURE_AUTH_UAA: 'true'
   federalist:
     depends_on:
       - uaa
-    environment:
-      UAA_HOST: http://localhost:9000
-      UAA_HOST_DOCKER_URL: http://uaa:8080
-      FEATURE_AUTH_UAA: 'false'
   bull-board:
     depends_on:
       - uaa
-    environment:
-      UAA_HOST: http://localhost:9000
-      UAA_HOST_DOCKER_URL: http://uaa:8080
   uaa:
     build:
       dockerfile: ./Dockerfile-uaa

--- a/docker-compose.uaa.yml
+++ b/docker-compose.uaa.yml
@@ -1,0 +1,34 @@
+services:
+  app:
+    depends_on:
+      - uaa
+    environment:
+      UAA_HOST: http://localhost:9000
+      UAA_HOST_DOCKER_URL: http://uaa:8080
+  federalist:
+    depends_on:
+      - uaa
+    environment:
+      UAA_HOST: http://localhost:9000
+      UAA_HOST_DOCKER_URL: http://uaa:8080
+  bull-board:
+    depends_on:
+      - uaa
+    environment:
+      UAA_HOST: http://localhost:9000
+      UAA_HOST_DOCKER_URL: http://uaa:8080
+  uaa:
+    build:
+      dockerfile: ./Dockerfile-uaa
+      context: .
+    ports:
+      - 9000:8080
+    environment:
+      POSTGRES_DB: federalist
+      POSTGRES_PORT: 5432
+      POSTGRES_HOST: db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    depends_on:
+      - db
+    command: ["/tomcat/bin/catalina.sh", "run"]

--- a/docker-compose.uaa.yml
+++ b/docker-compose.uaa.yml
@@ -5,12 +5,14 @@ services:
     environment:
       UAA_HOST: http://localhost:9000
       UAA_HOST_DOCKER_URL: http://uaa:8080
+      FEATURE_AUTH_UAA: 'true'
   federalist:
     depends_on:
       - uaa
     environment:
       UAA_HOST: http://localhost:9000
       UAA_HOST_DOCKER_URL: http://uaa:8080
+      FEATURE_AUTH_UAA: 'false'
   bull-board:
     depends_on:
       - uaa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,11 @@ services:
       APP_HOSTNAME: http://localhost:1337
       DOMAIN: localhost:1337
       FEATURE_AUTH_GITHUB: 'false'
+      FEATURE_AUTH_UAA: 'true'
       PORT: 1337
       PRODUCT: pages
+      UAA_HOST: http://localhost:9000
+      UAA_HOST_DOCKER_URL: http://uaa:8080
       USER_AUDITOR: federalist
   federalist:
     build:
@@ -50,8 +53,11 @@ services:
       APP_HOSTNAME: http://localhost:1338
       DOMAIN: localhost:1338
       FEATURE_AUTH_GITHUB: 'true'
+      FEATURE_AUTH_UAA: 'false'
       PORT: 1338
       PRODUCT: federalist
+      UAA_HOST: http://localhost:9000
+      UAA_HOST_DOCKER_URL: http://uaa:8080
       USER_AUDITOR: federalist
   bull-board:
     build:
@@ -70,6 +76,8 @@ services:
     environment:
       APP_HOSTNAME: http://localhost:1340
       PORT: 1340
+      UAA_HOST: http://localhost:9000
+      UAA_HOST_DOCKER_URL: http://uaa:8080
   admin-client:
     build:
       dockerfile: ./admin-client/Dockerfile-admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,17 +22,13 @@ services:
     depends_on:
       - db
       - redis
-      - uaa
     environment:
       APP_HOSTNAME: http://localhost:1337
       DOMAIN: localhost:1337
       FEATURE_AUTH_GITHUB: 'false'
-      FEATURE_AUTH_UAA: 'true'
       PORT: 1337
       PRODUCT: pages
-      UAA_HOST: http://localhost:9000
-      UAA_HOST_DOCKER_URL: http://uaa:8080
-      USER_AUDITOR: federalist     
+      USER_AUDITOR: federalist
   federalist:
     build:
       dockerfile: Dockerfile-app
@@ -50,17 +46,13 @@ services:
     depends_on:
       - db
       - redis
-      - uaa
     environment:
       APP_HOSTNAME: http://localhost:1338
       DOMAIN: localhost:1338
       FEATURE_AUTH_GITHUB: 'true'
-      FEATURE_AUTH_UAA: 'false'
       PORT: 1338
       PRODUCT: federalist
-      UAA_HOST: http://localhost:9000
-      UAA_HOST_DOCKER_URL: http://uaa:8080
-      USER_AUDITOR: federalist 
+      USER_AUDITOR: federalist
   bull-board:
     build:
       dockerfile: Dockerfile-app
@@ -75,12 +67,9 @@ services:
       - "1340:1340"
     depends_on:
       - redis
-      - uaa
     environment:
       APP_HOSTNAME: http://localhost:1340
       PORT: 1340
-      UAA_HOST: http://localhost:9000
-      UAA_HOST_DOCKER_URL: http://uaa:8080
   admin-client:
     build:
       dockerfile: ./admin-client/Dockerfile-admin
@@ -113,21 +102,6 @@ services:
     image: redis
     ports:
       - 6379:6379
-  uaa:
-    build:
-      dockerfile: ./Dockerfile-uaa
-      context: .
-    ports:
-      - 9000:8080
-    environment:
-      POSTGRES_DB: federalist
-      POSTGRES_PORT: 5432
-      POSTGRES_HOST: db
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-    depends_on:
-      - db
-    command: ["/tomcat/bin/catalina.sh", "run"]
   worker:
     build:
       dockerfile: Dockerfile-app


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes `uaa/cloudfoundry-identity-uaa-4.19.0.war`
- Extracts UAA dependencies into optional `docker-compose.uaa.yml`

This is work toward #3744 

## security considerations
The file `uaa/cloudfoundry-identity-uaa-4.19.0.war` contains an unsupported and potentially vulnerable version of log4j. This file is only ever needed as a resource during local development, so this pull request was created to remove it from the codebase so that it no longer ends up in the staging environment. 
