### PR TITLE
Stop @-ing Federalist operators on all those Concourse jobs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -159,7 +159,6 @@ jobs:
             text: |
               :x: FAILED: pages api tests on staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))
@@ -212,7 +211,6 @@ jobs:
             text: |
               :x: FAILED: pages admin client tests on staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))
@@ -293,7 +291,6 @@ jobs:
             text: |
               :x: FAILED: api deployment on pages staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))
@@ -307,7 +304,6 @@ jobs:
             text: |
               :white_check_mark: SUCCESS: Successfully deployed api on pages staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))
@@ -371,7 +367,6 @@ jobs:
             text: |
               :x: FAILED: admin client deployment on pages staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))
@@ -432,7 +427,6 @@ jobs:
   #           text: |
   #             :x: FAILED: pages queues UI deployment on pages staging
   #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  #             ((slack-users))
   #           channel: ((slack-channel))
   #           username: ((slack-username))
   #           icon_url: ((slack-icon-url))
@@ -446,7 +440,6 @@ jobs:
   #           text: |
   #             :white_check_mark: SUCCESS: Successfully deployed pages queues UI on pages staging
   #             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  #             ((slack-users))
   #           channel: ((slack-channel))
   #           username: ((slack-username))
   #           icon_url: ((slack-icon-url))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -497,7 +497,6 @@ jobs:
                 text: |
                   :x: FAILED: sites builds checks on pages staging
                   <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-                  ((slack-users))
                 channel: ((slack-channel))
                 username: ((slack-username))
                 icon_url: ((slack-icon-url))


### PR DESCRIPTION
## Changes proposed in this pull request:
-Remove inclusion of slack-users variable in Concourse Slack job status messages, including
  - Successes:
    - `test-and-deploy-api-pages-staging` success
  - Failures:
    - `test-api-staging` failure
    - `test-admin-client-staging` failure
    - `test-and-deploy-api-pages-staging` failure
    - `test-and-deploy-admin-client-pages-staging` failure
    - `sites-builds-checks-staging` failure
  - Even the commented-out jobs:
    - `deploy-queues-ui-pages-staging` failure
    - `deploy-queues-ui-pages-staging` success

This addresses the noisy nuisance noted as #3816 

## security considerations
None
