### PR TITLE
Add uaa_login_host to production deploy vars

### DIFF
--- a/.cloudgov/vars/production.yml
+++ b/.cloudgov/vars/production.yml
@@ -10,6 +10,7 @@ feature_auth_github: 'true'
 feature_auth_uaa: 'false'
 feature_bull_site_build_queue: 'false'
 uaa_host: https://uaa.fr.cloud.gov
+uaa_login_host: https://login.fr.cloud.gov
 new_relic_app_name: web
 proxy_domain: app.cloud.gov
 cf_cdn_space_name: sites

--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -74,14 +74,6 @@ test-api: &test-api
             - bash
             - -ceux
             - |
-              pushd ..
-                docker load -i redis/image
-                docker tag "$(cat redis/image-id)" "$(cat redis/repository):$(cat redis/tag)"
-                docker load -i postgres/image
-                docker tag "$(cat postgres/image-id)" "$(cat postgres/repository):$(cat postgres/tag)"
-                docker load -i node/image
-                docker tag "$(cat node/image-id)" "$(cat node/repository):$(cat node/tag)"
-              popd
               docker network prune -f
               docker-compose -f ci/docker/docker-compose.yml run app app/ci/tasks/test-api.sh
               docker-compose -f ci/docker/docker-compose.yml down

--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -82,9 +82,11 @@ test-api: &test-api
                 docker load -i node/image
                 docker tag "$(cat node/image-id)" "$(cat node/repository):$(cat node/tag)"
               popd
+              docker network prune -f
               docker-compose -f ci/docker/docker-compose.yml run app app/ci/tasks/test-api.sh
               docker-compose -f ci/docker/docker-compose.yml down
               docker volume rm $(docker volume ls -q)
+              docker network prune -f
 
 test-admin-client: &test-admin-client
   - task: install-deps-admin-client

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -74,14 +74,6 @@ test-api: &test-api
             - bash
             - -ceux
             - |
-              pushd ..
-                docker load -i redis/image
-                docker tag "$(cat redis/image-id)" "$(cat redis/repository):$(cat redis/tag)"
-                docker load -i postgres/image
-                docker tag "$(cat postgres/image-id)" "$(cat postgres/repository):$(cat postgres/tag)"
-                docker load -i node/image
-                docker tag "$(cat node/image-id)" "$(cat node/repository):$(cat node/tag)"
-              popd
               docker network prune -f
               docker-compose -f ci/docker/docker-compose.yml run app app/ci/tasks/test-api.sh
               docker-compose -f ci/docker/docker-compose.yml down

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -82,9 +82,11 @@ test-api: &test-api
                 docker load -i node/image
                 docker tag "$(cat node/image-id)" "$(cat node/repository):$(cat node/tag)"
               popd
+              docker network prune -f
               docker-compose -f ci/docker/docker-compose.yml run app app/ci/tasks/test-api.sh
               docker-compose -f ci/docker/docker-compose.yml down
               docker volume rm $(docker volume ls -q)
+              docker network prune -f
 
 test-admin-client: &test-admin-client
   - task: install-deps-admin-client


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `uaa_login_host` var to production deploy vars
- Add additional `docker network prune -f` to make sure tests can migrate test db
- Remove image loading and tagging for tests

## security considerations
Needed for SCR
