### PR TITLE
Get pages-staging up and running

### DIFF
--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -1,7 +1,7 @@
 product: pages
 name: pages-staging
 domain: pages-staging.cloud.gov
-app_subdomain: app.
+app_subdomain: app
 memory: 256MB
 instances: 2
 env: staging
@@ -12,5 +12,6 @@ feature_auth_uaa: 'true'
 feature_bull_site_build_queue: 'true'
 uaa_host: https://uaa.fr-stage.cloud.gov
 new_relic_app_name: web-pages-staging
-proxy_domain: sites.pages-staging.cloud.gov
+# proxy_domain: sites.pages-staging.cloud.gov
+proxy_domain: app.cloud.gov
 cf_cdn_space_name: sites-staging

--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -7,11 +7,10 @@ instances: 2
 env: staging
 env_postfix: -staging
 log_level: verbose
-feature_auth_github: 'false'
+feature_auth_github: 'true'
 feature_auth_uaa: 'true'
 feature_bull_site_build_queue: 'true'
 uaa_host: https://uaa.fr-stage.cloud.gov
 new_relic_app_name: web-pages-staging
-# proxy_domain: sites.pages-staging.cloud.gov
 proxy_domain: app.cloud.gov
 cf_cdn_space_name: sites-staging

--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -1,7 +1,7 @@
 product: pages
 name: pages-staging
 domain: pages-staging.cloud.gov
-app_subdomain: app
+app_subdomain: app.
 memory: 256MB
 instances: 2
 env: staging

--- a/api/admin/routers/auth.js
+++ b/api/admin/routers/auth.js
@@ -23,7 +23,6 @@ router.get('/auth/github2/callback', passport.authenticate('github'), onSuccess)
 
 // Callbacks need to be registered with CF UAA service
 if (Features.enabled(Features.Flags.FEATURE_AUTH_UAA)) {
-  // router.get('/login', passport.authenticate('uaa'));
   router.get('/logout', passport.logout);
   router.get('/auth/uaa/callback', passport.authenticate('uaa'), onSuccess);
   router.get('/auth/uaa/logout', onSuccess);

--- a/api/bull-board/config.js
+++ b/api/bull-board/config.js
@@ -58,7 +58,7 @@ module.exports = {
   },
   product: PRODUCT,
   session: {
-    secret: SESSION_SECRET,
+    secret: SESSION_SECRET || 'test-secret',
   },
   uaa: {
     apiUrl: internalUAAHost,
@@ -74,7 +74,7 @@ module.exports = {
     state: true,
   },
   redis: {
-    url: REDIS_URL,
+    url: REDIS_URL || 'redis://redis:6379',
     tls: REDIS_TLS,
   },
 };

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       CC_TEST_REPORTER_ID: 101a439651b6abd27e5440028a53b5b8f08fe0889f3948d5f58f6cf9f7c786a0
       CONCOURSE: 'true'
       APP_HOSTNAME: http://localhost:1337
+      FEATURE_AUTH_UAA: 'true'
       PRODUCT: pages
   db:
     image: postgres:11-alpine

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -182,58 +182,58 @@ jobs:
             username: ((slack-username))
             icon_url: ((slack-icon-url))   
 
-  - name: test-admin-client-staging
-    plan:
-      - get: src-admin-client
-        resource: pr-staging
-        trigger: true
-        version: every
-      - put: src-admin-client
-        resource: pr-staging
-        params:
-          path: src-admin-client
-          status: pending
-          base_context: concourse
-          context: test-admin-client
+  # - name: test-admin-client-staging
+  #   plan:
+  #     - get: src-admin-client
+  #       resource: pr-staging
+  #       trigger: true
+  #       version: every
+  #     - put: src-admin-client
+  #       resource: pr-staging
+  #       params:
+  #         path: src-admin-client
+  #         status: pending
+  #         base_context: concourse
+  #         context: test-admin-client
 
-      - do: *test-admin-client
+  #     - do: *test-admin-client
       
-    on_failure:
-      in_parallel:
-        - put: src-admin-client
-          resource: pr-staging
-          params:
-            path: src-admin-client
-            status: failure
-            base_context: concourse
-            context: test-admin-client
-        - put: slack
-          params:
-            text: |
-              :x: FAILED: pages admin client tests on staging
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
+  #   on_failure:
+  #     in_parallel:
+  #       - put: src-admin-client
+  #         resource: pr-staging
+  #         params:
+  #           path: src-admin-client
+  #           status: failure
+  #           base_context: concourse
+  #           context: test-admin-client
+  #       - put: slack
+  #         params:
+  #           text: |
+  #             :x: FAILED: pages admin client tests on staging
+  #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  #             ((slack-users))
+  #           channel: ((slack-channel))
+  #           username: ((slack-username))
+  #           icon_url: ((slack-icon-url))
 
-    on_success:
-      in_parallel:
-        - put: src-admin-client
-          resource: pr-staging
-          params:
-            path: src-admin-client
-            status: success
-            base_context: concourse
-            context: test-admin-client
-        - put: slack
-          params:
-            text: |
-              :white_check_mark: SUCCESS: Successfully tested pages admin client on staging
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))   
+  #   on_success:
+  #     in_parallel:
+  #       - put: src-admin-client
+  #         resource: pr-staging
+  #         params:
+  #           path: src-admin-client
+  #           status: success
+  #           base_context: concourse
+  #           context: test-admin-client
+  #       - put: slack
+  #         params:
+  #           text: |
+  #             :white_check_mark: SUCCESS: Successfully tested pages admin client on staging
+  #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  #           channel: ((slack-channel))
+  #           username: ((slack-username))
+  #           icon_url: ((slack-icon-url))   
 
   - name: test-and-deploy-api-pages-staging
     plan:
