### PR TITLE
Separate pages and federalist jobs for worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ set-pipeline: ## Set Concourse `web` pipeline
 start: ## Start
 	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up
 
+start-workers: ## Start with workers
+	docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml -f ./docker-compose.workers.yml up
+
 test-client: ## Run client tests
 	docker-compose run --rm app yarn test:client
 

--- a/docker-compose.workers.yml
+++ b/docker-compose.workers.yml
@@ -1,0 +1,43 @@
+version: '3'
+
+volumes:
+  yarn:
+  nm-app:
+
+services:
+  pages-worker:
+    build:
+      dockerfile: Dockerfile-app
+      context: .
+    command: ["scripts/wait-for-it.sh", "db:5432", "--", "yarn", "start-workers"]
+    volumes:
+      - yarn:/usr/local/share/.cache/yarn
+      - .:/app
+      - /app/admin-client/
+      - nm-app:/app/node_modules
+    depends_on:
+      - db
+      - redis
+      - echo
+    environment:
+      APP_HOSTNAME: http://localhost:1337
+      NODE_ENV: development
+      PRODUCT: pages
+  federalist-worker:
+    build:
+      dockerfile: Dockerfile-app
+      context: .
+    command: ["scripts/wait-for-it.sh", "db:5432", "--", "yarn", "start-workers"]
+    volumes:
+      - yarn:/usr/local/share/.cache/yarn
+      - .:/app
+      - /app/admin-client/
+      - nm-app:/app/node_modules
+    depends_on:
+      - db
+      - redis
+      - echo
+    environment:
+      APP_HOSTNAME: http://localhost:1338
+      NODE_ENV: development
+      PRODUCT: federalist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,23 +126,6 @@ services:
     image: redis
     ports:
       - 6379:6379
-  worker:
-    build:
-      dockerfile: Dockerfile-app
-      context: .
-    command: ["scripts/wait-for-it.sh", "db:5432", "--", "yarn", "start-workers"]
-    volumes:
-      - yarn:/usr/local/share/.cache/yarn
-      - .:/app
-      - /app/admin-client/
-      - nm-app:/app/node_modules
-    depends_on:
-      - db
-      - redis
-      - echo
-    environment:
-      APP_HOSTNAME: http://localhost:1337
-      NODE_ENV: development
   echo:
     image: node:16
     volumes:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Addresses #3859 
- Separates the background jobs between the Federalist and Pages worker apps
- moves worker to separate docker compose file so running them locally is optional (`make start-workers` instead of `make start` starts the app w the workers)

## security considerations
None
