### PR TITLE
Remove custom https agent and allowance for bad certs

### DIFF
--- a/api/workers/Mailer.js
+++ b/api/workers/Mailer.js
@@ -1,5 +1,3 @@
-const https = require('https');
-
 const HttpClient = require('../utils/httpClient');
 
 const { mailer } = require('../../config');

--- a/api/workers/Mailer.js
+++ b/api/workers/Mailer.js
@@ -6,7 +6,6 @@ const { mailer } = require('../../config');
 
 class Mailer {
   constructor({ host, password, username } = mailer) {
-    this.httpsAgent = new https.Agent({ rejectUnauthorized: false });
     this.httpClient = new HttpClient(host);
     this.password = password;
     this.username = username;
@@ -16,7 +15,6 @@ class Mailer {
     return this.httpClient.request({
       method: 'POST',
       url: '/send',
-      httpsAgent: this.httpsAgent,
       auth: {
         password: this.password,
         username: this.username,


### PR DESCRIPTION
## Changes proposed in this pull request:
- Addresses #3856 
- Must update `mailer` UPS in CF to use port 61443

## security considerations
Rely on C2C encryption
