### PR TITLE
Refresh DNS table (and de/provision button) after domain de/provision

### DIFF
--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -29,12 +29,14 @@
 
   function provision() {
     domainPromise = provisionDomain(id);
+    refreshDnsResults();
   }
 
   function deprovision() {
     // eslint-disable-next-line no-alert
     if (window.confirm('Are you sure you want to deprovision this domain?')) {
       domainPromise = deprovisionDomain(id);
+      refreshDnsResults();
     }
   }
 

--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -76,11 +76,11 @@
           <LabeledItem label="origin" value={domain.origin} />
           <LabeledItem label="path" value={domain.path} />
           <LabeledItem label="service" value={domain.serviceName} />
-        {/if}        
+        {/if}
       </div>
       <div class="tablet:grid-col-auto padding-bottom-1">
         <LabeledItem label="created at" value={formatDateTime(domain.createdAt)} />
-        <LabeledItem label="updated at" value={formatDateTime(domain.updatedAt)} />        
+        <LabeledItem label="updated at" value={formatDateTime(domain.updatedAt)} />
       </div>
     </div>
     <Await on={dnsResultsPromise} let:response={dnsResults}>


### PR DESCRIPTION
## Changes proposed in this pull request:
- In admin client domain administration, after pressing the provision or deprovision button, refresh the domain table. 
 
This is intended to ensure that the available button is correctly displayed once the de/provision process has begun, which would address the concern noted in #3727. 

What I don't know is 
1. Whether adding the refresh where I am is _too soon_ after beginning the de/provision process, and
2. Whether there is any way for me to give this a workout _without_ deploying it on staging.

## security considerations
None
