### PR TITLE
Correctly set site engine when adding a site

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -126,7 +126,7 @@ module.exports = wrapHandlers({
   async create(req, res) {
     const {
       body: {
-        owner, template, organizationId, repository,
+        owner, template, organizationId, repository, engine,
       },
       user,
     } = req;
@@ -136,6 +136,7 @@ module.exports = wrapHandlers({
       template,
       organizationId: toInt(organizationId),
       repository,
+      engine,
       sharedBucket: false,
     };
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Actually passes the `engine` parameter through when creating new sites.

This is intended to address #3753

## security considerations
None
