### PR TITLE
Explicitly exit task

### DIFF
--- a/scripts/queued-builds-check.js
+++ b/scripts/queued-builds-check.js
@@ -69,4 +69,8 @@ async function runCheck() {
 }
 
 runCheck()
-  .catch(console.error);
+  .then(() => process.exit())
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Changes proposed in this pull request:
- Make sure to call `process.exit` task when checking queued build status.

## security considerations
- none
