### PR TITLE
Increase worker memory and moves logs to job

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -14,7 +14,7 @@ applications:
         command: yarn start-workers
         disk_quota: 2G
         instances: 1
-        memory: ((memory))
+        memory: 2G
     services:
       - app-((env))-uaa-client
       - federalist-((env))-rds

--- a/test/api/workers/jobProcessors.test.js
+++ b/test/api/workers/jobProcessors.test.js
@@ -10,6 +10,8 @@ const SandboxHelper = require('../../../api/services/SandboxHelper');
 const factory = require('../support/factory');
 const jobProcessors = require('../../../api/workers/jobProcessors');
 
+const job = { log: () => Promise.resolve() };
+
 describe('job processors', () => {
   afterEach(() => {
     sinon.restore();
@@ -69,13 +71,13 @@ describe('job processors', () => {
 
     it('all archived successfully', async () => {
       sinon.stub(BuildLogs, 'archiveBuildLogsForBuildId').resolves();
-      const result = await jobProcessors.archiveBuildLogsDaily();
+      const result = await jobProcessors.archiveBuildLogsDaily(job);
       expect(result).to.not.be.an('error');
     });
 
     it('fails to archive successfully', async () => {
       sinon.stub(BuildLogs, 'archiveBuildLogsForBuildId').rejects('erred out');
-      const result = await jobProcessors.archiveBuildLogsDaily().catch(e => e);
+      const result = await jobProcessors.archiveBuildLogsDaily(job).catch(e => e);
       expect(result).to.be.an('error');
       const dateStr = moment().subtract(1, 'days').startOf('day').format('YYYY-MM-DD');
       expect(result.message.split(',')[0]).to
@@ -165,11 +167,11 @@ describe('job processors', () => {
         { status: 'rejected', reason: 'just because' },
       ]);
 
-      const result = await jobProcessors.cleanSandboxOrganizations().catch(e => e); 
+      const result = await jobProcessors.cleanSandboxOrganizations().catch(e => e);
       expect(result).to.be.an('error');
       expect(result.message).to.equal([
         'Sandbox organizations cleaned with 1 successes and 1 failures.',
-        '   Successes:\n      cleaned\n   Failures:\n      just because'
+        '   Successes:\n      cleaned\n   Failures:\n      just because',
       ].join('\n'));
     });
   });


### PR DESCRIPTION
It looks like the worker is running out of memory when processing this job, let's try upping the memory a bit. We can keep increasing it to a limit, if that doesn't work, we have a couple options:
1. Move the job to a "sandboxed" processor which may prevent the job from "stalling"
2. Revisit how we archive since we're trying to move all the logs in one request.

## Changes proposed in this pull request:
- Increase worker memory to 2GB
- Move logs to job so they are visible in Bull Board
- #3793 

## security considerations
None
