### PR TITLE
Replace organization delete button with de/activate buttons

### DIFF
--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -172,6 +172,10 @@ async function deactivateOrganization(id) {
   return post(`/organizations/${id}/deactivate`);
 }
 
+async function activateOrganization(id) {
+  return post(`/organizations/${id}/activate`);
+}
+
 async function fetchRoles() {
   return get('/roles').catch(() => []);
 }
@@ -246,6 +250,7 @@ export {
   fetchOrganizations,
   updateOrganization,
   deactivateOrganization,
+  activateOrganization,
   removeUserOrgRole,
   updateUserOrgRole,
   fetchRoles,

--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -168,6 +168,10 @@ async function updateOrganization(id, params) {
   return put(`/organizations/${id}`, params);
 }
 
+async function deactivateOrganization(id) {
+  return post(`/organizations/${id}/deactivate`);
+}
+
 async function fetchRoles() {
   return get('/roles').catch(() => []);
 }
@@ -241,6 +245,7 @@ export {
   fetchOrganization,
   fetchOrganizations,
   updateOrganization,
+  deactivateOrganization,
   removeUserOrgRole,
   updateUserOrgRole,
   fetchRoles,

--- a/admin-client/src/pages/organization/Edit.svelte
+++ b/admin-client/src/pages/organization/Edit.svelte
@@ -42,13 +42,13 @@
     <form
       class="usa-form usa-form--large"
       on:submit|preventDefault={handleSubmit} >
-  
+
       <legend class="usa-legend usa-legend--large">Edit Organization</legend>
-  
+
       <p>
         Required fields are marked with an asterisk (<abbr title="required" class="usa-hint usa-hint--required">*</abbr>).
       </p>
-  
+
       <fieldset class="usa-fieldset">
         <label class="usa-label" for="name">Organization Name<abbr title="required" class="usa-hint usa-hint--required">*</abbr></label>
         <span class="usa-hint">Organization name must be globally unique</span>
@@ -104,7 +104,7 @@
         </div>
       </fieldset>
 
-      <fieldset class="usa-fieldset">
+      <fieldset class="usa-fieldset" disabled>
         <legend class="usa-legend usa-legend">Organization Status</legend>
         <div class="usa-radio">
           <input

--- a/admin-client/src/pages/organization/Index.svelte
+++ b/admin-client/src/pages/organization/Index.svelte
@@ -1,6 +1,6 @@
 <script>
   import page from 'page';
-  import { fetchOrganizations, deactivateOrganization } from '../../lib/api';
+  import { fetchOrganizations, deactivateOrganization, activateOrganization } from '../../lib/api';
   import { formatDateTime } from '../../helpers/formatter';
   import { DataTable, PaginatedQueryPage } from '../../components';
 
@@ -10,6 +10,11 @@
       deactivateOrganization(id);
       page('/organizations');
     }
+  }
+
+  function activate(id) {
+    activateOrganization(id);
+    page('/organizations');
   }
 </script>
 
@@ -66,6 +71,12 @@
           class="usa-button usa-button--secondary"
           on:click={deactivate(org.id)}>
           Deactivate
+        </button>
+        {:else}
+        <button
+          class="usa-button"
+          on:click={activate(org.id)}>
+          Activate
         </button>
         {/if}
       </td>

--- a/admin-client/src/pages/organization/Index.svelte
+++ b/admin-client/src/pages/organization/Index.svelte
@@ -1,7 +1,16 @@
 <script>
-  import { fetchOrganizations } from '../../lib/api';
+  import page from 'page';
+  import { fetchOrganizations, deactivateOrganization } from '../../lib/api';
   import { formatDateTime } from '../../helpers/formatter';
   import { DataTable, PaginatedQueryPage } from '../../components';
+
+  function deactivate(id) {
+    // eslint-disable-next-line no-alert
+    if (window.confirm('Are you sure you want to deactivate this organization?')) {
+      deactivateOrganization(id);
+      page('/organizations');
+    }
+  }
 </script>
 
 <PaginatedQueryPage path="organizations" query={fetchOrganizations} addAction let:data>
@@ -52,7 +61,13 @@
         </ul>
       </td>
       <td>
-        <button class="usa-button usa-button--secondary">Delete</button>
+        {#if org.isActive}
+        <button
+          class="usa-button usa-button--secondary"
+          on:click={deactivate(org.id)}>
+          Deactivate
+        </button>
+        {/if}
       </td>
     </tr>
   </DataTable>

--- a/api/admin/controllers/organization.js
+++ b/api/admin/controllers/organization.js
@@ -112,4 +112,17 @@ module.exports = wrapHandlers({
 
     return res.json(serialize(org));
   },
+
+  async deactivate(req, res) {
+    const {
+      params: { id },
+    } = req;
+
+    const org = await fetchModelById(id, Organization);
+    if (!org) return res.notFound();
+
+    // TODO: Add audit logging
+    const deactivatedOrg = await OrganizationService.deactivateOrganization(org);
+    return res.json(serialize(deactivatedOrg));
+  },
 });

