### PR TITLE
Return a serializeable object from the Mailer job

### DIFF
--- a/api/workers/Mailer.js
+++ b/api/workers/Mailer.js
@@ -9,8 +9,8 @@ class Mailer {
     this.username = username;
   }
 
-  send({ html, subject, to }) {
-    return this.httpClient.request({
+  async send({ html, subject, to }) {
+    const { data, status } = await this.httpClient.request({
       method: 'POST',
       url: '/send',
       auth: {
@@ -19,6 +19,8 @@ class Mailer {
       },
       data: { to, subject, html },
     });
+
+    return { data, status };
   }
 }
 

--- a/test/api/workers/Mailer.test.js
+++ b/test/api/workers/Mailer.test.js
@@ -1,8 +1,9 @@
+const { expect } = require('chai');
 const nock = require('nock');
 
 const Mailer = require('../../../api/workers/Mailer');
 
-describe('Mailer', () => {
+describe.only('Mailer', () => {
   describe('.send()', () => {
     it('sends a POST request to the mailer with basic auth and data', async () => {
       const host = 'http://localhost:2343';
@@ -22,8 +23,9 @@ describe('Mailer', () => {
         .post('/send', { html, subject, to })
         .reply(200);
 
-      await mailer.send({ html, subject, to });
+      const response = await mailer.send({ html, subject, to });
 
+      expect(response).to.deep.eq({ data: '', status: 200 });
       scope.done();
     });
   });

--- a/test/api/workers/Mailer.test.js
+++ b/test/api/workers/Mailer.test.js
@@ -3,7 +3,7 @@ const nock = require('nock');
 
 const Mailer = require('../../../api/workers/Mailer');
 
-describe.only('Mailer', () => {
+describe('Mailer', () => {
   describe('.send()', () => {
     it('sends a POST request to the mailer with basic auth and data', async () => {
       const host = 'http://localhost:2343';


### PR DESCRIPTION
I believe Bull was throwing bc it failed when attempting the serialize the response object returned from Axios.

## Changes proposed in this pull request:
- Only returns the data and status from the http request in the mailer job

## security considerations
None
