### PR TITLE
Refactor config.js out of CF clients and use env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,10 @@ jobs:
           environment:
             APP_HOSTNAME: http://localhost:1337
             PRODUCT: federalist
+            CLOUD_FOUNDRY_API_HOST: https://api.example.com
+            CLOUD_FOUNDRY_OAUTH_TOKEN_URL: https://login.example.com/oauth/token
+            CF_API_USERNAME: deploy_user
+            CF_API_PASSWORD: deploy_pass
 
       - run:
           name: CodeClimate combine and upload coverage

--- a/.profile
+++ b/.profile
@@ -1,0 +1,2 @@
+export CF_API_USERNAME="$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == "federalist-deploy-user") | .credentials | .DEPLOY_USER_USERNAME')"
+export CF_API_PASSWORD="$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == "federalist-deploy-user") | .credentials | .DEPLOY_USER_PASSWORD')"

--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -221,12 +221,19 @@ async function provision(domain, dnsResults) {
   const origin = siteViewOrigin(site);
   const path = sitePath(site, domain.context);
 
-  await cfApi().createExternalDomain(
-    domain.names,
-    serviceName,
+  const {
+    cfCdnSpaceName,
+    cfDomainWithCdnPlanGuid,
+  } = config.env;
+
+  await cfApi().createExternalDomain({
+    domains: domain.names,
+    name: serviceName,
     origin,
-    path
-  );
+    path,
+    cfCdnSpaceName,
+    cfDomainWithCdnPlanGuid,
+  });
 
   await domain.update({
     origin,

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -109,7 +109,7 @@ function buildSite(params, s3) {
 }
 
 function buildInfrastructure(params, s3ServiceName) {
-  return apiClient.createSiteBucket(s3ServiceName)
+  return apiClient.createSiteBucket(s3ServiceName, config.env.cfSpaceGuid)
     .then((response) => {
       const { credentials } = response.entity;
 
@@ -119,7 +119,12 @@ function buildInfrastructure(params, s3ServiceName) {
         region: credentials.region,
       };
 
-      return apiClient.createSiteProxyRoute(credentials.bucket)
+      return apiClient.createSiteProxyRoute(
+        credentials.bucket,
+        config.env.cfDomainGuid,
+        config.env.cfSpaceGuid,
+        config.env.cfProxyGuid
+      )
         .then(() => buildSite(params, s3));
     });
 }

--- a/api/utils/cfAuthClient.js
+++ b/api/utils/cfAuthClient.js
@@ -1,13 +1,12 @@
 const jwt = require('jsonwebtoken');
-const config = require('../../config');
 const HttpClient = require('./httpClient');
 
 class CloudFoundryAuthClient {
-  constructor() {
-    this.username = config.deployUser.username;
-    this.password = config.deployUser.password;
+  constructor({ username, password, tokenUrl } = {}) {
+    this.username = username ?? process.env.CF_API_USERNAME;
+    this.password = password ?? process.env.CF_API_PASSWORD;
+    this.httpClient = new HttpClient(tokenUrl ?? process.env.CLOUD_FOUNDRY_OAUTH_TOKEN_URL);
     this.token = '';
-    this.httpClient = new HttpClient(config.env.cfOauthTokenUrl);
   }
 
   accessToken() {

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -15,6 +15,10 @@ services:
       APP_HOSTNAME: http://localhost:1337
       FEATURE_AUTH_UAA: 'true'
       PRODUCT: pages
+      CLOUD_FOUNDRY_API_HOST: https://api.example.com
+      CLOUD_FOUNDRY_OAUTH_TOKEN_URL: https://login.example.com/oauth/token
+      CF_API_USERNAME: deploy_user
+      CF_API_PASSWORD: deploy_pass
   db:
     image: postgres:11-alpine
     environment:

--- a/config/env.js
+++ b/config/env.js
@@ -4,8 +4,6 @@ module.exports = {
   cfSpaceGuid: process.env.CF_SPACE_GUID || '123abc-456def-789ghi',
   cfCdnSpaceName: process.env.CF_CDN_SPACE_NAME || 'sites',
   cfDomainWithCdnPlanGuid: process.env.CF_DOMAIN_WITH_CDN_PLAN_GUID || '123abc-456def-789ghi',
-  cfOauthTokenUrl: process.env.CLOUD_FOUNDRY_OAUTH_TOKEN_URL || 'https://login.example.com/oauth/token',
-  cfApiHost: process.env.CLOUD_FOUNDRY_API_HOST || 'https://api.example.com',
   uaaHost: process.env.UAA_HOST || 'http://uaa.example.com',
   uaaHostUrl: process.env.UAA_HOST_DOCKER_URL || process.env.UAA_HOST || 'http://uaa.example.com',
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -76,42 +76,27 @@ if (redisCreds) {
   throw new Error('No Redis credentials found');
 }
 
-// Deploy User
-const deployUserCreds = appEnv.getServiceCreds('federalist-deploy-user');
-if (deployUserCreds) {
-  module.exports.deployUser = {
-    username: deployUserCreds.DEPLOY_USER_USERNAME,
-    password: deployUserCreds.DEPLOY_USER_PASSWORD,
-  };
-} else {
-  throw new Error('No deploy user credentials found');
-}
-
 // Environment Variables
 const cfDomain = appEnv.getServiceCreds(`${productPrefix}-domain`);
 const cfProxy = appEnv.getServiceCreds(`${productPrefix}-proxy`);
-const cfOauthTokenUrl = process.env.CLOUD_FOUNDRY_OAUTH_TOKEN_URL;
-const cfApiHost = process.env.CLOUD_FOUNDRY_API_HOST;
 const cfCdnSpaceName = process.env.CF_CDN_SPACE_NAME;
 const cfDomainWithCdnPlanGuid = process.env.CF_DOMAIN_WITH_CDN_PLAN_GUID;
 // optional environment variables
 const newRelicAppName = process.env.NEW_RELIC_APP_NAME;
 const newRelicLicenseKey = process.env.NEW_RELIC_LICENSE_KEY;
 
-if (cfOauthTokenUrl && cfApiHost && cfDomain && cfProxy) {
+if (cfDomain && cfProxy) {
   module.exports.env = {
     cfDomainGuid: cfDomain.guid,
     cfProxyGuid: cfProxy.guid,
     cfSpaceGuid,
     cfCdnSpaceName,
     cfDomainWithCdnPlanGuid,
-    cfOauthTokenUrl,
-    cfApiHost,
     newRelicAppName,
     newRelicLicenseKey,
   };
 } else {
-  throw new Error('Missing environment variables for build space, cloud founders host url and token url.');
+  throw new Error('Missing environment variables for build space.');
 }
 
 // See https://github.com/nfriedly/express-rate-limit/blob/master/README.md#configuration

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -82,16 +82,10 @@ module.exports = {
     level: 'error',
     silent: true,
   },
-  deployUser: {
-    username: 'deploy_user',
-    password: 'deploy_pass',
-  },
   env: {
     cfDomainGuid: '987ihg-654fed-321cba',
     cfProxyGuid: '867fiv-309ine',
     cfSpaceGuid: '123abc-456def-789ghi',
-    cfOauthTokenUrl: 'https://login.example.com/oauth/token',
-    cfApiHost: 'https://api.example.com',
     proxySiteTable: 'testSiteTable',
     uaaHost: 'https://uaa.example.com',
     uaaHostUrl: 'https://uaa.example.com',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,10 @@ services:
       UAA_HOST: http://localhost:9000
       UAA_HOST_DOCKER_URL: http://uaa:8080
       USER_AUDITOR: federalist
+      CLOUD_FOUNDRY_API_HOST: https://api.example.com
+      CLOUD_FOUNDRY_OAUTH_TOKEN_URL: https://login.example.com/oauth/token
+      CF_API_USERNAME: deploy_user
+      CF_API_PASSWORD: deploy_pass      
   federalist:
     build:
       dockerfile: Dockerfile-app
@@ -59,6 +63,10 @@ services:
       UAA_HOST: http://localhost:9000
       UAA_HOST_DOCKER_URL: http://uaa:8080
       USER_AUDITOR: federalist
+      CLOUD_FOUNDRY_API_HOST: https://api.example.com
+      CLOUD_FOUNDRY_OAUTH_TOKEN_URL: https://login.example.com/oauth/token
+      CF_API_USERNAME: deploy_user
+      CF_API_PASSWORD: deploy_pass
   bull-board:
     build:
       dockerfile: Dockerfile-app

--- a/test/api/unit/utils/cfApiClient.create.test.js
+++ b/test/api/unit/utils/cfApiClient.create.test.js
@@ -29,7 +29,7 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockCreateS3ServiceInstance(requestBody, serviceResponse);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.createS3ServiceInstance(name, planName)
+      apiClient.createS3ServiceInstance(name, planName, config.env.cfSpaceGuid)
         .then((res) => {
           expect(res).to.be.an('object');
           expect(res.entity.name).to.equal(name);
@@ -55,7 +55,7 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockCreateS3ServiceInstance(requestBody);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.createS3ServiceInstance(name, serviceName)
+      apiClient.createS3ServiceInstance(name, serviceName, config.env.cfSpaceGuid)
         .catch((err) => {
           expect(err).to.be.an('error');
           done();
@@ -164,7 +164,7 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockCreateServiceKey(keyRequestBody, keyResponse);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.createSiteBucket(name, keyIdentifier, planName)
+      apiClient.createSiteBucket(name, config.env.cfSpaceGuid, keyIdentifier, planName)
         .then((res) => {
           expect(res).to.be.an('object');
           expect(res.entity.name).to.equal(keyName);
@@ -184,7 +184,7 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockCreateRoute(response);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.createRoute(host)
+      apiClient.createRoute(host, config.env.cfDomainGuid, config.env.cfSpaceGuid)
         .then((res) => {
           expect(res.metadata.guid).to.equal(guid);
           expect(res.entity.host).to.equal(host);
@@ -208,7 +208,7 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockMapRoute(response);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.mapRoute(routeGuid)
+      apiClient.mapRoute(routeGuid, config.env.cfProxyGuid)
         .then((res) => {
           expect(res.metadata.guid).to.equal(guid);
           expect(res.entity.app_guid).to.equal(appGuid);
@@ -236,7 +236,12 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockMapRoute(mapResponse);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.createSiteProxyRoute(host)
+      apiClient.createSiteProxyRoute(
+        host,
+        config.env.cfDomainGuid,
+        config.env.cfSpaceGuid,
+        config.env.cfProxyGuid
+      )
         .then((res) => {
           expect(res.metadata.guid).to.equal(guid);
           expect(res.entity.app_guid).to.equal(appGuid);
@@ -261,7 +266,14 @@ describe('CloudFoundryAPIClient', () => {
       }, {});
 
       const apiClient = new CloudFoundryAPIClient();
-      await apiClient.createExternalDomain(domains, name, origin, path);
+      await apiClient.createExternalDomain({
+        domains,
+        name,
+        origin,
+        path,
+        cfCdnSpaceName: config.env.cfCdnSpaceName,
+        cfDomainWithCdnPlanGuid: config.env.cfDomainWithCdnPlanGuid,
+      });
     });
   });
 });

--- a/test/api/unit/utils/cfAuthClient.test.js
+++ b/test/api/unit/utils/cfAuthClient.test.js
@@ -9,46 +9,39 @@ const mockToken = (expiration = (Date.now() / 1000) + 600) => (
   jwt.sign({ exp: expiration }, '123abc')
 );
 
-
 describe('CloudFoundryAuthClient', () => {
   describe('.accessToken()', () => {
     afterEach(() => nock.cleanAll());
 
-    it('should fetch and resolve a new token if it has yet to fetch a token', (done) => {
+    it('should fetch and resolve a new token if it has yet to fetch a token', async () => {
       const accessToken = mockToken();
       mockTokenRequest(accessToken);
 
       const authClient = new CloudFoundryAuthClient();
 
-      authClient.accessToken().then((token) => {
-        expect(token).to.equal(accessToken);
-        done();
-      });
+      const token = await authClient.accessToken();
+      expect(token).to.equal(accessToken);
     });
 
-    it('should fetch and resolve a new token if the current token is expired', (done) => {
+    it('should fetch and resolve a new token if the current token is expired', async () => {
       const accessToken = mockToken();
       mockTokenRequest(accessToken);
 
       const authClient = new CloudFoundryAuthClient();
       authClient.token = mockToken(Date.now() / 1000);
 
-      authClient.accessToken().then((token) => {
-        expect(token).to.equal(accessToken);
-        done();
-      });
+      const token = await authClient.accessToken();
+      expect(token).to.equal(accessToken);
     });
 
-    it('should resolve the current token if it is not expired', (done) => {
+    it('should resolve the current token if it is not expired', async () => {
       const accessToken = mockToken();
 
       const authClient = new CloudFoundryAuthClient();
       authClient.token = accessToken;
 
-      authClient.accessToken().then((token) => {
-        expect(token).to.equal(accessToken);
-        done();
-      });
+      const token = await authClient.accessToken();
+      expect(token).to.equal(accessToken);
     });
   });
 });


### PR DESCRIPTION
## Changes proposed in this pull request:
- Refactor CF clients to be externally configurable and not rely on config.js
- Uses `.profile` to move CF username and password to env vars
-

## security considerations
None
