### PR TITLE
Move archiveBuildLogs to a "sandboxed" processor and its own queue

### DIFF
--- a/api/bull-board/app.js
+++ b/api/bull-board/app.js
@@ -8,7 +8,11 @@ const IORedis = require('ioredis');
 const helmet = require('helmet');
 
 const {
-  DomainQueue, MailQueue, ScheduledQueue, SlackQueue,
+  ArchiveBuildLogsQueue,
+  DomainQueue,
+  MailQueue,
+  ScheduledQueue,
+  SlackQueue,
 } = require('../queues');
 
 const passport = require('./passport');
@@ -32,6 +36,7 @@ const serverAdapter = new ExpressAdapter();
 createBullBoard({
   queues: [
     new BullAdapter(createQueue('site-build-queue')),
+    new BullMQAdapter(new ArchiveBuildLogsQueue(connection)),
     new BullMQAdapter(new DomainQueue(connection)),
     new BullMQAdapter(new MailQueue(connection)),
     new BullMQAdapter(new SlackQueue(connection)),

--- a/api/queues/ArchiveBuildLogsQueue.js
+++ b/api/queues/ArchiveBuildLogsQueue.js
@@ -1,0 +1,14 @@
+const { Queue } = require('bullmq');
+
+const ArchiveBuildLogsQueueName = 'archive-build-logs';
+
+class ArchiveBuildLogsQueue extends Queue {
+  constructor(connection) {
+    super(ArchiveBuildLogsQueueName, { connection });
+  }
+}
+
+module.exports = {
+  ArchiveBuildLogsQueue,
+  ArchiveBuildLogsQueueName,
+};

--- a/api/queues/index.js
+++ b/api/queues/index.js
@@ -1,9 +1,12 @@
+const { ArchiveBuildLogsQueue, ArchiveBuildLogsQueueName } = require('./ArchiveBuildLogsQueue');
 const { DomainQueue, DomainQueueName } = require('./DomainQueue');
 const { MailQueue, MailQueueName } = require('./MailQueue');
 const { ScheduledQueue, ScheduledQueueName } = require('./ScheduledQueue');
 const { SlackQueue, SlackQueueName } = require('./SlackQueue');
 
 module.exports = {
+  ArchiveBuildLogsQueue,
+  ArchiveBuildLogsQueueName,
   DomainQueue,
   DomainQueueName,
   MailQueue,


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move archiveBuildLogs to a "sandboxed" processor and its own queue

## security considerations
None

## References
https://docs.bullmq.io/guide/workers/sandboxed-processors