### PR TITLE
Git ignore cloudfoundry-identity-uaa-4.19.0.war and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ current-sites.csv
 credentials*.json
 tmp
 ci/vars/.*
+uaa/cloudfoundry-identity-uaa-4.19.0.war

--- a/Makefile
+++ b/Makefile
@@ -19,29 +19,29 @@ db: ## Connect to the database - it must already be running ie with `make start`
 	psql postgresql://postgres:password@localhost:5433/federalist
 
 build-client: ## Build client app - typically only done to test production artifacts
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run -rm app yarn build
+	docker-compose run -rm app yarn build
 
 install: ## Install npm deps
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm admin-client yarn
+	docker-compose run --rm app yarn
+	docker-compose run --rm admin-client yarn
 
 lint-server: ## Lint server code
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn lint
+	docker-compose run --rm app yarn lint
 
 lint-client: ## Lint admin client code
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm admin-client yarn lint
+	docker-compose run --rm admin-client yarn lint
 
 lint: lint-server lint-client ## Lint project
 
 migrate: ## Run database migrations
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn migrate:up
+	docker-compose run --rm app yarn migrate:up
 
 rebuild: ## Rebuild docker images and database volumes
 	docker volume rm federalist_db-data
 	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml build
 
 seed: ## (Re)Create seed data
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn create-dev-data
+	docker-compose run --rm app yarn create-dev-data
 
 set-pipeline: ## Set Concourse `web` pipeline
 	fly -t pages-staging sp -p web -c ci/pipeline.yml
@@ -50,10 +50,10 @@ start: ## Start
 	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up
 
 test-client: ## Run client tests
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn test:client
+	docker-compose run --rm app yarn test:client
 
 test-server: ## Run server tests
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn test:server
+	docker-compose run --rm app yarn test:server
 
 test-all: ## Run all tests
-	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn test
+	docker-compose run --rm app yarn test

--- a/Makefile
+++ b/Makefile
@@ -19,41 +19,41 @@ db: ## Connect to the database - it must already be running ie with `make start`
 	psql postgresql://postgres:password@localhost:5433/federalist
 
 build-client: ## Build client app - typically only done to test production artifacts
-	docker-compose run -rm app yarn build
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run -rm app yarn build
 
 install: ## Install npm deps
-	docker-compose run --rm app yarn
-	docker-compose run --rm admin-client yarn
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm admin-client yarn
 
 lint-server: ## Lint server code
-	docker-compose run --rm app yarn lint
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn lint
 
 lint-client: ## Lint admin client code
-	docker-compose run --rm admin-client yarn lint
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm admin-client yarn lint
 
 lint: lint-server lint-client ## Lint project
 
 migrate: ## Run database migrations
-	docker-compose run --rm app yarn migrate:up
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn migrate:up
 
 rebuild: ## Rebuild docker images and database volumes
 	docker volume rm federalist_db-data
-	docker-compose build
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml build
 
 seed: ## (Re)Create seed data
-	docker-compose run --rm app yarn create-dev-data
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn create-dev-data
 
 set-pipeline: ## Set Concourse `web` pipeline
 	fly -t pages-staging sp -p web -c ci/pipeline.yml
 
 start: ## Start
-	docker-compose up
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up
 
 test-client: ## Run client tests
-	docker-compose run --rm app yarn test:client
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn test:client
 
 test-server: ## Run server tests
-	docker-compose run --rm app yarn test:server
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn test:server
 
 test-all: ## Run all tests
-	docker-compose run --rm app yarn test
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn test

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Note that `npm run update-local-config` will need to be re-run with some frequen
 
 #### Setting up Docker
 
+If local UAA authentication is not needed, Docker can be set up and started with these commdands:
+
 1. Run `docker-compose build`.
 1. Run `docker-compose run --rm app yarn` to install dependencies.
 1. Run `docker-compose run --rm admin-client yarn` to install dependencies.
@@ -82,6 +84,15 @@ Note that `npm run update-local-config` will need to be re-run with some frequen
 1. Run `docker-compose up` to start the development environment.
 
 Any time the node dependencies are changed (like from a recently completed new feature), `docker-compose run --rm app yarn` will need to be re-run to install updated dependencies after pulling the new code from GitHub.
+
+In order to log in with local UAA authentication in a development environment it is necessary to install the file `cloudfoundry-identity-uaa-4.19.0.war` in the `uaa` folder in the application root, and to include a second docker-compose configuration file when executing docker-compose commands, e.g.:
+
+1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml build`.
+1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn` to install dependencies.
+1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm admin-client yarn` to install dependencies.
+1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn migrate:up` to initialize the local database.
+1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn create-dev-data` to create some fake development data for your local database.
+1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up` to start the development environment.
 
 #### Check to see if everything is working correctly
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,10 @@ If local UAA authentication is not needed, Docker can be set up and started with
 
 Any time the node dependencies are changed (like from a recently completed new feature), `docker-compose run --rm app yarn` will need to be re-run to install updated dependencies after pulling the new code from GitHub.
 
-In order to log in with local UAA authentication in a development environment it is necessary to install the file `cloudfoundry-identity-uaa-4.19.0.war` in the `uaa` folder in the application root, and to include a second docker-compose configuration file when executing docker-compose commands, e.g.:
+In order to make it possible to log in with local UAA authentication in a development environment it is necessary to install the file `cloudfoundry-identity-uaa-4.19.0.war` in the `uaa` folder in the application root, and to include a second docker-compose configuration file when executing the docker-compose commands which build containers or start the development environment, e.g.:
 
-1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml build`.
-1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn` to install dependencies.
-1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm admin-client yarn` to install dependencies.
-1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn migrate:up` to initialize the local database.
-1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml run --rm app yarn create-dev-data` to create some fake development data for your local database.
-1. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up` to start the development environment.
+1. `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml build`
+1. `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up`
 
 #### Check to see if everything is working correctly
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds `uaa/cloudfoundry-identity-uaa-4.19.0.war` to `.gitignore`
- Updates readme to note the potential need to install `cloudfoundry-identity-uaa-4.19.0.war` locally in `uaa/` and to document appropriate usage of the second optional uaa yml file with `docker-compose` 

This is work towards #3744 

## security considerations
The `.gitignore` change is intended to reduce the likelihood of `cloudfoundry-identity-uaa-4.19.0.war` being inadvertently recommitted and pushed, where, if it found its way to staging, it could create a security concern.
