### PR TITLE
Fix appEnv in queue workers

### DIFF
--- a/api/bull-board/config.js
+++ b/api/bull-board/config.js
@@ -26,7 +26,7 @@ module.exports = {
     org: ADMIN_GITHUB_ORGANIZATION,
     team: ADMIN_GITHUB_TEAM,
   },
-  appEnv: APP_ENV,
+  appEnv: APP_ENV ?? 'development',
   cookie: {
     secure: NODE_ENV === 'production',
   },

--- a/api/workers/index.js
+++ b/api/workers/index.js
@@ -100,9 +100,9 @@ function federalistWorker(connection) {
 }
 
 function pagesWorker(connection) {
-  const mailJobProcessor = appEnv === 'production'
-    ? job => (new Mailer()).send(job.data)
-    : job => logger.info(job.data);
+  const mailJobProcessor = appEnv === 'development'
+    ? job => logger.info(job.data)
+    : job => (new Mailer()).send(job.data);
 
   const scheduledJobProcessor = Processors.multiJobProcessor({
     revokeMembershipForUAAUsers: Processors.revokeMembershipForUAAUsers,


### PR DESCRIPTION
## Changes proposed in this pull request:
- Correctly uses `appEnv` to use mailer in non-dev envs
- sets `appEnv` locally

## security considerations
none
