### PR TITLE
Await de/provision before refreshing DNS results. 

### DIFF
--- a/admin-client/src/pages/domain/Show.svelte
+++ b/admin-client/src/pages/domain/Show.svelte
@@ -27,15 +27,17 @@
     dnsResultsPromise = fetchDomainDnsResult(id);
   }
 
-  function provision() {
+  async function provision() {
     domainPromise = provisionDomain(id);
+    await domainPromise;
     refreshDnsResults();
   }
 
-  function deprovision() {
+  async function deprovision() {
     // eslint-disable-next-line no-alert
     if (window.confirm('Are you sure you want to deprovision this domain?')) {
       domainPromise = deprovisionDomain(id);
+      await domainPromise;
       refreshDnsResults();
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- In admin client domain administration, after pressing the provision or deprovision button, refresh the domain table.

This is once again intended to ensure that the available button is correctly displayed once the de/provision process has begun, which would address the concern noted in https://github.com/18F/federalist/issues/3727.

This is a followup on #3772 after testing in staging revealed the feared timing issue which prevented it from successfully addressing the problem. This will need confirmation in staging as well. HT to @davemcorwin for suggesting how to `await` the result of an already-running process. 

## security considerations
None