@@ -312,144 +312,144 @@ jobs:
             username: ((slack-username))
             icon_url: ((slack-icon-url))
 
-  - name: test-and-deploy-admin-client-pages-staging
-    plan:
-      - get: src-admin-client
-        resource: src-staging
-        trigger: true
-        params: {depth: 1}
-      - put: gh-status
-        inputs: [src-admin-client]
-        params: {state: pending}
+  # - name: test-and-deploy-admin-client-pages-staging
+  #   plan:
+  #     - get: src-admin-client
+  #       resource: src-staging
+  #       trigger: true
+  #       params: {depth: 1}
+  #     - put: gh-status
+  #       inputs: [src-admin-client]
+  #       params: {state: pending}
 
-      - do: *test-admin-client
+  #     - do: *test-admin-client
 
-      - task: configure-nginx
-        config:
-          <<: *cf-image
-          inputs: [name: src-admin-client]
-          outputs: [name: src-admin-client]
-          run:
-            dir: src-admin-client
-            path: ci/tasks/configure-admin-client-nginx.sh
-        params:
-          API_DOMAIN: app.pages-staging.cloud.gov
+  #     - task: configure-nginx
+  #       config:
+  #         <<: *cf-image
+  #         inputs: [name: src-admin-client]
+  #         outputs: [name: src-admin-client]
+  #         run:
+  #           dir: src-admin-client
+  #           path: ci/tasks/configure-admin-client-nginx.sh
+  #       params:
+  #         API_DOMAIN: app.pages-staging.cloud.gov
 
-      - task: deploy-admin-client
-        config:
-          <<: *cf-image
-          inputs: [name: src-admin-client]
-          run:
-            dir: src-admin-client
-            path: ci/tasks/deploy.sh
-        params:
-          <<: *staging-cf
-          CF_APP_NAME: pages-admin-staging
-          CF_MANIFEST: .cloudgov/manifest.yml
-          CF_VARS_FILE: .cloudgov/vars/pages-staging.yml
-          CF_PATH: admin-client
-        on_failure:
-          try:
-            task: cancel-admin-client-deployment
-            config:
-              <<: *cf-image
-              inputs: [name: src-admin-client]
-              run:
-                dir: src-admin-client
-                path: ci/tasks/cancel-deployment.sh
-            params:
-              <<: *staging-cf
-              CF_APP_NAME: pages-admin-staging
+  #     - task: deploy-admin-client
+  #       config:
+  #         <<: *cf-image
+  #         inputs: [name: src-admin-client]
+  #         run:
+  #           dir: src-admin-client
+  #           path: ci/tasks/deploy.sh
+  #       params:
+  #         <<: *staging-cf
+  #         CF_APP_NAME: pages-admin-staging
+  #         CF_MANIFEST: .cloudgov/manifest.yml
+  #         CF_VARS_FILE: .cloudgov/vars/pages-staging.yml
+  #         CF_PATH: admin-client
+  #       on_failure:
+  #         try:
+  #           task: cancel-admin-client-deployment
+  #           config:
+  #             <<: *cf-image
+  #             inputs: [name: src-admin-client]
+  #             run:
+  #               dir: src-admin-client
+  #               path: ci/tasks/cancel-deployment.sh
+  #           params:
+  #             <<: *staging-cf
+  #             CF_APP_NAME: pages-admin-staging
 
-    on_failure:
-      in_parallel:
-        - put: gh-status
-          inputs: [src-admin-client]
-          params: {state: failure}   
-        - put: slack
-          params:
-            text: |
-              :x: FAILED: admin client deployment on pages staging
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
+  #   on_failure:
+  #     in_parallel:
+  #       - put: gh-status
+  #         inputs: [src-admin-client]
+  #         params: {state: failure}   
+  #       - put: slack
+  #         params:
+  #           text: |
+  #             :x: FAILED: admin client deployment on pages staging
+  #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  #             ((slack-users))
+  #           channel: ((slack-channel))
+  #           username: ((slack-username))
+  #           icon_url: ((slack-icon-url))
 
-    on_success:
-      in_parallel:
-        - put: gh-status
-          inputs: [src-admin-client]
-          params: {state: success}   
-        - put: slack
-          params:
-            text: |
-              :white_check_mark: SUCCESS: Successfully deployed admin client on pages staging
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
+  #   on_success:
+  #     in_parallel:
+  #       - put: gh-status
+  #         inputs: [src-admin-client]
+  #         params: {state: success}   
+  #       - put: slack
+  #         params:
+  #           text: |
+  #             :white_check_mark: SUCCESS: Successfully deployed admin client on pages staging
+  #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  #           channel: ((slack-channel))
+  #           username: ((slack-username))
+  #           icon_url: ((slack-icon-url))
 
