### PR TITLE
Add builds queued check job in concourse ci

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -480,33 +480,34 @@ jobs:
 
   - name: sites-builds-checks-staging
     plan:
-    - get: src
-      resource: src-staging
-      params: {depth: 1}
-    - get: five-minutes
-      trigger: true
-    - in_parallel:
-      - task: queued-builds-check
-        config:
-          inputs: [name: src]
-          <<: *cf-image
-          run:
-            path: src/ci/tasks/run-task.sh
-        params:
-          <<: *staging-cf
-          CF_APP_NAME: pages-staging
-          CF_TASK_NAME: queued-builds-check
-          CF_TASK_COMMAND: yarn queued-builds-check ((support-email))
-    on_failure:
-      - put: slack
-        params:
-          text: |
-            :x: FAILED: sites builds checks on pages staging
-            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-            ((slack-users))
-          channel: ((slack-channel))
-          username: ((slack-username))
-          icon_url: ((slack-icon-url))
+      - get: src
+        resource: src-staging
+        params: {depth: 1}
+      - get: five-minutes
+        trigger: true
+      - in_parallel:
+        - task: queued-builds-check
+          config:
+            inputs: [name: src]
+            <<: *cf-image
+            run:
+              path: src/ci/tasks/run-task.sh
+          params:
+            <<: *staging-cf
+            CF_APP_NAME: pages-staging
+            CF_TASK_NAME: queued-builds-check
+            CF_TASK_COMMAND: yarn queued-builds-check ((support-email))
+        on_failure:
+          in_parallel:
+            - put: slack
+              params:
+                text: |
+                  :x: FAILED: sites builds checks on pages staging
+                  <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+                  ((slack-users))
+                channel: ((slack-channel))
+                username: ((slack-username))
+                icon_url: ((slack-icon-url))
 
 ############################
 #  RESOURCES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -84,7 +84,7 @@ test-api: &test-api
               popd
               docker-compose -f ci/docker/docker-compose.yml run app app/ci/tasks/test-api.sh
               docker-compose -f ci/docker/docker-compose.yml down
-              docker volume rm $(docker volume ls -q)    
+              docker volume rm $(docker volume ls -q)
 
 test-admin-client: &test-admin-client
   - task: install-deps-admin-client
@@ -119,7 +119,7 @@ test-admin-client: &test-admin-client
       outputs: [name: src-admin-client]
       params:
         API_URL: https://app.pages-staging.cloud.gov
-        NODE_ENV: production           
+        NODE_ENV: production
       run:
         dir: src-admin-client/admin-client
         path: bash
@@ -180,7 +180,7 @@ jobs:
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
             channel: ((slack-channel))
             username: ((slack-username))
-            icon_url: ((slack-icon-url))   
+            icon_url: ((slack-icon-url))
 
   # - name: test-admin-client-staging
   #   plan:
@@ -197,7 +197,7 @@ jobs:
   #         context: test-admin-client
 
   #     - do: *test-admin-client
-      
+
   #   on_failure:
   #     in_parallel:
   #       - put: src-admin-client
@@ -233,7 +233,7 @@ jobs:
   #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
   #           channel: ((slack-channel))
   #           username: ((slack-username))
-  #           icon_url: ((slack-icon-url))   
+  #           icon_url: ((slack-icon-url))
 
   - name: test-and-deploy-api-pages-staging
     plan:
@@ -301,7 +301,7 @@ jobs:
       in_parallel:
         - put: gh-status
           inputs: [src-api]
-          params: {state: success}      
+          params: {state: success}
         - put: slack
           params:
             text: |
@@ -365,7 +365,7 @@ jobs:
   #     in_parallel:
   #       - put: gh-status
   #         inputs: [src-admin-client]
-  #         params: {state: failure}   
+  #         params: {state: failure}
   #       - put: slack
   #         params:
   #           text: |
@@ -380,7 +380,7 @@ jobs:
   #     in_parallel:
   #       - put: gh-status
   #         inputs: [src-admin-client]
-  #         params: {state: success}   
+  #         params: {state: success}
   #       - put: slack
   #         params:
   #           text: |
@@ -426,7 +426,7 @@ jobs:
   #     in_parallel:
   #       - put: gh-status
   #         inputs: [src-queues-ui]
-  #         params: {state: failure}  
+  #         params: {state: failure}
   #       - put: slack
   #         params:
   #           text: |
@@ -478,6 +478,35 @@ jobs:
         #     <<: *staging-cf
         #     CF_APP_NAME: pages-queues-ui-staging
 
