### PR TITLE
Source UAA War from S&W GitHub

### DIFF
--- a/Dockerfile-uaa
+++ b/Dockerfile-uaa
@@ -1,22 +1,23 @@
-FROM openjdk:8u141-jre
+FROM openjdk:11.0.13-jre
 
 ENV UAA_CONFIG_PATH /uaa
 ENV CATALINA_HOME /tomcat
 
 COPY ./uaa/uaa.yml /uaa/uaa.yml
 
-RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.28/bin/apache-tomcat-8.0.28.tar.gz
-RUN wget -qO- https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.28/bin/apache-tomcat-8.0.28.tar.gz.md5 | md5sum -c -
+RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.45/bin/apache-tomcat-9.0.45.tar.gz
+RUN wget -qO- https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.45/bin/apache-tomcat-9.0.45.tar.gz.sha512 | sha512sum -c -
 
-RUN tar zxf apache-tomcat-8.0.28.tar.gz
-RUN rm apache-tomcat-8.0.28.tar.gz
+RUN tar zxf apache-tomcat-9.0.45.tar.gz
+RUN rm apache-tomcat-9.0.45.tar.gz
 
 RUN mkdir /tomcat
-RUN mv apache-tomcat-8.0.28/* /tomcat
+RUN mv apache-tomcat-9.0.45/* /tomcat
 RUN rm -rf /tomcat/webapps/*
 
-COPY ./uaa/cloudfoundry-identity-uaa-4.19.0.war /tomcat/webapps/cloudfoundry-identity-uaa-4.19.0.war
-RUN mv /tomcat/webapps/cloudfoundry-identity-uaa-4.19.0.war /tomcat/webapps/ROOT.war
+RUN wget https://github.com/starkandwayne/uaa-war-releases/releases/download/v75.13.0/cloudfoundry-identity-uaa-75.13.0.war
+RUN echo "d818c36615876299ee0efa49b85bb6cf1467cb1b2b39a5e13eb5220282affbee94eec168e4ae15e7a326131f18129b42209019962172d1da4f6c9b85bdd9c408 cloudfoundry-identity-uaa-75.13.0.war" | sha512sum -c
+RUN mv cloudfoundry-identity-uaa-75.13.0.war /tomcat/webapps/ROOT.war
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Note that `npm run update-local-config` will need to be re-run with some frequen
 
 #### Setting up Docker
 
-If local UAA authentication is not needed, Docker can be set up and started with these commdands:
+If local UAA authentication is not needed, Docker can be set up and started with these commands:
 
 1. Run `docker-compose build`.
 1. Run `docker-compose run --rm app yarn` to install dependencies.
@@ -85,7 +85,7 @@ If local UAA authentication is not needed, Docker can be set up and started with
 
 Any time the node dependencies are changed (like from a recently completed new feature), `docker-compose run --rm app yarn` will need to be re-run to install updated dependencies after pulling the new code from GitHub.
 
-In order to make it possible to log in with local UAA authentication in a development environment it is necessary to install the file `cloudfoundry-identity-uaa-4.19.0.war` in the `uaa` folder in the application root, and to include a second docker-compose configuration file when executing the docker-compose commands which build containers or start the development environment, e.g.:
+In order to make it possible to log in with local UAA authentication in a development environment it is necessary to also build and start the UAA container, which requires specifying a second docker-compose configuration file when executing the docker-compose commands which build containers or start the development environment, e.g.:
 
 1. `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml build`
 1. `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up`


### PR DESCRIPTION
## Changes proposed in this pull request:
- Sources UAA war online instead of locally, and uses a newer version.
  - Instead of looking for `uaa/cloudfoundry-identity-uaa-4.19.0.war` — which must be sourced elsewhere and placed there by the developer — then loading that file into a UAA Docker, `Dockerfile-uaa` now downloads a `75.13.0` version of the UAA war [from Stark & Wayne](https://github.com/starkandwayne/uaa-war-releases/releases), verifies that its sha512 hash hasn't changed since the one I observed today, and uses that instead.
  - This required updating from Java 8 to Java 11 and from Tomcat 8 to Tomcat 9. I went with Java 11.0.13 and Tomcat 9.0.45, specifically. I found these to work locally but others might as well, and we could explore it further if anyone feels it's worth doing.
- Update the README to remove the need to have your own 4.19.0 war before running with the UAA container enabled. As of this writing I do still have the UAA container in a optional separate dc yml file. We could consider abandoning that additional complexity, but it does have the positive effect of preventing any UAA stuff from happening on staging.

This work should satisfy #3749 (which was split out of #3744). 

All I know to do to test this is to
1. Remove any local UAA docker containers and images.
2. Rebuild and restart: 
```
docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml build
docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up
```
3. Go to localhost:1337 and make sure I can log in via UAA. 

**If there are other details to local UAA integration or utilization, _please_ let me know so that I can follow up.**

## security considerations
Some of us have started to get warnings about having the 4.19.0 war file on our workstations. If we're satisfied that this change works, we won't have to do that any more.
