### PR TITLE
Fix .audit() calls in controllers.

### DIFF
--- a/api/admin/controllers/build.js
+++ b/api/admin/controllers/build.js
@@ -69,7 +69,7 @@ module.exports = wrapHandlers({
     if (!build) return res.notFound();
 
     await build.update({ state });
-    EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'Build Updated', { build: { id, state } });
+    EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'Build Updated', { build: { id, state } });
 
     return res.json(buildSerializer.serializeObject(build));
   },

--- a/api/admin/controllers/domain.js
+++ b/api/admin/controllers/domain.js
@@ -80,7 +80,7 @@ module.exports = wrapHandlers({
 
     try {
       const domain = await Domain.create({ siteId, context, names });
-      EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'Domain Created', { domain });
+      EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'Domain Created', { domain });
       return res.json(domainSerializer.serialize(domain, true));
     } catch (err) {
       if (!err.errors) {
@@ -106,7 +106,7 @@ module.exports = wrapHandlers({
 
     try {
       await DomainService.destroy(domain);
-      EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'Domain Destroyed', { domain });
+      EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'Domain Destroyed', { domain });
       return res.json({});
     } catch (error) {
       return res.unprocessableEntity(error);
@@ -166,7 +166,7 @@ module.exports = wrapHandlers({
 
     try {
       const updatedDomain = await DomainService.deprovision(domain);
-      EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'Domain Deprovisioned', { domain: updatedDomain });
+      EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'Domain Deprovisioned', { domain: updatedDomain });
       return res.json({
         dnsRecords: DomainService.buildDnsRecords(updatedDomain),
         domain: domainSerializer.serialize(updatedDomain, true),
@@ -190,7 +190,7 @@ module.exports = wrapHandlers({
 
     try {
       const updatedDomain = await DomainService.provision(domain, dnsResults);
-      EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'Domain Provisioned', { domain: updatedDomain });
+      EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'Domain Provisioned', { domain: updatedDomain });
       return res.json({
         dnsRecords: DomainService.buildDnsRecords(updatedDomain),
         domain: domainSerializer.serialize(updatedDomain, true),

--- a/api/admin/controllers/organization-role.js
+++ b/api/admin/controllers/organization-role.js
@@ -22,7 +22,7 @@ module.exports = wrapHandlers({
         userId: toInt(userId),
       },
     });
-    EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'OrganizationRole Removed', { organizationRole: { organizationId, userId } });
+    EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'OrganizationRole Removed', { organizationRole: { organizationId, userId } });
 
     return res.json({});
   },
@@ -45,7 +45,7 @@ module.exports = wrapHandlers({
         userId: toInt(userId),
       },
     });
-    EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'OrganizationRole Updated', { organizationRole: { organizationId, userId, roleId } });
+    EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'OrganizationRole Updated', { organizationRole: { organizationId, userId, roleId } });
     const member = await OrganizationRole.forOrganization(org)
       .findOne({ where: { userId: toInt(userId) } });
 

--- a/api/admin/controllers/site.js
+++ b/api/admin/controllers/site.js
@@ -85,7 +85,7 @@ module.exports = wrapHandlers({
 
     // This will not remove the webhook since we don't have permissions
     await SiteDestroyer.destroySite(site);
-    EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'Site Destroyed', { site });
+    EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'Site Destroyed', { site });
 
     return res.json({});
   },

--- a/api/admin/controllers/user.js
+++ b/api/admin/controllers/user.js
@@ -80,12 +80,12 @@ module.exports = wrapHandlers({
     const { email, inviteLink: link } = await OrganizationService.inviteUserToOrganization(
       user, toInt(organizationId), toInt(roleId), uaaEmail, githubUsername
     );
-    EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'User Invited', {
+    EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'User Invited', {
       organizationId, roleId, email, link, githubUsername,
     });
     if (link) {
       await Mailer.sendUAAInvite(email, link);
-      EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'User Invite Sent', { user: { email }, link });
+      EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'User Invite Sent', { user: { email }, link });
     }
 
     const json = {
@@ -102,7 +102,7 @@ module.exports = wrapHandlers({
     } = req;
 
     const { email, inviteLink: link } = await OrganizationService.resendInvite(user, uaaEmail);
-    EventCreator.audit(req.user, Event.labels.ADMIN_ACTION, 'User Invite Resent', { user: { email }, link });
+    EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'User Invite Resent', { user: { email }, link });
     if (link) {
       await Mailer.sendUAAInvite(email, link);
     }

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -68,7 +68,7 @@ module.exports = wrapHandlers({
 
     await authorizer.destroy(user, site);
     await SiteDestroyer.destroySite(site, user);
-    EventCreator.audit(req.user, Event.labels.USER_ACTION, 'Site Destroyed', { site });
+    EventCreator.audit(Event.labels.USER_ACTION, req.user, 'Site Destroyed', { site });
     return res.json({});
   },
 
@@ -83,7 +83,7 @@ module.exports = wrapHandlers({
       user,
       siteParams: body,
     });
-    EventCreator.audit(req.user, Event.labels.USER_ACTION, 'SiteUser Created', {
+    EventCreator.audit(Event.labels.USER_ACTION, req.user, 'SiteUser Created', {
       siteUser: { siteId: site.id, userId: user.id },
     });
     const siteJSON = await siteSerializer.serialize(site);
@@ -109,7 +109,7 @@ module.exports = wrapHandlers({
 
     await authorizer.removeUser(req.user, site);
     await SiteMembershipCreator.revokeSiteMembership({ user: req.user, site, userId });
-    EventCreator.audit(req.user, Event.labels.USER_ACTION, 'SiteUser Removed', {
+    EventCreator.audit(Event.labels.USER_ACTION, req.user, 'SiteUser Removed', {
       siteUser: { siteId: site.id, userId },
     });
     // UserActionCreator to be deleted
@@ -145,7 +145,7 @@ module.exports = wrapHandlers({
       user,
       siteParams,
     });
-    EventCreator.audit(req.user, Event.labels.USER_ACTION, 'Site Created', { site });
+    EventCreator.audit(Event.labels.USER_ACTION, req.user, 'Site Created', { site });
     await site.reload({ include: [Organization, User] });
     const siteJSON = siteSerializer.serializeNew(site);
     return res.json(siteJSON);
@@ -191,7 +191,7 @@ module.exports = wrapHandlers({
     }
 
     await site.update(updateParams);
-    EventCreator.audit(req.user, Event.labels.USER_ACTION, 'Site Updated', {
+    EventCreator.audit(Event.labels.USER_ACTION, req.user, 'Site Updated', {
       site: { ...updateParams, id: site.id },
     });
     await Build.create({

--- a/api/controllers/user-environment-variable.js
+++ b/api/controllers/user-environment-variable.js
@@ -52,7 +52,7 @@ module.exports = wrapHandlers({
         .create({
           siteId: site.id, name, ciphertext, hint,
         });
-      EventCreator.audit(req.user, Event.labels.USER_ACTION, 'UserEnvironmentVariable Created', {
+      EventCreator.audit(Event.labels.USER_ACTION, req.user, 'UserEnvironmentVariable Created', {
         userEnvironmentVariable: { id: uev.id, siteId: uev.siteId, name: uev.name },
       });
       const json = serialize(uev);
@@ -85,7 +85,7 @@ module.exports = wrapHandlers({
     }
 
     await uev.destroy();
-    EventCreator.audit(req.user, Event.labels.USER_ACTION, 'UserEnvironmentVariable Destroyed', {
+    EventCreator.audit(Event.labels.USER_ACTION, req.user, 'UserEnvironmentVariable Destroyed', {
       userEnvironmentVariable: { id: uev.id, siteId: uev.siteId, name: uev.name },
     });
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Corrects the syntax of `EventCreator.audit` calls in controllers

As documented in #3771, about half of these were wrong. Because the calls are in controllers this did not cause failures in testing, and in general I believe they were just silently breaking in practice. Well, they would cause 'Failed to create Event' errors in the application container and the events wouldn't got logged. For a full list of the events that weren't logging correctly, see the lines changed in this PR.

## security considerations
None