--- a/api/admin/controllers/organization.js
+++ b/api/admin/controllers/organization.js
@@ -125,4 +125,17 @@ module.exports = wrapHandlers({
     const deactivatedOrg = await OrganizationService.deactivateOrganization(org);
     return res.json(serialize(deactivatedOrg));
   },
+
+  async activate(req, res) {
+    const {
+      params: { id },
+    } = req;
+
+    const org = await fetchModelById(id, Organization);
+    if (!org) return res.notFound();
+
+    // TODO: Add audit logging
+    const deactivatedOrg = await OrganizationService.activateOrganization(org);
+    return res.json(serialize(deactivatedOrg));
+  },
 });

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -31,6 +31,7 @@ apiRouter.post('/organizations', parseJson, AdminControllers.Organization.create
 apiRouter.get('/organizations/:id', AdminControllers.Organization.findById);
 apiRouter.put('/organizations/:id', parseJson, AdminControllers.Organization.update);
 apiRouter.post('/organizations/:id/deactivate', AdminControllers.Organization.deactivate);
+apiRouter.post('/organizations/:id/activate', AdminControllers.Organization.activate);
 apiRouter.delete('/organization-role', parseJson, AdminControllers.OrganizationRole.destroy);
 apiRouter.put('/organization-role', parseJson, AdminControllers.OrganizationRole.update);
 apiRouter.get('/roles', AdminControllers.Role.list);

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -30,6 +30,7 @@ apiRouter.get('/organizations', AdminControllers.Organization.list);
 apiRouter.post('/organizations', parseJson, AdminControllers.Organization.create);
 apiRouter.get('/organizations/:id', AdminControllers.Organization.findById);
 apiRouter.put('/organizations/:id', parseJson, AdminControllers.Organization.update);
+apiRouter.post('/organizations/:id/deactivate', AdminControllers.Organization.deactivate);
 apiRouter.delete('/organization-role', parseJson, AdminControllers.OrganizationRole.destroy);
 apiRouter.put('/organization-role', parseJson, AdminControllers.OrganizationRole.update);
 apiRouter.get('/roles', AdminControllers.Role.list);

--- a/api/services/organization/Organization.js
+++ b/api/services/organization/Organization.js
@@ -217,4 +217,13 @@ module.exports = {
     await organization.update({ isActive: false });
     return organization;
   },
+
+  /**
+     * @param {OrganizationModel} organization The organization
+     * @returns {Promise<OrgType>}
+     */
+  async activateOrganization(organization) {
+    await organization.update({ isActive: true });
+    return organization;
+  },
 };

--- a/api/services/organization/Organization.js
+++ b/api/services/organization/Organization.js
@@ -208,4 +208,13 @@ module.exports = {
 
     return [org, uaaUserAttributes];
   },
+
+  /**
+   * @param {OrganizationModel} organization The organization
+   * @returns {Promise<OrgType>}
+   */
+  async deactivateOrganization(organization) {
+    await organization.update({ isActive: false });
+    return organization;
+  },
 };

--- a/api/services/organization/index.js
+++ b/api/services/organization/index.js
@@ -5,4 +5,5 @@ module.exports = {
   inviteUserToOrganization: OrganizationService.inviteUserToOrganization.bind(OrganizationService),
   resendInvite: OrganizationService.resendInvite.bind(OrganizationService),
   deactivateOrganization: OrganizationService.deactivateOrganization.bind(OrganizationService),
+  activateOrganization: OrganizationService.activateOrganization.bind(OrganizationService),
 };

--- a/api/services/organization/index.js
+++ b/api/services/organization/index.js
@@ -4,4 +4,5 @@ module.exports = {
   createOrganization: OrganizationService.createOrganization.bind(OrganizationService),
   inviteUserToOrganization: OrganizationService.inviteUserToOrganization.bind(OrganizationService),
   resendInvite: OrganizationService.resendInvite.bind(OrganizationService),
+  deactivateOrganization: OrganizationService.deactivateOrganization.bind(OrganizationService),
 };

--- a/test/api/unit/services/organization.test.js
+++ b/test/api/unit/services/organization.test.js
@@ -487,4 +487,24 @@ describe('OrganizationService', () => {
       });
     });
   });
+
+  describe('.deactivate', () => {
+    it('deactivates the organization', async () => {
+      const org = await orgFactory.create({ isActive: true });
+      expect(org.isActive).to.be.true;
+      await OrganizationService.deactivateOrganization(org);
+      await org.reload();
+      expect(org.isActive).to.be.false;
+    });
+  });
+
+  describe('.activate', () => {
+    it('activates the organization', async () => {
+      const org = await orgFactory.create({ isActive: false });
+      expect(org.isActive).to.be.false;
+      await OrganizationService.activateOrganization(org);
+      await org.reload();
+      expect(org.isActive).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes the (non-working) delete button on the orgs index page in the admin client
- Replaces it with deactivate and activate buttons
- Disables* the isActive (organization status) field set on the org update page. 

These changes addresses #3728

*While I disabled the isActive field, I did _not_ add logic to reject or ignore this field when updates. It didn't seem important under the circumstances, but I am open to opposing viewpoints.

## security considerations
None
