### PR TITLE
Remove inclusion of slack-users variable in Concourse Slack job status messages. You too, _metrics_.

### DIFF
--- a/apps/metrics/ci/pipeline.yml
+++ b/apps/metrics/ci/pipeline.yml
@@ -94,7 +94,6 @@ jobs:
             text: |
               :x: FAILED: pages metrics tests on staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))
@@ -179,7 +178,6 @@ jobs:
             text: |
               :x: FAILED: metrics deployment on pages staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove inclusion of slack-users variable in Concourse Slack job status messages

This is just like #3817 except that it updates the `metrics` sub-application.

## security considerations
None