-  - name: deploy-queues-ui-pages-staging
-    plan:
-      - get: src-queues-ui
-        resource: src-staging
-        trigger: true
-        params: {depth: 1}
-      - put: gh-status
-        inputs: [src-queues-ui]
-        params: {state: pending}
-      - task: deploy-queues-ui
-        config:
-          <<: *cf-image
-          inputs: [name: src-queues-ui]
-          run:
-            path: src-queues-ui/ci/tasks/deploy.sh
-        params:
-          <<: *staging-cf
-          CF_APP_NAME: pages-queues-ui-staging
-          CF_MANIFEST: src-queues-ui/.cloudgov/manifest.yml
-          CF_VARS_FILE: src-queues-ui/.cloudgov/vars/pages-staging.yml
-          CF_PATH: src-queues-ui
-        on_failure:
-          try:
-            task: cancel-queues-ui-deployment
-            config:
-              <<: *cf-image
-              inputs: [name: src-queues-ui]
-              run:
-                path: src-queues-ui/ci/tasks/cancel-deployment.sh
-            params:
-              <<: *staging-cf
-              CF_APP_NAME: pages-queues-ui-staging
-    on_failure:
-      in_parallel:
-        - put: gh-status
-          inputs: [src-queues-ui]
-          params: {state: failure}  
-        - put: slack
-          params:
-            text: |
-              :x: FAILED: pages queues UI deployment on pages staging
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
-    on_success:
-      in_parallel:
-        - put: gh-status
-          inputs: [src-queues-ui]
-          params: {state: success}
-        - put: slack
-          params:
-            text: |
-              :white_check_mark: SUCCESS: Successfully deployed pages queues UI on pages staging
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
+  # - name: deploy-queues-ui-pages-staging
+  #   plan:
+  #     - get: src-queues-ui
+  #       resource: src-staging
+  #       trigger: true
+  #       params: {depth: 1}
+  #     - put: gh-status
+  #       inputs: [src-queues-ui]
+  #       params: {state: pending}
+  #     - task: deploy-queues-ui
+  #       config:
+  #         <<: *cf-image
+  #         inputs: [name: src-queues-ui]
+  #         run:
+  #           path: src-queues-ui/ci/tasks/deploy.sh
+  #       params:
+  #         <<: *staging-cf
+  #         CF_APP_NAME: pages-queues-ui-staging
+  #         CF_MANIFEST: src-queues-ui/.cloudgov/manifest.yml
+  #         CF_VARS_FILE: src-queues-ui/.cloudgov/vars/pages-staging.yml
+  #         CF_PATH: src-queues-ui
+  #       on_failure:
+  #         try:
+  #           task: cancel-queues-ui-deployment
+  #           config:
+  #             <<: *cf-image
+  #             inputs: [name: src-queues-ui]
+  #             run:
+  #               path: src-queues-ui/ci/tasks/cancel-deployment.sh
+  #           params:
+  #             <<: *staging-cf
+  #             CF_APP_NAME: pages-queues-ui-staging
+  #   on_failure:
+  #     in_parallel:
+  #       - put: gh-status
+  #         inputs: [src-queues-ui]
+  #         params: {state: failure}  
+  #       - put: slack
+  #         params:
+  #           text: |
+  #             :x: FAILED: pages queues UI deployment on pages staging
+  #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  #             ((slack-users))
+  #           channel: ((slack-channel))
+  #           username: ((slack-username))
+  #           icon_url: ((slack-icon-url))
+  #   on_success:
+  #     in_parallel:
+  #       - put: gh-status
+  #         inputs: [src-queues-ui]
+  #         params: {state: success}
+  #       - put: slack
+  #         params:
+  #           text: |
+  #             :white_check_mark: SUCCESS: Successfully deployed pages queues UI on pages staging
+  #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  #             ((slack-users))
+  #           channel: ((slack-channel))
+  #           username: ((slack-username))
+  #           icon_url: ((slack-icon-url))
 
   - name: nightly-tasks-pages-staging
     plan:
@@ -468,15 +468,15 @@ jobs:
           params:
             <<: *staging-cf
             CF_APP_NAME: pages-staging
-        - task: restage-queues-ui
-          config:
-            inputs: [name: src]
-            <<: *cf-image
-            run:
-              path: src/ci/tasks/restage.sh
-          params:
-            <<: *staging-cf
-            CF_APP_NAME: pages-queues-ui-staging
+        # - task: restage-queues-ui
+        #   config:
+        #     inputs: [name: src]
+        #     <<: *cf-image
+        #     run:
+        #       path: src/ci/tasks/restage.sh
+        #   params:
+        #     <<: *staging-cf
+        #     CF_APP_NAME: pages-queues-ui-staging
 
 
 ############################

--- a/test/api/admin/requests/admin-auth.test.js
+++ b/test/api/admin/requests/admin-auth.test.js
@@ -31,83 +31,85 @@ describe('Admin authentication request', () => {
     });
   });
 
