### PR TITLE
Use Redis-backed session and do not cache reponses

### DIFF
--- a/api/bull-board/cacheControl.js
+++ b/api/bull-board/cacheControl.js
@@ -1,0 +1,8 @@
+function cacheControl(value) {
+  return function cacheControlMiddleware(req, res, next) {
+    res.set('Cache-Control', value);
+    next();
+  };
+}
+
+module.exports = cacheControl;

--- a/api/bull-board/sessionConfig.js
+++ b/api/bull-board/sessionConfig.js
@@ -1,17 +1,30 @@
-const { MemoryStore } = require('express-session');
+const session = require('express-session');
+const connectRedis = require('connect-redis');
+const IORedis = require('ioredis');
 const config = require('./config');
 
-module.exports = {
-  cookie: {
-    httpOnly: true,
-    maxAge: 24 * 60 * 60 * 1000,
-    secure: config.cookie.secure,
-    sameSite: 'lax',
-  },
-  name: 'federalist-bull-board.sid',
-  secret: config.session.secret,
-  proxy: true,
-  resave: true,
-  saveUninitialized: true,
-  store: new MemoryStore(),
-};
+function configureSession() {
+  const RedisStore = connectRedis(session);
+
+  const client = new IORedis(config.redis.url, {
+    tls: config.redis.tls,
+  });
+
+  const store = new RedisStore({ client });
+
+  return session({
+    cookie: {
+      httpOnly: true,
+      maxAge: 24 * 60 * 60 * 1000,
+      secure: config.cookie.secure,
+      sameSite: 'lax',
+    },
+    name: `${config.product}-${config.appEnv}-bull-board.sid`,
+    secret: config.session.secret,
+    resave: false,
+    saveUninitialized: false,
+    store,
+  });
+}
+
+module.exports = configureSession;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bullmq": "^1.26.5",
     "cfenv": "^1.2.3",
     "connect-flash": "^0.1.1",
-    "connect-redis": "^6.0.0",
+    "connect-redis": "^6.1.1",
     "connect-session-sequelize": "^7.0.1",
     "core-js": "^3.9.1",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3278,10 +3278,10 @@ connect-history-api-fallback@^1.6.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
 
-connect-redis@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-6.0.0.tgz#7e443fc7028eca43302bee59f51a315f65cd56b5"
-  integrity sha512-6eGEAAPHYvcfbRNCMmPzBIjrqRWLw7at9lCUH4G6NQ8gwWDJelaUmFNOqPIhehbw941euVmIuqWsaWiKXfb+5g==
+connect-redis@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-6.1.1.tgz#f909ff6d39a5854658d596ac006d1ce901f3ddcd"
+  integrity sha512-4on27NmUz1hVCVsrUFUOe06YkgCx88ZZ29Wi7D5mXg22alN/Xx+Y+iPrJ1Cc7coUKAe5SP3W2LF/zo6WXSJFFg==
 
 connect-session-sequelize@^7.0.1:
   version "7.1.1"


### PR DESCRIPTION
## Changes proposed in this pull request:
- #3780 
- Use Redis-backed session instead of non-recommended memory store
- do not cache responses
- resolves potential redirect loop
- makes cookie name unique

## security considerations
Prevents caching of responses that may include cookies
