### PR TITLE
Add `demoBranch` field to sites returned when creating domain to enable selecting `demo` context when present

### DIFF
--- a/api/admin/controllers/site.js
+++ b/api/admin/controllers/site.js
@@ -12,7 +12,7 @@ const updateableAttrs = [
 
 module.exports = wrapHandlers({
   listRaw: async (req, res) => {
-    const sites = await Site.findAll({ attributes: ['id', 'owner', 'repository'], raw: true });
+    const sites = await Site.findAll({ attributes: ['id', 'owner', 'repository', 'demoBranch'], raw: true });
     return res.json(sites);
   },
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `demoBranch` field to sites returned when creating domain to enable selecting `demo` context when present #3758 

## security considerations
None
