### PR TITLE
Refactor cf client round 2

### DIFF
--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -109,7 +109,11 @@ function buildSite(params, s3) {
 }
 
 function buildInfrastructure(params, s3ServiceName) {
-  return apiClient.createSiteBucket(s3ServiceName, config.env.cfSpaceGuid)
+  return apiClient.createSiteBucket(
+    s3ServiceName,
+    config.env.cfSpaceGuid,
+    config.app.s3ServicePlanId
+  )
     .then((response) => {
       const { credentials } = response.entity;
 

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -37,37 +37,6 @@ function buildEnum(values) {
   };
 }
 
-function filterEntity(res, name, field = 'name') {
-  let errMsg = `Not found: Entity @${field} = ${name}`;
-  const filtered = res.resources.filter(item => item.entity[field] === name);
-  if (filtered.length === 0) {
-    const error = new Error(errMsg);
-    error.name = name;
-    throw error;
-  }
-  if (name === 'basic-public') {
-    const servicePlan = filtered.find(f => f.entity.unique_id === config.app.s3ServicePlanId);
-    if (!servicePlan) {
-      errMsg = `${errMsg} @basic-public service plan = (${config.app.s3ServicePlanId})`;
-      const error = new Error(errMsg);
-      error.name = name;
-      throw error;
-    }
-    return servicePlan;
-  }
-  return filtered[0];
-}
-
-function firstEntity(res, name) {
-  if (res.resources.length === 0) {
-    const error = new Error('Not found');
-    error.name = name;
-    throw error;
-  }
-
-  return res.resources[0];
-}
-
 function generateS3ServiceName(owner, repository) {
   if (!owner || !repository) return undefined;
 
@@ -249,16 +218,6 @@ function omitBy(fn, obj) {
   return pick(pickedKeys, obj);
 }
 
-function objToQueryParams(obj) {
-  const qs = new URLSearchParams();
-  Object
-    .entries(obj)
-    .forEach(([key, value]) => {
-      qs.append(key, value);
-    });
-  return qs;
-}
-
 async function paginate(model, serialize, params, query = {}) {
   const limit = toInt(params.limit) || 25;
   const page = toInt(params.page) || 1;
@@ -314,8 +273,6 @@ function defaultContext(req, res) {
 
 module.exports = {
   buildEnum,
-  filterEntity,
-  firstEntity,
   generateS3ServiceName,
   generateSubdomain,
   getDirectoryFiles,
@@ -325,7 +282,6 @@ module.exports = {
   loadDevelopmentManifest,
   loadProductionManifest,
   mapValues,
-  objToQueryParams,
   omitBy,
   omit,
   paginate,

--- a/test/api/unit/utils/cfApiClient.create.test.js
+++ b/test/api/unit/utils/cfApiClient.create.test.js
@@ -29,7 +29,9 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockCreateS3ServiceInstance(requestBody, serviceResponse);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.createS3ServiceInstance(name, planName, config.env.cfSpaceGuid)
+      apiClient.createS3ServiceInstance(
+        name, planName, config.env.cfSpaceGuid, config.env.s3ServicePlanId
+      )
         .then((res) => {
           expect(res).to.be.an('object');
           expect(res.entity.name).to.equal(name);
@@ -55,7 +57,9 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockCreateS3ServiceInstance(requestBody);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.createS3ServiceInstance(name, serviceName, config.env.cfSpaceGuid)
+      apiClient.createS3ServiceInstance(
+        name, serviceName, config.env.cfSpaceGuid, config.env.s3ServicePlanId
+      )
         .catch((err) => {
           expect(err).to.be.an('error');
           done();
@@ -164,7 +168,9 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockCreateServiceKey(keyRequestBody, keyResponse);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.createSiteBucket(name, config.env.cfSpaceGuid, keyIdentifier, planName)
+      apiClient.createSiteBucket(
+        name, config.env.cfSpaceGuid, config.app.s3ServicePlanId, keyIdentifier, planName
+      )
         .then((res) => {
           expect(res).to.be.an('object');
           expect(res.entity.name).to.equal(keyName);

--- a/test/api/unit/utils/cfApiClient.fetch.test.js
+++ b/test/api/unit/utils/cfApiClient.fetch.test.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const nock = require('nock');
 const sinon = require('sinon');
+const config = require('../../../../config');
 const CloudFoundryAPIClient = require('../../../../api/utils/cfApiClient');
 const mockTokenRequest = require('../../support/cfAuthNock');
 const apiNocks = require('../../support/cfAPINocks');
@@ -219,7 +220,7 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockFetchS3ServicePlanGUID(response);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.fetchS3ServicePlanGUID(name)
+      apiClient.fetchS3ServicePlanGUID(name, config.env.s3ServicePlanId)
         .then((res) => {
           expect(res).to.deep.equal(guid);
           done();
@@ -242,7 +243,7 @@ describe('CloudFoundryAPIClient', () => {
       apiNocks.mockFetchS3ServicePlanGUID(response);
 
       const apiClient = new CloudFoundryAPIClient();
-      apiClient.fetchS3ServicePlanGUID(name)
+      apiClient.fetchS3ServicePlanGUID(name, config.env.s3ServicePlanId)
         .catch((err) => {
           expect(err.message).to.equal(message);
           expect(err.name).to.equal(name);

--- a/test/api/unit/utils/cfApiClient.test.js
+++ b/test/api/unit/utils/cfApiClient.test.js
@@ -1,0 +1,105 @@
+const { expect } = require('chai');
+
+const CloudFoundryAPIClient = require('../../../../api/utils/cfApiClient');
+
+describe('CloudFoundryAPIClient', () => {
+  describe('.findEntity', () => {
+    const name = 'one';
+    const field = 'name';
+    const entity1 = { [field]: name };
+    const entity2 = { [field]: 'two' };
+
+    it('should filter out the named entity from an objects resources array', () => {
+      const resources = [{ entity: entity1 }, { entity: entity2 }];
+
+      const result = CloudFoundryAPIClient.findEntity({ resources }, name, field);
+
+      expect(result).to.deep.equal({ entity: entity1 });
+    });
+
+    it('should throw an error if entity not found', () => {
+      const resources = [{ entity: entity2 }];
+
+      const fn = () => CloudFoundryAPIClient.findEntity({ resources }, name, field);
+
+      expect(fn).to.throw(Error, `Not found: Entity @${field} = ${name}`);
+    });
+  });
+
+  describe('.findS3ServicePlan', () => {
+    describe('when name is `basic-public`', () => {
+      it('returns the entity that matches the configured S3 plan', () => {
+        const basicPublic = 'basic-public';
+        const s3ServicePlanId = 's3ServicePlanId';
+        const entity = { name: basicPublic, unique_id: s3ServicePlanId };
+        const entity2 = { name: 'two' };
+        const resources = [{ entity }, { entity: entity2 }];
+
+        const result = CloudFoundryAPIClient.findS3ServicePlan(
+          { resources }, basicPublic, s3ServicePlanId
+        );
+
+        expect(result).to.deep.equal({ entity });
+      });
+
+      it('throws an error if none of the filtered entities match the configured S3 plan', () => {
+        const basicPublic = 'basic-public';
+        const s3ServicePlanId = 's3ServicePlanId';
+        const entity = { name: basicPublic, unique_id: 'foobar' };
+        const resources = [{ entity }];
+
+        const fn = () => CloudFoundryAPIClient.findS3ServicePlan(
+          { resources }, basicPublic, s3ServicePlanId
+        );
+
+        expect(fn).to.throw(Error, `Not found: @basic-public service plan = (${s3ServicePlanId})`);
+      });
+    });
+  });
+
+  describe('.firstEntity', () => {
+    it('should return first entity from an objects resources array', () => {
+      const name = 'one';
+      const field = 'name';
+      const entity = { [field]: name };
+      const resources = {
+        resources: [
+          {
+            entity,
+          },
+          {
+            entity: { [field]: 'two' },
+          },
+        ],
+      };
+
+      const result = CloudFoundryAPIClient.firstEntity(resources, name);
+
+      expect(result).to.deep.equal({ entity });
+    });
+
+    it('should throw an error if no resources returned', () => {
+      const name = 'one';
+      const resources = {
+        resources: [],
+      };
+
+      const fn = () => CloudFoundryAPIClient.firstEntity(resources, name);
+
+      expect(fn).to.throw(Error, 'Not found');
+    });
+  });
+
+  describe('.objToQueryParams', () => {
+    it('returns an instance of URLSearchParams with the correct values', () => {
+      const obj = { foo: 'bar', baz: 'foo' };
+
+      const result = CloudFoundryAPIClient.objToQueryParams(obj);
+
+      expect(result).to.be.an.instanceOf(URLSearchParams);
+      Object.entries(obj).forEach(([key, value]) => {
+        expect(result.get(key)).to.equal(value);
+      });
+    });
+  });
+});

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -29,84 +29,6 @@ describe('utils', () => {
     });
   });
 
-  describe('.filterEntity', () => {
-    const name = 'one';
-    const field = 'name';
-    const entity1 = { [field]: name };
-    const entity2 = { [field]: 'two' };
-
-    it('should filter out the named entity from an objects resources array', () => {
-      const resources = [{ entity: entity1 }, { entity: entity2 }];
-
-      const result = utils.filterEntity({ resources }, name, field);
-
-      expect(result).to.deep.equal({ entity: entity1 });
-    });
-
-    it('should throw an error if entity not found', () => {
-      const resources = [{ entity: entity2 }];
-
-      const fn = () => utils.filterEntity({ resources }, name, field);
-
-      expect(fn).to.throw(Error, `Not found: Entity @${field} = ${name}`);
-    });
-
-    describe('when name is `basic-public`', () => {
-      it('returns the entity that matches the configured S3 plan', () => {
-        const basicPublic = 'basic-public';
-        const entity = { [field]: basicPublic, unique_id: config.app.s3ServicePlanId };
-        const resources = [{ entity }, { entity: entity2 }];
-
-        const result = utils.filterEntity({ resources }, basicPublic, field);
-
-        expect(result).to.deep.equal({ entity });
-      });
-
-      it('throws an error if none of the filtered entities match the configured S3 plan', () => {
-        const basicPublic = 'basic-public';
-        const entity = { [field]: basicPublic, unique_id: 'foobar' };
-        const resources = [{ entity }];
-
-        const fn = () => utils.filterEntity({ resources }, basicPublic, field);
-
-        expect(fn).to.throw(Error, `Not found: Entity @${field} = ${basicPublic} @basic-public service plan = (${config.app.s3ServicePlanId})`);
-      });
-    });
-  });
-
-  describe('.firstEntity', () => {
-    it('should return first entity from an objects resources array', () => {
-      const name = 'one';
-      const field = 'name';
-      const entity = { [field]: name };
-      const resources = {
-        resources: [
-          {
-            entity,
-          },
-          {
-            entity: { [field]: 'two' },
-          },
-        ],
-      };
-
-      const result = utils.firstEntity(resources, name);
-
-      expect(result).to.deep.equal({ entity });
-    });
-
-    it('should throw an error if no resources returned', () => {
-      const name = 'one';
-      const resources = {
-        resources: [],
-      };
-
-      const fn = () => utils.firstEntity(resources, name);
-
-      expect(fn).to.throw(Error, 'Not found');
-    });
-  });
-
   describe('.generateS3ServiceName', () => {
     it('should concat and lowercase owner and repository name', (done) => {
       const owner = 'Hello';
@@ -450,19 +372,6 @@ describe('utils', () => {
       it('resolves with the value with which `fn` resolves', async () => {
         const result = await utils.retry(spy);
         expect(result).to.eq(value);
-      });
-    });
-  });
-
-  describe('.objToQueryParams', () => {
-    it('returns an instance of URLSearchParams with the correct values', () => {
-      const obj = { foo: 'bar', baz: 'foo' };
-
-      const result = utils.objToQueryParams(obj);
-
-      expect(result).to.be.an.instanceOf(URLSearchParams);
-      Object.entries(obj).forEach(([key, value]) => {
-        expect(result.get(key)).to.equal(value);
       });
     });
   });


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move functions in `utils` that were only used by the CF client into the CF client
- Remove transient references to `config`

No the CF Api Client only depends on the CF Auth client and the Http Client, and CF Auth Client only depends on the Https client. Tests are another matter to be addressed later.

## security considerations
None