-  describe('GET /admin/auth/uaa/callback', () => {
-    it('returns unauthorized if the user is not an admin', async () => {
-      const uaaId = 'user_id_1';
-      const code = 'code';
-      const profile = { email: 'hello@example.com', user_id: uaaId };
-      const user = await userFactory();
-      await createUAAIdentity({
-        uaaId,
-        userId: user.id,
-      });
-      const userProfile = uaaUser({
-        id: uaaId,
-        groups: [{
-          display: 'not.admin',
-        }],
-        ...profile,
-      });
-
-      cfUAANock.mockUAAAuth(profile, code);
-      cfUAANock.mockVerifyUserGroup(uaaId, userProfile);
-
-      return request(app)
-        .get(`/admin/auth/uaa/callback?code=${code}&state=abc123`)
-        .expect(401);
-    });
-
-    describe.skip('when successful', () => {
-      const uaaId = 'admin_id_1';
-      const code = 'code';
-      const email = 'hello@example.com';
-      const uaaUserProfile = uaaProfile({
-        userId: uaaId,
-        email,
-      });
-      const uaaUserInfo = uaaUser({
-        uaaId,
-        email,
-        groups: [{
-          display: 'pages.admin',
-        }],
-      });
-
-      before(async () => {
+  if (process.env.FEATURE_AUTH_UAA === 'true') {
+    describe('GET /admin/auth/uaa/callback', () => {
+      it('returns unauthorized if the user is not an admin', async () => {
+        const uaaId = 'user_id_1';
+        const code = 'code';
+        const profile = { email: 'hello@example.com', user_id: uaaId };
         const user = await userFactory();
         await createUAAIdentity({
           uaaId,
-          email,
           userId: user.id,
         });
-      });
+        const userProfile = uaaUser({
+          id: uaaId,
+          groups: [{
+            display: 'not.admin',
+          }],
+          ...profile,
+        });
 
-      beforeEach(() => {
-        cfUAANock.mockUAAAuth(uaaUserProfile, code);
-        cfUAANock.mockVerifyUserGroup(uaaId, uaaUserInfo);
-      });
+        cfUAANock.mockUAAAuth(profile, code);
+        cfUAANock.mockVerifyUserGroup(uaaId, userProfile);
 
-      it('returns a script tag', (done) => {
-        request(app)
+        return request(app)
           .get(`/admin/auth/uaa/callback?code=${code}&state=abc123`)
-          .expect((res) => {
-            expect(res.text.trim()).to.match(/^<script nonce=".*">(.|\n)*<\/script>$/g);
-          })
-          .expect(200, done);
+          .expect(401);
       });
 
-      it('authenticates the session', async () => {
-        const cookie = await unauthenticatedSession({ oauthState: 'state-123abc', cfg: sessionConfig });
-        await request(app)
-          .get(`/admin/auth/uaa/callback?code=${code}&state=abc123`)
-          .set('Cookie', cookie)
-          .expect(200)
-          .expect((res) => {
-            expect(res.text.trim()).to.match(/^<script nonce=".*">(.|\n)*<\/script>$/g);
+      describe('when successful', () => {
+        const uaaId = 'admin_id_1';
+        const code = 'code';
+        const email = 'hello@example.com';
+        const uaaUserProfile = uaaProfile({
+          userId: uaaId,
+          email,
+        });
+        const uaaUserInfo = uaaUser({
+          uaaId,
+          email,
+          groups: [{
+            display: 'pages.admin',
+          }],
+        });
+
+        before(async () => {
+          const user = await userFactory();
+          await createUAAIdentity({
+            uaaId,
+            email,
+            userId: user.id,
           });
-        const session = await sessionForCookie(cookie, 'federalist-admin.sid');
-        expect(session.passport.user).to.exist;
+        });
+
+        beforeEach(() => {
+          cfUAANock.mockUAAAuth(uaaUserProfile, code);
+          cfUAANock.mockVerifyUserGroup(uaaId, uaaUserInfo);
+        });
+
+        it('returns a script tag', (done) => {
+          request(app)
+            .get(`/admin/auth/uaa/callback?code=${code}&state=abc123`)
+            .expect((res) => {
+              expect(res.text.trim()).to.match(/^<script nonce=".*">(.|\n)*<\/script>$/g);
+            })
+            .expect(200, done);
+        });
+
+        it('authenticates the session', async () => {
+          const cookie = await unauthenticatedSession({ oauthState: 'state-123abc', cfg: sessionConfig });
+          await request(app)
+            .get(`/admin/auth/uaa/callback?code=${code}&state=abc123`)
+            .set('Cookie', cookie)
+            .expect(200)
+            .expect((res) => {
+              expect(res.text.trim()).to.match(/^<script nonce=".*">(.|\n)*<\/script>$/g);
+            });
+          const session = await sessionForCookie(cookie, 'federalist-admin.sid');
+          expect(session.passport.user).to.exist;
+        });
       });
     });
-  });
+  }
 });

--- a/test/api/bull-board/requests/auth.test.js
+++ b/test/api/bull-board/requests/auth.test.js
@@ -7,8 +7,10 @@ const cfUAANock = require('../../support/cfUAANock');
 const userFactory = require('../../support/factory/user');
 const { uaaUser, uaaProfile, createUAAIdentity } = require('../../support/factory/uaa-identity');
 const sessionConfig = require('../../../../api/bull-board/sessionConfig');
-const { options: uaaConfig } = require('../../../../config').passport.uaa;
+const config = require('../../../../config');
 const app = require('../../../../api/bull-board/app');
+
+const { options: uaaConfig } = config.passport.uaa;
 
 function unauthenticatedSession({ oauthState, authRedirectPath, cfg = sessionConfig } = {}) {
   return new Promise((resolve, reject) => {
@@ -62,109 +64,111 @@ const sessionForCookie = (cookie, sid = 'federalist-bull-board.sid') => {
   });
 };
 
-describe.skip('bull board authentication request', () => {
-  after(() => Promise.all([
-    User.truncate(),
-    UAAIdentity.truncate(),
-  ]));
+if (config.product === 'pages') {
+  describe('bull board authentication request', () => {
+    after(() => Promise.all([
+      User.truncate(),
+      UAAIdentity.truncate(),
+    ]));
 
-  describe('GET /login', () => {
-    it('should redirect to the configured cloud.gov authorization endpoint', () => {
-      const locationRE = new RegExp(`^${uaaConfig.authorizationURL}`);
-      request(app)
-        .get('/login')
-        .expect('Location', locationRE)
-        .expect(302);
-    });
-  });
-
-  describe('GET /auth/uaa/logout', () => {
-    it('redirects to the root', () => request(app)
-      .get('/auth/uaa/logout')
-      .expect('Location', '/')
-      .expect(302));
-  });
-
-  describe('GET / while unauthenticated', () => {
-    it('redirects to the root', () => request(app)
-      .get('/')
-      .expect('Location', '/login')
-      .expect(302));
-  });
-
-  describe('GET /auth/uaa/callback', () => {
-    it('returns unauthorized if the user is not an admin', async () => {
-      const uaaId = 'bull_non_admin_id_1';
-      const code = 'code';
-      const profile = { email: 'hello@bull-example.com', user_id: uaaId };
-      const user = await userFactory();
-      await createUAAIdentity({
-        uaaId,
-        userId: user.id,
+    describe('GET /login', () => {
+      it('should redirect to the configured cloud.gov authorization endpoint', () => {
+        const locationRE = new RegExp(`^${uaaConfig.authorizationURL}`);
+        request(app)
+          .get('/login')
+          .expect('Location', locationRE)
+          .expect(302);
       });
-      const userProfile = uaaUser({
-        id: uaaId,
-        groups: [{
-          display: 'pages.user',
-        }],
-        ...profile,
-      });
-
-      cfUAANock.mockUAAAuth(profile, code);
-      cfUAANock.mockVerifyUserGroup(uaaId, userProfile);
-
-      return request(app)
-        .get(`/auth/uaa/callback?code=${code}&state=abc123`)
-        .expect(401);
     });
 
-    describe('when successful', () => {
-      const uaaId = 'bull_admin_id_1';
-      const code = 'code';
-      const email = 'hello@bull-example.com';
-      const uaaUserProfile = uaaProfile({
-        userId: uaaId,
-        email,
-      });
-      const uaaUserInfo = uaaUser({
-        uaaId,
-        email,
-        groups: [{
-          display: 'pages.admin',
-        }],
-      });
-      let user;
-      before(async () => {
-        user = await userFactory();
+    describe('GET /auth/uaa/logout', () => {
+      it('redirects to the root', () => request(app)
+        .get('/auth/uaa/logout')
+        .expect('Location', '/')
+        .expect(302));
+    });
+
+    describe('GET / while unauthenticated', () => {
+      it('redirects to the root', () => request(app)
+        .get('/')
+        .expect('Location', '/login')
+        .expect(302));
+    });
+
+    describe('GET /auth/uaa/callback', () => {
+      it('returns unauthorized if the user is not an admin', async () => {
+        const uaaId = 'bull_non_admin_id_1';
+        const code = 'code';
+        const profile = { email: 'hello@bull-example.com', user_id: uaaId };
+        const user = await userFactory();
         await createUAAIdentity({
           uaaId,
-          email,
           userId: user.id,
         });
+        const userProfile = uaaUser({
+          id: uaaId,
+          groups: [{
+            display: 'pages.user',
+          }],
+          ...profile,
+        });
+
+        cfUAANock.mockUAAAuth(profile, code);
+        cfUAANock.mockVerifyUserGroup(uaaId, userProfile);
+
+        return request(app)
+          .get(`/auth/uaa/callback?code=${code}&state=abc123`)
+          .expect(401);
       });
 
-      beforeEach(() => {
-        cfUAANock.mockUAAAuth(uaaUserProfile, code);
-        cfUAANock.mockVerifyUserGroup(uaaId, uaaUserInfo);
-      });
+      describe('when successful', () => {
+        const uaaId = 'bull_admin_id_1';
+        const code = 'code';
+        const email = 'hello@bull-example.com';
+        const uaaUserProfile = uaaProfile({
+          userId: uaaId,
+          email,
+        });
+        const uaaUserInfo = uaaUser({
+          uaaId,
+          email,
+          groups: [{
+            display: 'pages.admin',
+          }],
+        });
+        let user;
+        before(async () => {
+          user = await userFactory();
+          await createUAAIdentity({
+            uaaId,
+            email,
+            userId: user.id,
+          });
+        });
 
-      it('authenticates the session', async () => {
-        const oauthState = 'state-123abc';
-        const uaaIdentity = await user.getUAAIdentity();
-        const cookie = await unauthenticatedSession({ oauthState, cfg: sessionConfig });
+        beforeEach(() => {
+          cfUAANock.mockUAAAuth(uaaUserProfile, code);
+          cfUAANock.mockVerifyUserGroup(uaaId, uaaUserInfo);
+        });
 
-        await request(app)
-          .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
-          .set('Cookie', cookie)
-          .expect('Location', '/')
-          .expect(302);
+        it('authenticates the session', async () => {
+          const oauthState = 'state-123abc';
+          const uaaIdentity = await user.getUAAIdentity();
+          const cookie = await unauthenticatedSession({ oauthState, cfg: sessionConfig });
 
-        const authSession = await sessionForCookie(cookie, 'federalist-bull-board.sid');
+          await request(app)
+            .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
+            .set('Cookie', cookie)
+            .expect('Location', '/')
+            .expect(302);
 
-        expect(authSession.passport.user).to.exist;
-        expect(authSession.authenticated).to.equal(true);
-        expect(authSession.passport.user).to.equal(uaaIdentity.uaaId);
+          const authSession = await sessionForCookie(cookie, 'federalist-bull-board.sid');
+
+          expect(authSession.passport.user).to.exist;
+          expect(authSession.authenticated).to.equal(true);
+          expect(authSession.passport.user).to.equal(uaaIdentity.uaaId);
+        });
       });
     });
   });
-});
+}

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -333,189 +333,191 @@ describe('Authentication requests', () => {
     });
   });
 
-  context.skip('UAA', () => {
-    context('Callbacks', () => {
-      beforeEach(() => Promise.all([
-        User.truncate(),
-        UAAIdentity.truncate(),
-      ]));
+  if (process.env.FEATURE_AUTH_UAA === 'true') {
+    context('UAA', () => {
+      context('Callbacks', () => {
+        beforeEach(() => Promise.all([
+          User.truncate(),
+          UAAIdentity.truncate(),
+        ]));
 
-      afterEach(() => Promise.all([
-        User.truncate(),
-        UAAIdentity.truncate(),
-      ]));
+        afterEach(() => Promise.all([
+          User.truncate(),
+          UAAIdentity.truncate(),
+        ]));
 
-      describe('GET /login', () => {
-        it('should redirect to the configured IdP for authentication', (done) => {
-          request(app)
-            .get('/login')
-            .expect('Location', new RegExp(`^${uaa.options.authorizationURL}`))
-            .expect(302, done);
-        });
-
-        it('should redirect to the root URL if the users is logged in', (done) => {
-          authenticatedSession().then((cookie) => {
+        describe('GET /login', () => {
+          it('should redirect to the configured IdP for authentication', (done) => {
             request(app)
               .get('/login')
+              .expect('Location', new RegExp(`^${uaa.options.authorizationURL}`))
+              .expect(302, done);
+          });
+
+          it('should redirect to the root URL if the users is logged in', (done) => {
+            authenticatedSession().then((cookie) => {
+              request(app)
+                .get('/login')
+                .set('Cookie', cookie)
+                .expect('Location', '/')
+                .expect(302, done);
+            });
+          });
+        });
+
+        describe('GET /logout', () => {
+          it('should de-authenticate and remove the user from the session', async () => {
+            const user = await factory.user();
+            const cookie = await authenticatedSession(user);
+            const authSession = await sessionForCookie(cookie);
+
+            expect(authSession.authenticated).to.be.equal(true);
+            expect(authSession.passport.user).to.equal(user.id);
+
+            await request(app)
+              .get('/logout')
               .set('Cookie', cookie)
-              .expect('Location', '/')
+              .expect('Location', new RegExp(`^${uaa.options.logoutURL}`))
+              .expect(302);
+
+            expect(eventAuditStub.called).to.equal(true);
+
+            const nonAuthSession = await sessionForCookie(cookie);
+
+            expect(nonAuthSession).to.equal(null);
+
+            expect(eventAuditStub.called).to.equal(true);
+          });
+
+          it('should redirect to the root URL for an unauthenticated user', (done) => {
+            request(app)
+              .get('/logout')
+              .expect('Location', new RegExp(`^${uaa.options.logoutURL}`))
               .expect(302, done);
           });
         });
-      });
 
-      describe('GET /logout', () => {
-        it('should de-authenticate and remove the user from the session', async () => {
+        describe('GET /auth/uaa/callback', () => {
+          context('when the admin user exists in the database', () => {
+            it('should authenticate the user', async () => {
+              nock.cleanAll();
+              const uaaId = 'uaa-admin-authenticated';
+              const email = 'uaa-admin-authenticated@example.com';
+              const uaaUserProfile = uaaProfile({
+                userId: uaaId,
+                email,
+              });
+              const uaaUserInfo = uaaUser({
+                uaaId,
+                email,
+                groups: [{
+                  display: 'pages.admin',
+                }],
+              });
+              const user = await factory.user();
+              await factory.uaaIdentity({
+                uaaId,
+                email,
+                userId: user.id,
+              });
+              const oauthState = 'state-123abc';
+              const code = 'code';
+
+              cfUAANocks.mockUAAAuth(uaaUserProfile, code);
+              cfUAANocks.mockVerifyUserGroup(uaaId, uaaUserInfo);
+
+              const cookie = await unauthenticatedSession({ oauthState });
+
+              await request(app)
+                .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
+                .set('Cookie', cookie)
+                .expect(302);
+
+              const authSession = await sessionForCookie(cookie);
+
+              expect(authSession.authenticated).to.equal(true);
+              expect(authSession.passport.user).to.equal(user.id);
+              expect(eventAuditStub.calledOnce).to.equal(true);
+            });
+          });
+
+          context('when the admin user does not exist in the database', () => {
+            it('should fail to authenticate, redirect the user and provide a flash message', async () => {
+              const uaaId = 'uaa-admin-does-not-exist';
+              const profile = { email: 'hello@example.com', user_id: uaaId };
+              const userProfile = uaaUser({
+                id: uaaId,
+                groups: [{
+                  display: 'pages.admin',
+                }],
+                ...profile,
+              });
+              const oauthState = 'state-123abc';
+              const code = 'code';
+
+              cfUAANocks.mockUAAAuth(profile, code);
+              cfUAANocks.mockVerifyUserGroup(uaaId, userProfile);
+
+              const cookie = await unauthenticatedSession({ oauthState });
+
+              await request(app)
+                .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
+                .set('Cookie', cookie)
+                .expect('Location', '/')
+                .expect(302);
+
+              const session = await sessionForCookie(cookie);
+
+              expect(session.flash.error.length).to.equal(1);
+              expect(session.flash.error[0]).to.equal(flashMessage);
+              expect(eventAuditStub.called).to.equal(false);
+            });
+          });
+        });
+
+        it('should redirect to a redirect path if one is set in the session', async () => {
+          const uaaId = 'uaa-admin-auth-redirect';
+          const email = 'uaa-admin-auth-redirect@example.com';
+          const uaaUserProfile = uaaProfile({
+            userId: uaaId,
+            email,
+          });
+          const uaaUserInfo = uaaUser({
+            uaaId,
+            email,
+            groups: [{
+              display: 'pages.admin',
+            }],
+          });
           const user = await factory.user();
-          const cookie = await authenticatedSession(user);
-          const authSession = await sessionForCookie(cookie);
+          await factory.uaaIdentity({
+            uaaId,
+            email,
+            userId: user.id,
+          });
+          const authRedirectPath = '/path/to/something';
+          const oauthState = 'state-123abc';
+          const code = 'code';
 
-          expect(authSession.authenticated).to.be.equal(true);
-          expect(authSession.passport.user).to.equal(user.id);
+          cfUAANocks.mockUAAAuth(uaaUserProfile, code);
+          cfUAANocks.mockVerifyUserGroup(uaaId, uaaUserInfo);
+
+          const session = await unauthenticatedSession({ oauthState, authRedirectPath });
 
           await request(app)
-            .get('/logout')
-            .set('Cookie', cookie)
-            .expect('Location', new RegExp(`^${uaa.options.logoutURL}`))
+            .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
+            .set('Cookie', session)
+            .expect('Location', authRedirectPath)
             .expect(302);
-
-          expect(eventAuditStub.called).to.equal(true);
-
-          const nonAuthSession = await sessionForCookie(cookie);
-
-          expect(nonAuthSession).to.equal(null);
-
-          expect(eventAuditStub.called).to.equal(true);
-        });
-
-        it('should redirect to the root URL for an unauthenticated user', (done) => {
-          request(app)
-            .get('/logout')
-            .expect('Location', new RegExp(`^${uaa.options.logoutURL}`))
-            .expect(302, done);
         });
       });
 
-      describe('GET /auth/uaa/callback', () => {
-        context('when the admin user exists in the database', () => {
-          it('should authenticate the user', async () => {
-            nock.cleanAll();
-            const uaaId = 'uaa-admin-authenticated';
-            const email = 'uaa-admin-authenticated@example.com';
-            const uaaUserProfile = uaaProfile({
-              userId: uaaId,
-              email,
-            });
-            const uaaUserInfo = uaaUser({
-              uaaId,
-              email,
-              groups: [{
-                display: 'pages.admin',
-              }],
-            });
-            const user = await factory.user();
-            await factory.uaaIdentity({
-              uaaId,
-              email,
-              userId: user.id,
-            });
-            const oauthState = 'state-123abc';
-            const code = 'code';
-
-            cfUAANocks.mockUAAAuth(uaaUserProfile, code);
-            cfUAANocks.mockVerifyUserGroup(uaaId, uaaUserInfo);
-
-            const cookie = await unauthenticatedSession({ oauthState });
-
-            await request(app)
-              .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
-              .set('Cookie', cookie)
-              .expect(302);
-
-            const authSession = await sessionForCookie(cookie);
-
-            expect(authSession.authenticated).to.equal(true);
-            expect(authSession.passport.user).to.equal(user.id);
-            expect(eventAuditStub.calledOnce).to.equal(true);
-          });
-        });
-
-        context('when the admin user does not exist in the database', () => {
-          it('should fail to authenticate, redirect the user and provide a flash message', async () => {
-            const uaaId = 'uaa-admin-does-not-exist';
-            const profile = { email: 'hello@example.com', user_id: uaaId };
-            const userProfile = uaaUser({
-              id: uaaId,
-              groups: [{
-                display: 'pages.admin',
-              }],
-              ...profile,
-            });
-            const oauthState = 'state-123abc';
-            const code = 'code';
-
-            cfUAANocks.mockUAAAuth(profile, code);
-            cfUAANocks.mockVerifyUserGroup(uaaId, userProfile);
-
-            const cookie = await unauthenticatedSession({ oauthState });
-
-            await request(app)
-              .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
-              .set('Cookie', cookie)
-              .expect('Location', '/')
-              .expect(302);
-
-            const session = await sessionForCookie(cookie);
-
-            expect(session.flash.error.length).to.equal(1);
-            expect(session.flash.error[0]).to.equal(flashMessage);
-            expect(eventAuditStub.called).to.equal(false);
-          });
-        });
-      });
-
-      it('should redirect to a redirect path if one is set in the session', async () => {
-        const uaaId = 'uaa-admin-auth-redirect';
-        const email = 'uaa-admin-auth-redirect@example.com';
-        const uaaUserProfile = uaaProfile({
-          userId: uaaId,
-          email,
-        });
-        const uaaUserInfo = uaaUser({
-          uaaId,
-          email,
-          groups: [{
-            display: 'pages.admin',
-          }],
-        });
-        const user = await factory.user();
-        await factory.uaaIdentity({
-          uaaId,
-          email,
-          userId: user.id,
-        });
-        const authRedirectPath = '/path/to/something';
-        const oauthState = 'state-123abc';
-        const code = 'code';
-
-        cfUAANocks.mockUAAAuth(uaaUserProfile, code);
-        cfUAANocks.mockVerifyUserGroup(uaaId, uaaUserInfo);
-
-        const session = await unauthenticatedSession({ oauthState, authRedirectPath });
-
-        await request(app)
-          .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
-          .set('Cookie', session)
-          .expect('Location', authRedirectPath)
-          .expect(302);
+      describe('GET /auth/uaa/logout', () => {
+        it('redirects to the root', () => request(app)
+          .get('/auth/uaa/logout')
+          .expect('Location', '/')
+          .expect(302));
       });
     });
-
-    describe('GET /auth/uaa/logout', () => {
-      it('redirects to the root', () => request(app)
-        .get('/auth/uaa/logout')
-        .expect('Location', '/')
-        .expect(302));
-    });
-  });
+  }
 });

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -198,7 +198,7 @@ describe('Build model', () => {
           expect(site.publishedAt).to.be.a('date');
           expect(build.completedAt.getTime()).to.eql(site.publishedAt.getTime());
           const url = [
-            `https://${site.awsBucketName}.${config.app.domain}`,
+            `https://${site.awsBucketName}.${config.app.proxyDomain}`,
             `/preview/${site.owner}/${site.repository}/${build.branch}`,
           ].join('');
           expect(build.url).to.eql(url);

--- a/test/api/unit/services/SiteBuildQueue.test.js
+++ b/test/api/unit/services/SiteBuildQueue.test.js
@@ -176,7 +176,7 @@ describe('SiteBuildQueue', () => {
         .then((build) => { // eslint-disable-line
           return SiteBuildQueue.messageBodyForBuild(build)
             .then((message) => {
-              expect(messageEnv(message, 'STATUS_CALLBACK')).to.equal(`http://localhost:1337/v0/build/${build.id}/status/${build.token}`);
+              expect(messageEnv(message, 'STATUS_CALLBACK')).to.equal(`http://${config.app.domain}/v0/build/${build.id}/status/${build.token}`);
               done();
             });
         })

--- a/test/api/unit/utils/build.test.js
+++ b/test/api/unit/utils/build.test.js
@@ -14,7 +14,7 @@ describe('build utils', () => {
     it('default branch url start with site', async () => {
       let build = await factory.build({ branch: site.defaultBranch, site });
       const url = [
-        `https://${site.awsBucketName}.${config.app.domain}`,
+        `https://${site.awsBucketName}.${config.app.proxyDomain}`,
         `/site/${site.owner}/${site.repository}`,
       ].join('');
       expect(buildUrl(build, site)).to.eql(url);
@@ -23,7 +23,7 @@ describe('build utils', () => {
     it('demo branch url start with demo', async () => {
       const build = await factory.build({ branch: site.demoBranch, site });
       const url = [
-        `https://${site.awsBucketName}.${config.app.domain}`,
+        `https://${site.awsBucketName}.${config.app.proxyDomain}`,
         `/demo/${site.owner}/${site.repository}`,
       ].join('');
       expect(buildUrl(build, site)).to.eql(url);
@@ -32,7 +32,7 @@ describe('build utils', () => {
     it('non-default/demo branch url start with preview', async () => {
       const build = await factory.build({ branch: 'other', site });
       const url = [
-        `https://${site.awsBucketName}.${config.app.domain}`,
+        `https://${site.awsBucketName}.${config.app.proxyDomain}`,
         `/preview/${site.owner}/${site.repository}/other`,
       ].join('');
       expect(buildUrl(build, site)).to.eql(url);

--- a/test/api/unit/utils/site.test.js
+++ b/test/api/unit/utils/site.test.js
@@ -8,7 +8,7 @@ const config = require('../../../../config');
 
 const awsBucketName = 'federalist-bucket';
 
-const url = bucket => `https://${bucket}.${config.app.domain}`;
+const url = bucket => `https://${bucket}.${config.app.proxyDomain}`;
 
 describe('site utils', () => {
   describe('siteViewLink', () => {
@@ -69,14 +69,14 @@ describe('site utils', () => {
 
     it('should return configured domain', async () => {
       const site = await factory.site({ awsBucketName });
-      expect(siteViewDomain(site)).equals(`https://${site.awsBucketName}.${config.app.domain}`);
+      expect(siteViewDomain(site)).equals(`https://${site.awsBucketName}.${config.app.proxyDomain}`);
     });
   });
 
   describe('siteViewOrigin', () => {
     it('should return configured domain', async () => {
       const site = await factory.site({ awsBucketName });
-      expect(siteViewOrigin(site)).equals(`${awsBucketName}.${config.app.domain}`);
+      expect(siteViewOrigin(site)).equals(`${awsBucketName}.${config.app.proxyDomain}`);
     });
   });
 });


### PR DESCRIPTION
## Changes proposed in this pull request:
- use current proxy url
- stick with `app.` until dns is updated
- enable github and uaa auth for now
- remove other apps from Concourse 

## security considerations
None