+  - name: sites-builds-checks-staging
+    plan:
+    - get: src
+      resource: src-staging
+      params: {depth: 1}
+    - get: five-minutes
+      trigger: true
+    - in_parallel:
+      - task: queued-builds-check
+        config:
+          inputs: [name: src]
+          <<: *cf-image
+          run:
+            path: src/ci/tasks/run-task.sh
+        params:
+          <<: *staging-cf
+          CF_APP_NAME: pages-staging
+          CF_TASK_NAME: queued-builds-check
+          CF_TASK_COMMAND: yarn queued-builds-check ((support-email))
+    on_failure:
+      - put: slack
+        params:
+          text: |
+            :x: FAILED: sites builds checks on pages staging
+            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+            ((slack-users))
+          channel: ((slack-channel))
+          username: ((slack-username))
+          icon_url: ((slack-icon-url))
 
 ############################
 #  RESOURCES
@@ -498,7 +527,7 @@ resources:
     type: git
     icon: github
     source:
-      uri: https://github.com/18F/federalist   
+      uri: https://github.com/18F/federalist
       branch: staging
 
   - name: nightly
@@ -507,6 +536,11 @@ resources:
       start: 12:00 AM
       stop: 1:00 AM
       location: America/New_York
+
+  - name: five-minutes
+    type: time
+    source:
+      interval: 5m
 
   - name: redis
     type: docker-image
@@ -525,7 +559,7 @@ resources:
     source:
       repository: node
       tag: 16.13
-  
+
   - name: slack
     type: slack-notification
     source:

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "bootstrap-admins": "node ./scripts/bootstrap-admins.js",
     "migrate-build-notification-settings": "node ./scripts/migrate-build-notification-settings.js",
     "remove-bucket-website-configs": "node ./scripts/remove-bucket-website-configs.js",
-    "check-object-paths": "node ./scripts/check-object-paths.js"
+    "check-object-paths": "node ./scripts/check-object-paths.js",
+    "queued-builds-check": "node ./scripts/queued-builds-check.js"
   },
   "main": "index.js",
   "repository": {

--- a/scripts/queued-builds-check.js
+++ b/scripts/queued-builds-check.js
@@ -14,6 +14,7 @@ async function checkQueuedBuilds() {
   const buildQueueTime = now.clone().subtract(BUILD_QUEUED_MINUTES, 'minutes');
 
   const options = {
+    attributes: ['id'],
     where: {
       [Op.or]: [
         {

--- a/scripts/queued-builds-check.js
+++ b/scripts/queued-builds-check.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-console */
+const moment = require('moment');
+const { Op } = require('sequelize');
+const { Build } = require('../api/models');
+const Mailer = require('../api/workers/Mailer');
+
+const [,, EMAIL_TO, MINUTES] = process.argv;
+const BUILD_QUEUED_MINUTES = MINUTES || 3;
+const EMAIL_SUBJECT = `ALERT ${process.env.CF_SPACE}: Site Builds Still Queued`;
+
+async function checkQueuedBuilds() {
+  const date = new Date();
+  const now = moment(date);
+  const buildQueueTime = now.clone().subtract(BUILD_QUEUED_MINUTES, 'minutes');
+
+  const options = {
+    where: {
+      [Op.or]: [
+        {
+          state: Build.States.Queued,
+          startedAt: {
+            [Op.lt]: buildQueueTime.toDate(),
+          },
+        },
+      ],
+    },
+    returning: ['id'],
+  };
+
+  const builds = await Build.findAll(options);
+  const buildIds = builds.map(b => b.id);
+
+  return buildIds;
+}
+
+function createBodyHTML(buildIds) {
+  const stringIds = buildIds.join(', ');
+
+  return `
+    <h1>Attention:</h1>
+    <p>
+      The following builds have been queued for
+      beyond ${BUILD_QUEUED_MINUTES} minutes.
+    </p>
+    </br>
+    <p>${stringIds}</p>
+    </br>
+    <p>
+      Please check the admin dashboard and
+      bull board to diagnose the delays.
+    </p>
+  `;
+}
+
+async function sendEmail(to, subject, html) {
+  const mailer = new Mailer();
+  const info = await mailer.send({ to, subject, html });
+  console.log(info.message);
+}
+
+async function runCheck() {
+  const buildIds = await checkQueuedBuilds();
+
+  if (buildIds.length === 0) return null;
+
+  const html = createBodyHTML(buildIds);
+  return sendEmail(EMAIL_TO, EMAIL_SUBJECT, html);
+}
+
+runCheck()
+  .catch(console.error);


### PR DESCRIPTION
See #3318 for more information

## Changes proposed in this pull request:
- [x] Add job to ci that will run a cf task every five minutes
- [x] cf task calls the queued-builds-check script to query the db for any builds queued beyond 3 minutes and sends an email of the build ids if there are any.
- [x] Update credhub with the pages support email

## security considerations
none